### PR TITLE
REP-33 Add UI support for Cancel, Suspend, and Enable

### DIFF
--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
@@ -68,7 +68,7 @@ public class ReplicatorImpl implements Replicator {
   private final FilterBuilder builder;
 
   /** Does not contain duplicates */
-  private final BlockingQueue<SyncRequest> pendingSyncRequests = new LinkedBlockingQueue<>();
+  private BlockingQueue<SyncRequest> pendingSyncRequests = new LinkedBlockingQueue<>();
 
   /** Does not contain duplicates */
   private final BlockingQueue<SyncRequest> activeSyncRequests = new LinkedBlockingQueue<>();
@@ -326,5 +326,10 @@ public class ReplicatorImpl implements Replicator {
       throw new ReplicationException("System at " + site.getUrl() + " is currently unavailable");
     }
     return store;
+  }
+
+  @VisibleForTesting
+  void setPendingSyncRequestsQueue(BlockingQueue<SyncRequest> queue) {
+    pendingSyncRequests = queue;
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
@@ -28,6 +28,7 @@ import ddf.security.Subject;
 import java.net.URL;
 import java.security.PrivilegedAction;
 import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import org.codice.ddf.security.common.Security;
 import org.codice.ditto.replication.api.Direction;
@@ -141,12 +142,14 @@ public class ReplicatorImplTest {
 
   @Test
   public void cancelPendingSyncRequest() throws Exception {
+    BlockingQueue<SyncRequest> queue = mock(BlockingQueue.class);
+    replicator.setPendingSyncRequestsQueue(queue);
     ReplicationStatus status = new ReplicationStatus("test");
     SyncRequest request = new SyncRequestImpl(config, status);
     replicator.submitSyncRequest(request);
-    assertThat(replicator.getPendingSyncRequests().size(), is(1));
+    verify(queue, times(1)).put(request);
     replicator.cancelSyncRequest(request);
-    assertThat(replicator.getPendingSyncRequests().size(), is(0));
+    verify(queue, times(1)).remove(request);
   }
 
   @Test

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,8 +15,6 @@
     "lint": "eslint src",
     "pretest": "yarn lint",
     "test": "jest",
-    "posttest": "yarn test:coverage",
-    "test:coverage": "jest --coverage",
     "format": "prettier \"**/*+(.tsx|.js|.less|.json|.css)\"",
     "fmt": "yarn format --write",
     "prebuild": "yarn audit",
@@ -74,10 +72,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 1,
-        "branches": 0,
-        "lines": 1,
-        "functions": 0
+        "statements": 8,
+        "branches": 8,
+        "lines": 8,
+        "functions": 2
       }
     },
     "collectCoverage": true,

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,9 +32,9 @@
     "immutable": "3.8.2",
     "moment": "2.24.0",
     "prop-types": "15.6.2",
-    "react": "16.6.3",
+    "react": "16.8.3",
     "react-apollo": "2.3.3",
-    "react-dom": "16.6.3",
+    "react-dom": "16.8.3",
     "react-router-dom": "4.3.1",
     "styled-components": "4.1.3"
   },

--- a/ui/src/main/webapp/components/replications/ActionsMenu.js
+++ b/ui/src/main/webapp/components/replications/ActionsMenu.js
@@ -1,0 +1,141 @@
+import React from 'react'
+import { Menu, MenuItem, Typography } from '@material-ui/core'
+import {
+  deleteReplication,
+  suspendReplication,
+  cancelReplication,
+} from './gql/mutations'
+import { allReplications } from './gql/queries'
+import { Mutation } from 'react-apollo'
+import Replications from './replications'
+
+const DeleteReplication = props => {
+  const { id, onClose } = props
+
+  return (
+    <Mutation mutation={deleteReplication}>
+      {deleteReplication => (
+        <MenuItem
+          key={'Delete'}
+          onClick={() => {
+            deleteReplication({
+              variables: {
+                id: id,
+              },
+              update: store => {
+                const data = store.readQuery({
+                  query: allReplications,
+                })
+
+                data.replication.replications = data.replication.replications.filter(
+                  r => r.id !== id
+                )
+                store.writeQuery({
+                  query: allReplications,
+                  data,
+                })
+              },
+            })
+            onClose()
+          }}
+        >
+          <Typography>Delete</Typography>
+        </MenuItem>
+      )}
+    </Mutation>
+  )
+}
+
+const SuspendReplication = props => {
+  const { id, suspend, key, label, onClose } = props
+
+  return (
+    <Mutation mutation={suspendReplication}>
+      {suspendReplication => (
+        <MenuItem
+          key={key}
+          onClick={() => {
+            suspendReplication({
+              variables: {
+                id: id,
+                suspend: suspend,
+              },
+            })
+            onClose()
+          }}
+        >
+          <Typography>{label}</Typography>
+        </MenuItem>
+      )}
+    </Mutation>
+  )
+}
+
+const CancelReplication = props => {
+  const { id, onClose } = props
+
+  return (
+    <Mutation mutation={cancelReplication}>
+      {cancelReplication => (
+        <MenuItem
+          key='Cancel'
+          onClick={() => {
+            cancelReplication({
+              variables: {
+                id: id,
+              },
+            })
+            onClose()
+          }}
+        >
+          <Typography>Cancel</Typography>
+        </MenuItem>
+      )}
+    </Mutation>
+  )
+}
+
+const ActionsMenu = function(props) {
+  const { menuId, anchorEl = null, onClose, replication } = props
+
+  if (replication === undefined) {
+    return null
+  }
+
+  const { id } = replication
+
+  return (
+    <Menu
+      id={menuId}
+      anchorEl={anchorEl}
+      open={anchorEl !== null}
+      disableAutoFocusItem
+      onClose={onClose}
+    >
+      {Replications.cancelable(replication) && (
+        <CancelReplication id={id} onClose={onClose} />
+      )}
+
+      <DeleteReplication id={id} onClose={onClose} />
+      {replication.suspended ? (
+        <SuspendReplication
+          id={id}
+          onClose={onClose}
+          suspend={false}
+          key='Enable'
+          label='Enable'
+        />
+      ) : (
+        <SuspendReplication
+          id={id}
+          onClose={onClose}
+          suspend={true}
+          key='Disable'
+          label='Disable'
+        />
+      )}
+    </Menu>
+  )
+}
+
+export default ActionsMenu

--- a/ui/src/main/webapp/components/replications/AddReplication.js
+++ b/ui/src/main/webapp/components/replications/AddReplication.js
@@ -17,53 +17,10 @@ import {
 import HelpIcon from '@material-ui/icons/Help'
 import sitesQuery from '../sites/gql/sitesQuery'
 import { Query, Mutation } from 'react-apollo'
-import gql from 'graphql-tag'
 import Immutable from 'immutable'
-import { AllReplications } from './gql/queries'
+import { allReplications } from './gql/queries'
+import { addReplication } from './gql/mutations'
 import { withStyles } from '@material-ui/core/styles'
-
-const ADD_REPLICATION = gql`
-  mutation createReplication(
-    $name: String!
-    $sourceId: Pid!
-    $destinationId: Pid!
-    $filter: String!
-    $biDirectional: Boolean
-  ) {
-    createReplication(
-      name: $name
-      sourceId: $sourceId
-      destinationId: $destinationId
-      filter: $filter
-      biDirectional: $biDirectional
-    ) {
-      name
-      id
-      source {
-        id
-        name
-        address {
-          url
-        }
-      }
-      destination {
-        id
-        name
-        address {
-          url
-        }
-      }
-      lastRun
-      lastSuccess
-      firstRun
-      biDirectional
-      replicationStatus
-      filter
-      itemsTransferred
-      dataTransferred
-    }
-  }
-`
 
 const styles = {
   tooltip: {
@@ -290,7 +247,7 @@ class AddReplication extends React.Component {
               Cancel
             </Button>
             <Mutation
-              mutation={ADD_REPLICATION}
+              mutation={addReplication}
               onError={error => {
                 error.graphQLErrors &&
                   error.graphQLErrors.forEach(e => {
@@ -321,11 +278,11 @@ class AddReplication extends React.Component {
                         },
                         update: (store, { data: { createReplication } }) => {
                           const data = store.readQuery({
-                            query: AllReplications,
+                            query: allReplications,
                           })
                           data.replication.replications.push(createReplication)
                           store.writeQuery({
-                            query: AllReplications,
+                            query: allReplications,
                             data,
                           })
                         },

--- a/ui/src/main/webapp/components/replications/ReplicationsContainer.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsContainer.js
@@ -1,10 +1,11 @@
 import React, { Fragment } from 'react'
 import { Query } from 'react-apollo'
-import { AllReplications } from './gql/queries'
+import { allReplications } from './gql/queries'
 import ReplicationsTable from './ReplicationsTable'
 import AddReplication from './AddReplication'
 import { Typography, CardContent, Card, Button } from '@material-ui/core'
 import { withStyles } from '@material-ui/core/styles'
+import Immutable from 'immutable'
 
 const styles = {
   expandingCard: {
@@ -58,7 +59,7 @@ function ReplicationsContainer(props) {
   const { classes } = props
 
   return (
-    <Query query={AllReplications} pollInterval={10000}>
+    <Query query={allReplications} pollInterval={10000}>
       {({ data, loading, error }) => {
         if (loading) return <Typography>Loading...</Typography>
         if (error) return <Typography>Error...</Typography>
@@ -68,12 +69,34 @@ function ReplicationsContainer(props) {
           data.replication.replications &&
           data.replication.replications.length > 0
         ) {
+          const activeReplications = Immutable.List(
+            data.replication.replications.filter(r => !r.suspended)
+          )
+          const inactiveReplications = Immutable.List(
+            data.replication.replications.filter(r => r.suspended)
+          )
+
           return (
             <Fragment>
               <div className={classes.right}>
                 <AddReplication Button={AddButton} />
               </div>
-              <ReplicationsTable replications={data.replication.replications} />
+
+              {activeReplications.size > 0 && (
+                <ReplicationsTable
+                  title='Active Replications'
+                  replications={activeReplications}
+                />
+              )}
+
+              {inactiveReplications.size > 0 && (
+                <div style={{ marginTop: 10 }}>
+                  <ReplicationsTable
+                    title='Inactive Replications'
+                    replications={inactiveReplications}
+                  />
+                </div>
+              )}
             </Fragment>
           )
         }

--- a/ui/src/main/webapp/components/replications/actionsMenu.spec.js
+++ b/ui/src/main/webapp/components/replications/actionsMenu.spec.js
@@ -1,0 +1,96 @@
+/*global test, shallow, expect */
+import React from 'react'
+import ActionsMenu from './ActionsMenu'
+import Replications from './replications'
+
+test('empty replication property causes no render', () => {
+  const wrapper = shallow(
+    <ActionsMenu
+      replication={undefined}
+      menuId='1234'
+      anchorEl={null}
+      onClose={() => {}}
+    />
+  )
+  expect(wrapper.isEmptyRender())
+})
+
+test('push in progress status renders cancel action', () => {
+  const wrapper = shallow(
+    <ActionsMenu
+      replication={{
+        id: '1234',
+        replicationStatus: Replications.Status.PUSH_IN_PROGRESS,
+        suspended: false,
+      }}
+      menuId='1234'
+      anchorEl={null}
+      onClose={() => {}}
+    />
+  )
+  expect(wrapper.find('CancelReplication').exists()).toBe(true)
+})
+
+test('pull in progress status renders cancel action', () => {
+  const wrapper = shallow(
+    <ActionsMenu
+      replication={{
+        id: '1234',
+        replicationStatus: Replications.Status.PULL_IN_PROGRESS,
+        suspended: false,
+      }}
+      menuId='1234'
+      anchorEl={null}
+      onClose={() => {}}
+    />
+  )
+  expect(wrapper.find('CancelReplication').exists()).toBe(true)
+})
+
+test('pending status renders cancel action', () => {
+  const wrapper = shallow(
+    <ActionsMenu
+      replication={{
+        id: '1234',
+        replicationStatus: Replications.Status.PENDING,
+        suspended: false,
+      }}
+      menuId='1234'
+      anchorEl={null}
+      onClose={() => {}}
+    />
+  )
+  expect(wrapper.find('CancelReplication').exists()).toBe(true)
+})
+
+test('suspended config renders enable action', () => {
+  const wrapper = shallow(
+    <ActionsMenu
+      replication={{
+        id: '1234',
+        replicationStatus: Replications.Status.PENDING,
+        suspended: true,
+      }}
+      menuId='1234'
+      anchorEl={null}
+      onClose={() => {}}
+    />
+  )
+  expect(wrapper.find('SuspendReplication').prop('suspend')).toBe(false)
+})
+
+test('enabled config renders suspend action', () => {
+  const wrapper = shallow(
+    <ActionsMenu
+      replication={{
+        id: '1234',
+        replicationStatus: Replications.Status.PENDING,
+        suspended: false,
+      }}
+      menuId='1234'
+      anchorEl={null}
+      onClose={() => {}}
+    />
+  )
+  expect(wrapper.find('SuspendReplication').prop('suspend')).toBe(true)
+})

--- a/ui/src/main/webapp/components/replications/gql/mutations.js
+++ b/ui/src/main/webapp/components/replications/gql/mutations.js
@@ -1,0 +1,62 @@
+import gql from 'graphql-tag'
+
+export const addReplication = gql`
+  mutation createReplication(
+    $name: String!
+    $sourceId: Pid!
+    $destinationId: Pid!
+    $filter: String!
+    $biDirectional: Boolean
+  ) {
+    createReplication(
+      name: $name
+      sourceId: $sourceId
+      destinationId: $destinationId
+      filter: $filter
+      biDirectional: $biDirectional
+    ) {
+      name
+      id
+      source {
+        id
+        name
+        address {
+          url
+        }
+      }
+      destination {
+        id
+        name
+        address {
+          url
+        }
+      }
+      lastRun
+      lastSuccess
+      firstRun
+      biDirectional
+      replicationStatus
+      filter
+      itemsTransferred
+      dataTransferred
+      suspended
+    }
+  }
+`
+export const suspendReplication = gql`
+  mutation suspendReplication($id: Pid!, $suspend: Boolean!) {
+    suspendReplication(id: $id, suspend: $suspend)
+  }
+`
+
+export const cancelReplication = gql`
+  mutation cancelReplication($id: Pid!) {
+    cancelReplication(id: $id)
+  }
+`
+
+export const deleteReplication = gql`
+  mutation deleteReplication($id: Pid!) {
+    deleteReplication(id: $id)
+  }
+`

--- a/ui/src/main/webapp/components/replications/gql/queries.js
+++ b/ui/src/main/webapp/components/replications/gql/queries.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 
-export const AllReplications = gql`
+export const allReplications = gql`
   {
     replication {
       replications {
@@ -28,6 +28,7 @@ export const AllReplications = gql`
         itemsTransferred
         dataTransferred
         filter
+        suspended
       }
     }
   }

--- a/ui/src/main/webapp/components/replications/replications.js
+++ b/ui/src/main/webapp/components/replications/replications.js
@@ -1,0 +1,67 @@
+const Status = {
+  SUCCESS: 'SUCCESS',
+  PENDING: 'PENDING',
+  SUSPENDED: 'SUSPENDED',
+  CANCELED: 'CANCELED',
+  PULL_IN_PROGRESS: 'PULL_IN_PROGRESS',
+  PUSH_IN_PROGRESS: 'PUSH_IN_PROGRESS',
+  FAILURE: 'FAILURE',
+  CONNECTION_LOST: 'CONNECTION_LOST',
+  CONNECTION_UNAVAILABLE: 'CONNECTION_UNAVAILABLE',
+  NOT_RUN: 'NOT_RUN',
+}
+
+const statusDisplayNameMapping = {
+  SUCCESS: 'Success',
+  PENDING: 'Pending',
+  SUSPENDED: 'Suspended',
+  CANCELED: 'Canceled',
+  PULL_IN_PROGRESS: 'Pulling resources...',
+  PUSH_IN_PROGRESS: 'Pushing resources...',
+  FAILURE: 'Failure',
+  CONNECTION_LOST: 'Connection Lost',
+  CONNECTION_UNAVAILABLE: 'Connection Unavailable',
+  NOT_RUN: 'Not run',
+}
+
+function isInProgress(replication) {
+  const status = replication.replicationStatus
+  return (
+    status === Status.PULL_IN_PROGRESS || status === Status.PUSH_IN_PROGRESS
+  )
+}
+
+function statusDisplayName(replication) {
+  return statusDisplayNameMapping[replication.replicationStatus]
+}
+
+function cancelable(replication) {
+  const status = replication.replicationStatus
+  return (
+    status === Status.PUSH_IN_PROGRESS ||
+    status === Status.PULL_IN_PROGRESS ||
+    status === Status.PENDING
+  )
+}
+
+function repSort(a, b) {
+  if (isInProgress(a) || isInProgress(b)) {
+    return 1
+  }
+
+  if (a.name.toLowerCase() < b.name.toLowerCase()) {
+    return -1
+  }
+  if (a.name.toLowerCase() > b.name.toLowerCase()) {
+    return 1
+  }
+  return 0
+}
+
+export default {
+  Status,
+  isInProgress,
+  statusDisplayName,
+  cancelable,
+  repSort,
+}

--- a/ui/src/main/webapp/components/sites/Sites.js
+++ b/ui/src/main/webapp/components/sites/Sites.js
@@ -8,7 +8,7 @@ export default function Sites(props) {
   return (
     <Fragment>
       {sites &&
-        props.sites.map(site => (
+        sites.map(site => (
           <Site
             key={site.id}
             name={site.name}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6150,13 +6150,22 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@15.6.2, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@15.6.2, prop-types@^15.5.4, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+prop-types@^15.6.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
 
 proxy-addr@~2.0.4:
   version "2.0.4"
@@ -6320,15 +6329,15 @@ react-apollo@2.3.3:
     lodash.isequal "^4.5.0"
     prop-types "^15.6.0"
 
-react-dom@16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
-  integrity sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==
+react-dom@16.8.3:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.3.tgz#ae236029e66210783ac81999d3015dfc475b9c32"
+  integrity sha512-ttMem9yJL4/lpItZAQ2NTFAbV7frotHk5DZEHXUOws2rMmrsvh1Na7ThGT0dTzUIl6pqTOi5tYREfL8AEna3lA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.13.3"
 
 react-event-listener@^0.6.2:
   version "0.6.5"
@@ -6358,6 +6367,11 @@ react-is@^16.3.2, react-is@^16.6.0, react-is@^16.6.1, react-is@^16.6.3, react-is
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
+react-is@^16.8.1:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
 
 react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -6409,15 +6423,15 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react@16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
-  integrity sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==
+react@16.8.3:
+  version "16.8.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.3.tgz#c6f988a2ce895375de216edcfaedd6b9a76451d9"
+  integrity sha512-3UoSIsEq8yTJuSu0luO1QQWYbgGEILm+eJl2QN/VLDi7hL+EN18M3q3oVZwmVzzBJ3DkM7RMdRwBmZZ+b4IzSA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.11.2"
+    scheduler "^0.13.3"
 
 read-pkg-up@^4.0.0:
   version "4.0.0"
@@ -6830,18 +6844,18 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.11.2:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.3.tgz#b5769b90cf8b1464f3f3cfcafe8e3cd7555a2d6b"
-  integrity sha512-i9X9VRRVZDd3xZw10NY5Z2cVMbdYg6gqFecfj79USv1CFN+YrJ3gIPRKf1qlY+Sxly4djoKdfx1T+m9dnRB8kQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
 scheduler@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
   integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.3.tgz#bed3c5850f62ea9c716a4d781f9daeb9b2a58896"
+  integrity sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
#### What does this PR do?
- Upgrade react
- Add contextual menu (based on replication status) that displays cancel/suspend/enable actions.
- Split active and inactive replications into 2 tables.
- Fixes UI tests running twice in a build

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @mcalcote @kcover 

#### How should this be tested? (List steps with links to updated documentation)
- Create a replication and suspend it.
- Confirm after suspension action menu has `Enable` action.
- Confirm a pending, push in progress, and pull in progress replication has the cancel action.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #33 

#### Screenshots (if appropriate)
![activeinactive](https://user-images.githubusercontent.com/17572782/53740080-99ca7980-3e50-11e9-893e-da0f80b0e701.PNG)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
