### PR TITLE
REP-34 Fix snackbar errors for deleting nodes

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -29,6 +29,7 @@
     "graphql-tag": "2.10.0",
     "immutable": "3.8.2",
     "moment": "2.24.0",
+    "notistack": "0.5.0",
     "prop-types": "15.6.2",
     "react": "16.8.3",
     "react-apollo": "2.3.3",

--- a/ui/src/main/webapp/app.js
+++ b/ui/src/main/webapp/app.js
@@ -6,6 +6,7 @@ import { HashRouter, Route, Switch } from 'react-router-dom'
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles'
 import client from './client'
 import { ApolloProvider } from 'react-apollo'
+import { SnackbarProvider } from 'notistack'
 
 const theme = createMuiTheme({
   // see: https://material-ui.com/style/typography/#migration-to-typography-v2
@@ -18,22 +19,24 @@ const App = () => {
   return (
     <MuiThemeProvider theme={theme}>
       <ApolloProvider client={client}>
-        <HashRouter>
-          <div>
-            <Navbar />
-            <div style={{ margin: 10 }}>
-              <Switch>
-                <Route exact path='/' component={Home} />
-                <Route exact path='/nodes' component={SitesPage} />
-                <Route
-                  render={function() {
-                    return <p>Not Found</p>
-                  }}
-                />
-              </Switch>
+        <SnackbarProvider>
+          <HashRouter>
+            <div>
+              <Navbar />
+              <div style={{ margin: 10 }}>
+                <Switch>
+                  <Route exact path='/' component={Home} />
+                  <Route exact path='/nodes' component={SitesPage} />
+                  <Route
+                    render={function() {
+                      return <p>Not Found</p>
+                    }}
+                  />
+                </Switch>
+              </div>
             </div>
-          </div>
-        </HashRouter>
+          </HashRouter>
+        </SnackbarProvider>
       </ApolloProvider>
     </MuiThemeProvider>
   )

--- a/ui/src/main/webapp/components/Navbar.js
+++ b/ui/src/main/webapp/components/Navbar.js
@@ -12,6 +12,8 @@ import HomeIcon from '@material-ui/icons/Home'
 import LanguageIcon from '@material-ui/icons/Language'
 import HelpIcon from '@material-ui/icons/Help'
 import { Link } from 'react-router-dom'
+import { Tooltip } from '@material-ui/core'
+import { withTheme } from '@material-ui/core/styles'
 
 class Navbar extends React.Component {
   state = {
@@ -35,23 +37,36 @@ class Navbar extends React.Component {
   }
 
   render() {
+    const { theme } = this.props
+
     return (
       <AppBar
         position='static'
-        // todo theme this
-        style={{ backgroundColor: 'rgb(24, 188, 156)' }}
+        style={
+          { backgroundColor: 'rgb(24, 188, 156)' } // todo theme this
+        }
       >
         <Toolbar>
           <Typography variant='h6' color='inherit' noWrap>
             Project Charleston BETA
           </Typography>
           <div className='navIcons'>
-            <IconButton component={Link} to='/' color='inherit'>
-              <HomeIcon />
-            </IconButton>
-            <IconButton component={Link} to='/nodes' color='inherit'>
-              <LanguageIcon />
-            </IconButton>
+            <Tooltip
+              title='Manage Replications'
+              enterDelay={theme.transitions.duration.standard}
+            >
+              <IconButton component={Link} to='/' color='inherit'>
+                <HomeIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip
+              title='Manage Nodes'
+              enterDelay={theme.transitions.duration.standard}
+            >
+              <IconButton component={Link} to='/nodes' color='inherit'>
+                <LanguageIcon />
+              </IconButton>
+            </Tooltip>
             <IconButton onClick={this.handleOpen} color='inherit'>
               <HelpIcon />
             </IconButton>
@@ -86,4 +101,4 @@ class Navbar extends React.Component {
   }
 }
 
-export default Navbar
+export default withTheme()(Navbar)

--- a/ui/src/main/webapp/components/replications/ReplicationsContainer.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsContainer.js
@@ -3,7 +3,13 @@ import { Query } from 'react-apollo'
 import { allReplications } from './gql/queries'
 import ReplicationsTable from './ReplicationsTable'
 import AddReplication from './AddReplication'
-import { Typography, CardContent, Card, Button } from '@material-ui/core'
+import {
+  Typography,
+  CardContent,
+  Card,
+  Button,
+  CircularProgress,
+} from '@material-ui/core'
 import { withStyles } from '@material-ui/core/styles'
 import Immutable from 'immutable'
 
@@ -61,7 +67,7 @@ function ReplicationsContainer(props) {
   return (
     <Query query={allReplications} pollInterval={10000}>
       {({ data, loading, error }) => {
-        if (loading) return <Typography>Loading...</Typography>
+        if (loading) return <CircularProgress />
         if (error) return <Typography>Error...</Typography>
 
         if (

--- a/ui/src/main/webapp/components/replications/__tests__/actionsMenu.spec.js
+++ b/ui/src/main/webapp/components/replications/__tests__/actionsMenu.spec.js
@@ -1,7 +1,7 @@
 /*global test, shallow, expect */
 import React from 'react'
-import ActionsMenu from './ActionsMenu'
-import Replications from './replications'
+import ActionsMenu from '../ActionsMenu'
+import Replications from '../replications'
 
 test('empty replication property causes no render', () => {
   const wrapper = shallow(

--- a/ui/src/main/webapp/components/sites/__tests__/site.spec.js
+++ b/ui/src/main/webapp/components/sites/__tests__/site.spec.js
@@ -1,6 +1,6 @@
 /*global test, shallow, expect */
 import React from 'react'
-import Site from './Site'
+import Site from '../Site'
 
 test('site renders correctly', () => {
   const wrapper = shallow(

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1925,7 +1925,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -5496,6 +5496,14 @@ normalize-scroll-left@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
   integrity sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg==
+
+notistack@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.5.0.tgz#4fece949c973cad6d1d4a9d34da8024ef3158b5e"
+  integrity sha512-DYAix/jnN/Qv/AHwgbNFcQ2d6HjeQ8duEge6OJr5rn0pmxUutQjuGpZ+3dJ/4FBJtfRbnv0BX59ZtHrn2tE+Jw==
+  dependencies:
+    classnames "^2.2.6"
+    prop-types "^15.6.2"
 
 npm-bundled@^1.0.1:
   version "1.0.5"


### PR DESCRIPTION
#### What does this PR do?
- Adds new component for snackbars when displaying node deletion errors.
- Snackbars dismiss within a certain time and no longer stack on each other. 
- Move tests to `__tests__` directories.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@kcover @clockard @mcalcote 

#### How should this be tested? (List steps with links to updated documentation)
- Create a node.
- Create a Replication between the local Node and the new Node.
- Try to delete a Node used in the Replication.
- Verify snackbars do not stack directly on each other, dismiss over time, and do not duplicate for the same error. 

Verify hovering over home and node icons on navigation menu show help text

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #34 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
