### PR TITLE
[WIP] REP-45 Add option to delete replication data through UI

### DIFF
--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/discover/GetReplications.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/discover/GetReplications.java
@@ -41,7 +41,7 @@ public class GetReplications extends BaseFunctionField<ListField<ReplicationFiel
 
   @Override
   public ListField<ReplicationField> performFunction() {
-    return replicationUtils.getReplications();
+    return replicationUtils.getReplications(true);
   }
 
   @Override

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSite.java
@@ -60,7 +60,7 @@ public class DeleteReplicationSite extends BaseFunctionField<BooleanField> {
       return;
     }
 
-    ListField<ReplicationField> repFields = replicationUtils.getReplications();
+    ListField<ReplicationField> repFields = replicationUtils.getReplications(false);
     String idToDelete = id.getValue();
     for (ReplicationField repField : repFields.getList()) {
       if (idToDelete.equals(repField.source().id())

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
@@ -18,10 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -32,12 +29,7 @@ import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ditto.replication.admin.query.replications.fields.ReplicationField;
 import org.codice.ditto.replication.admin.query.sites.fields.ReplicationSiteField;
-import org.codice.ditto.replication.api.Direction;
-import org.codice.ditto.replication.api.ReplicationException;
-import org.codice.ditto.replication.api.ReplicationStatus;
-import org.codice.ditto.replication.api.Replicator;
-import org.codice.ditto.replication.api.ReplicatorHistory;
-import org.codice.ditto.replication.api.Status;
+import org.codice.ditto.replication.api.*;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.impl.data.ReplicationSiteImpl;
 import org.codice.ditto.replication.api.impl.data.ReplicationStatusImpl;
@@ -297,14 +289,14 @@ public class ReplicationUtilsTest {
     ReplicatorConfigImpl config = new ReplicatorConfigImpl();
     config.setId("id");
     config.setName("name");
-    assertThat(utils.deleteConfig("id"), is(true));
+    assertThat(utils.markConfigDeleted("id", true), is(true));
     verify(configManager).remove(anyString());
   }
 
   @Test
   public void deleteConfigFailed() {
     doThrow(new NotFoundException()).when(configManager).remove(anyString());
-    assertThat(utils.deleteConfig("id"), is(false));
+    assertThat(utils.markConfigDeleted("id", true), is(false));
   }
 
   @Test
@@ -337,7 +329,7 @@ public class ReplicationUtilsTest {
     config.setDestination("destId");
     config.setDirection(Direction.PUSH);
     when(configManager.objects()).thenReturn(Stream.of(config));
-    ReplicationField field = utils.getReplications().getList().get(0);
+    ReplicationField field = utils.getReplications(false).getList().get(0);
     assertThat(field.name(), is("test"));
     assertThat(field.source().id(), is("srcId"));
     assertThat(field.destination().id(), is("destId"));

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicationItemImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicationItemImpl.java
@@ -14,6 +14,7 @@
 package org.codice.ditto.replication.api.impl;
 
 import java.util.Date;
+import java.util.UUID;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ditto.replication.api.ReplicationItem;
 
@@ -31,6 +32,8 @@ public class ReplicationItemImpl implements ReplicationItem {
 
   private final String configurationId;
 
+  private final String id;
+
   private int failureCount;
 
   public ReplicationItemImpl(
@@ -40,10 +43,19 @@ public class ReplicationItemImpl implements ReplicationItem {
       String source,
       String destination,
       String configId) {
-    this(metacardId, resourceModified, metacardModified, source, destination, configId, 0);
+    this(
+        UUID.randomUUID().toString(),
+        metacardId,
+        resourceModified,
+        metacardModified,
+        source,
+        destination,
+        configId,
+        0);
   }
 
   public ReplicationItemImpl(
+      String id,
       String metacardId,
       Date resourceModified,
       Date metacardModified,
@@ -51,6 +63,7 @@ public class ReplicationItemImpl implements ReplicationItem {
       String destination,
       String configId,
       int failureCount) {
+    this.id = id;
     this.metacardId = notBlank(metacardId);
     // TODO these dates don't matter for delete requests that fail. Need to make a way to
     // instantiate a failed ReplicationItem for failed deletes.
@@ -70,6 +83,11 @@ public class ReplicationItemImpl implements ReplicationItem {
     } else {
       throw new IllegalArgumentException("String argument may not be empty");
     }
+  }
+
+  @Override
+  public String getId() {
+    return id;
   }
 
   @Override

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorHistoryImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorHistoryImpl.java
@@ -113,7 +113,7 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
   }
 
   @Override
-  public List<ReplicationStatus> getReplicationEvents(String replicatorid) {
+  public List<ReplicationStatus> getReplicationEvents(String replicationConfigId) {
     return helper.getTypeForFilter(
         filterBuilder.allOf(
             filterBuilder
@@ -121,7 +121,11 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
                 .is()
                 .equalTo()
                 .text(ReplicationHistory.METACARD_TAG),
-            filterBuilder.attribute(ReplicationConfig.NAME).is().equalTo().text(replicatorid)),
+            filterBuilder
+                .attribute(ReplicationConfig.NAME)
+                .is()
+                .equalTo()
+                .text(replicationConfigId)),
         this::getStatusFromMetacard);
   }
 
@@ -164,7 +168,7 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
   @Override
   public void removeReplicationEvents(Set<String> ids) {
     try {
-      provider.delete(new DeleteRequestImpl(ids.toArray(new String[ids.size()])));
+      provider.delete(new DeleteRequestImpl(ids.toArray(new String[0])));
     } catch (IngestException e) {
       throw new ReplicationPersistenceException(
           "Error deleting replication history items " + ids, e);

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
@@ -37,16 +37,8 @@ import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import org.apache.commons.collections4.queue.UnmodifiableQueue;
 import org.codice.ddf.security.common.Security;
-import org.codice.ditto.replication.api.Direction;
-import org.codice.ditto.replication.api.ReplicationException;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
-import org.codice.ditto.replication.api.ReplicationStatus;
-import org.codice.ditto.replication.api.ReplicationStore;
-import org.codice.ditto.replication.api.Replicator;
-import org.codice.ditto.replication.api.ReplicatorHistory;
-import org.codice.ditto.replication.api.ReplicatorStoreFactory;
-import org.codice.ditto.replication.api.Status;
-import org.codice.ditto.replication.api.SyncRequest;
+import org.codice.ditto.replication.api.*;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.persistence.SiteManager;
@@ -61,7 +53,7 @@ public class ReplicatorImpl implements Replicator {
 
   private final ReplicatorHistory history;
 
-  private final ReplicationPersistentStore persistentStore;
+  private final ReplicationItemManager persistentStore;
 
   private final SiteManager siteManager;
 
@@ -82,7 +74,7 @@ public class ReplicatorImpl implements Replicator {
   public ReplicatorImpl(
       ReplicatorStoreFactory replicatorStoreFactory,
       ReplicatorHistory history,
-      ReplicationPersistentStore persistentStore,
+      ReplicationItemManager persistentStore,
       SiteManager siteManager,
       ExecutorService executor,
       FilterBuilder builder) {
@@ -99,7 +91,7 @@ public class ReplicatorImpl implements Replicator {
   public ReplicatorImpl(
       ReplicatorStoreFactory replicatorStoreFactory,
       ReplicatorHistory history,
-      ReplicationPersistentStore persistentStore,
+      ReplicationItemManager persistentStore,
       SiteManager siteManager,
       ExecutorService executor,
       FilterBuilder builder,

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/SyncHelper.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/SyncHelper.java
@@ -65,14 +65,8 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.shiro.SecurityUtils;
-import org.codice.ditto.replication.api.ReplicationException;
-import org.codice.ditto.replication.api.ReplicationItem;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
-import org.codice.ditto.replication.api.ReplicationStatus;
-import org.codice.ditto.replication.api.ReplicationStore;
-import org.codice.ditto.replication.api.ReplicationType;
-import org.codice.ditto.replication.api.ReplicatorHistory;
-import org.codice.ditto.replication.api.Status;
+import org.codice.ditto.replication.api.*;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.mcard.Replication;
 import org.geotools.filter.text.cql2.CQLException;
@@ -96,7 +90,7 @@ class SyncHelper {
 
   private final ReplicatorConfig config;
 
-  private final ReplicationPersistentStore persistentStore;
+  private final ReplicationItemManager persistentStore;
 
   private final ReplicatorHistory history;
 
@@ -123,7 +117,7 @@ class SyncHelper {
       ReplicationStore destination,
       ReplicatorConfig config,
       ReplicationStatus status,
-      ReplicationPersistentStore persistentStore,
+      ReplicationItemManager persistentStore,
       ReplicatorHistory history,
       FilterBuilder builder) {
     this.source = source;

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicatorConfigImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicatorConfigImpl.java
@@ -43,11 +43,27 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
 
   private static final String SUSPENDED_KEY = "suspended";
 
+  private static final String DELETED_KEY = "deleted";
+
+  private static final String DELETE_DATA_KEY = "deleteData";
+
   /**
-   * 0/No Version - initial version of configs which were saved in the catalog framework. 1 - the
-   * first version of configs to be saved in the replication persistent store.
+   * Field specifying the version of the configuration. Possible versions include:
+   *
+   * <ol>
+   *   <li>0 (No version) - initial version of configs which were saved in the catalog framework
+   *   <li>1 - The first version of configs to be saved in the replication persistent store
+   *       <ul>
+   *         <li>Add <b>suspended</b> field of type boolean
+   *         <li>Add <b>deleted</b> field of type boolean
+   *       </ul>
+   * </ol>
    */
   public static final int CURRENT_VERSION = 1;
+
+  private boolean deleted = false;
+
+  private boolean deleteData = false;
 
   private String name;
 
@@ -80,6 +96,8 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
     result.put(RETRY_COUNT_KEY, getFailureRetryCount());
     result.put(DESCRIPTION_KEY, getDescription());
     result.put(SUSPENDED_KEY, Boolean.toString(isSuspended()));
+    result.put(DELETED_KEY, Boolean.toString(isDeleted()));
+    result.put(DELETE_DATA_KEY, Boolean.toString(deleteData()));
     return result;
   }
 
@@ -94,6 +112,8 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
     setFailureRetryCount((int) properties.get(RETRY_COUNT_KEY));
     setDescription((String) properties.get(DESCRIPTION_KEY));
     setSuspended(Boolean.valueOf((String) properties.get(SUSPENDED_KEY)));
+    setDeleted(Boolean.valueOf((String) properties.get(DELETED_KEY)));
+    setDeleteData(Boolean.valueOf((String) properties.get(DELETE_DATA_KEY)));
   }
 
   @Override
@@ -194,5 +214,25 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
   @Override
   public void setSuspended(boolean suspended) {
     this.suspended = suspended;
+  }
+
+  @Override
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  @Override
+  public void setDeleted(boolean deleted) {
+    this.deleted = deleted;
+  }
+
+  @Override
+  public boolean deleteData() {
+    return deleteData;
+  }
+
+  @Override
+  public void setDeleteData(boolean deleteData) {
+    this.deleteData = deleteData;
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/Metacards.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/Metacards.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api.impl.persistence;
+
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.data.types.Core;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.impl.SortByImpl;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
+import ddf.catalog.operation.impl.QueryImpl;
+import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.util.impl.ResultIterable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.opengis.filter.Filter;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Metacards {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Metacards.class);
+
+  private static final int BATCH_SIZE = 250;
+
+  private final CatalogFramework catalogFramework;
+
+  private final FilterBuilder filterBuilder;
+
+  public Metacards(CatalogFramework catalogFramework, FilterBuilder filterBuilder) {
+    this.catalogFramework = catalogFramework;
+    this.filterBuilder = filterBuilder;
+  }
+
+  public Set<String> getIdsOfMetacardsInCatalog(Set<String> ids) {
+    List<Filter> filters = new ArrayList<>();
+
+    for (String idString : ids) {
+      filters.add(filterBuilder.attribute(Core.ID).is().equalTo().text(idString));
+    }
+    Filter filter = filterBuilder.anyOf(filters);
+
+    QueryRequest request =
+        new QueryRequestImpl(
+            new QueryImpl(
+                filter, 1, ids.size(), new SortByImpl(Core.ID, SortOrder.ASCENDING), false, 0L));
+
+    ResultIterable results = ResultIterable.resultIterable(catalogFramework::query, request);
+    return results
+        .stream()
+        .map(Result::getMetacard)
+        .map(Metacard::getId)
+        .collect(Collectors.toSet());
+  }
+
+  public void doDelete(String[] idsToDelete) throws SourceUnavailableException {
+    if (idsToDelete.length > 0) {
+      int start = 0;
+      int end;
+
+      while (start < idsToDelete.length) {
+        end = start + BATCH_SIZE;
+        if (end > idsToDelete.length) {
+          end = idsToDelete.length;
+        }
+        deleteBatch(Arrays.copyOfRange(idsToDelete, start, end));
+        start += BATCH_SIZE;
+      }
+    }
+  }
+
+  private void deleteBatch(String[] idsToDelete) throws SourceUnavailableException {
+    try {
+      catalogFramework.delete(new DeleteRequestImpl(idsToDelete));
+    } catch (IngestException ie) {
+
+      // One metacard failing to delete will cause the entire batch to not be deleted. So,
+      // if the batch fails, perform the deletes individually and just skip over the ones that fail.
+      for (String id : idsToDelete) {
+        try {
+          catalogFramework.delete(new DeleteRequestImpl(id));
+        } catch (IngestException e) {
+          LOGGER.debug("Failed to delete metacard with id: {}", id, e);
+        }
+      }
+    }
+  }
+}

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/ScheduledReplicatorDeleter.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/ScheduledReplicatorDeleter.java
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api.impl.persistence;
+
+import com.google.common.collect.Sets;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.security.service.SecurityServiceException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.codice.ddf.configuration.SystemInfo;
+import org.codice.ddf.persistence.PersistenceException;
+import org.codice.ddf.security.common.Security;
+import org.codice.ditto.replication.api.*;
+import org.codice.ditto.replication.api.data.ReplicatorConfig;
+import org.codice.ditto.replication.api.persistence.ReplicatorConfigManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Periodically polls for available {@link ReplicatorConfig}s and deletes them based on the {@link
+ * ReplicatorConfig#isDeleted()} and {@link ReplicatorConfig#deleteData()} properties. A {@link
+ * ReplicatorConfig} marked as deleted always has its history deleted.
+ */
+public class ScheduledReplicatorDeleter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledReplicatorDeleter.class);
+
+  private static final int DEFAULT_PAGE_SIZE = 1000;
+
+  private final ReplicatorConfigManager replicatorConfigManager;
+
+  private final ReplicationItemManager replicationItemManager;
+
+  private final ReplicatorHistory replicatorHistory;
+
+  private final Metacards metacards;
+
+  private final ScheduledExecutorService scheduledExecutorService;
+
+  private final Security security;
+
+  public ScheduledReplicatorDeleter(
+      ReplicatorConfigManager replicatorConfigManager,
+      ScheduledExecutorService scheduledExecutorService,
+      ReplicationItemManager replicationItemManager,
+      ReplicatorHistory replicatorHistory,
+      Metacards metacards) {
+    this(
+        replicatorConfigManager,
+        scheduledExecutorService,
+        replicationItemManager,
+        replicatorHistory,
+        metacards,
+        Security.getInstance(),
+        TimeUnit.MINUTES.toMillis(1));
+  }
+
+  public ScheduledReplicatorDeleter(
+      ReplicatorConfigManager replicatorConfigManager,
+      ScheduledExecutorService scheduledExecutorService,
+      ReplicationItemManager replicationItemManager,
+      ReplicatorHistory replicatorHistory,
+      Metacards metacards,
+      Security security,
+      long pollPeriod) {
+    this.replicatorConfigManager = replicatorConfigManager;
+    this.scheduledExecutorService = scheduledExecutorService;
+    this.replicationItemManager = replicationItemManager;
+    this.replicatorHistory = replicatorHistory;
+    this.metacards = metacards;
+    this.security = security;
+
+    LOGGER.info(
+        "Scheduling replicator config cleanup every {} seconds",
+        TimeUnit.MILLISECONDS.toSeconds(pollPeriod));
+    scheduledExecutorService.scheduleAtFixedRate(
+        this::cleanup, 0, pollPeriod, TimeUnit.MILLISECONDS);
+  }
+
+  public void destroy() {
+    scheduledExecutorService.shutdownNow();
+  }
+
+  public void cleanup() {
+    security.runAsAdmin(
+        () -> {
+          try {
+            security.runWithSubjectOrElevate(
+                () -> {
+                  List<ReplicatorConfig> replicatorConfigs =
+                      replicatorConfigManager.objects().collect(Collectors.toList());
+
+                  cleanupOrphanedReplicationItems(replicatorConfigs);
+                  cleanupDeletedConfigs(replicatorConfigs);
+
+                  return null;
+                });
+          } catch (SecurityServiceException | InvocationTargetException e) {
+            LOGGER.debug("Failed scheduled cleanup of deleted replicator configs", e);
+          }
+
+          return null;
+        });
+  }
+
+  /**
+   * Deletes {@link ReplicationItem}s which have no corresponding data store entry or {@link
+   * ReplicatorConfig}. This occurs when a {@link ReplicatorConfig} was deleted without cleaning up
+   * data, but the data was then deleted manually afterwards.
+   */
+  private void cleanupOrphanedReplicationItems(List<ReplicatorConfig> replicatorConfigs) {
+    Set<String> replicatorConfigIds =
+        replicatorConfigs.stream().map(ReplicatorConfig::getId).collect(Collectors.toSet());
+
+    int startIndex = 0;
+    Set<String> configlessItemIds = Collections.emptySet();
+
+    do {
+      try {
+
+        configlessItemIds =
+            replicationItemManager
+                .getItemsForConfig("", startIndex, DEFAULT_PAGE_SIZE)
+                .stream()
+                .filter(item -> !replicatorConfigIds.contains(item.getConfigurationId()))
+                .map(ReplicationItem::getMetacardId)
+                .collect(Collectors.toSet());
+
+        if (!configlessItemIds.isEmpty()) {
+          Set<String> idsInTheCatalog = metacards.getIdsOfMetacardsInCatalog(configlessItemIds);
+          Set<String> orphanedItemIds = Sets.difference(configlessItemIds, idsInTheCatalog);
+          orphanedItemIds.forEach(replicationItemManager::deleteItem);
+
+          // todo: do we really increment the index this way?
+          startIndex += configlessItemIds.size();
+        }
+      } catch (PersistenceException e) {
+        LOGGER.debug("Failed to retrieve replication items. Continuing", e);
+        startIndex += DEFAULT_PAGE_SIZE;
+      }
+    } while (!configlessItemIds.isEmpty());
+  }
+
+  private void cleanupDeletedConfigs(List<ReplicatorConfig> replicatorConfigs) {
+    List<ReplicatorConfig> deletedConfigs =
+        replicatorConfigs.stream().filter(ReplicatorConfig::isDeleted).collect(Collectors.toList());
+
+    for (ReplicatorConfig config : deletedConfigs) {
+      final String configId = config.getId();
+      final String configName = config.getName();
+
+      if (config.deleteData()) {
+        try {
+          deleteReplicationItems(configId);
+        } catch (PersistenceException e) {
+          LOGGER.debug(
+              "Failed to retrieve replication items for config: {}. Deletion will be retried next poll interval.",
+              configName,
+              e);
+          return;
+        } catch (SourceUnavailableException e) {
+          LOGGER.debug(
+              "Failed to delete metacards replicated by config: {}. Deletion will be retried next poll interval.",
+              configName,
+              e);
+          return;
+        }
+      }
+
+      try {
+        deleteReplicatorHistory(configId);
+      } catch (ReplicationPersistenceException e) {
+        LOGGER.debug(
+            "History for replicator configuration {} could not be deleted. Deletion will be retried next polling interval.",
+            configName,
+            e);
+        return;
+      }
+
+      replicatorConfigManager.remove(configId);
+    }
+  }
+
+  private void deleteReplicationItems(String configId)
+      throws PersistenceException, SourceUnavailableException {
+    int startIndex = 0;
+    Set<String> idsToDelete;
+
+    do {
+      idsToDelete =
+          replicationItemManager
+              .getItemsForConfig(configId, startIndex, DEFAULT_PAGE_SIZE)
+              .stream()
+              .filter(item -> item.getDestination().equals(SystemInfo.getSiteName()))
+              .map(ReplicationItem::getMetacardId)
+              .collect(Collectors.toSet());
+
+      if (!idsToDelete.isEmpty()) {
+        Set<String> idsInTheCatalog = metacards.getIdsOfMetacardsInCatalog(idsToDelete);
+        metacards.doDelete(idsInTheCatalog.toArray(new String[0]));
+        startIndex += idsToDelete.size();
+      }
+
+    } while (!idsToDelete.isEmpty());
+
+    replicationItemManager.deleteItemsForConfig(configId);
+  }
+
+  private void deleteReplicatorHistory(String replicatorId) {
+    ReplicatorConfig config = replicatorConfigManager.get(replicatorId);
+    Set<String> eventIds =
+        replicatorHistory
+            .getReplicationEvents(config.getName())
+            .stream()
+            .map(ReplicationStatus::getId)
+            .collect(Collectors.toSet());
+
+    replicatorHistory.removeReplicationEvents(eventIds);
+  }
+}

--- a/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -30,17 +30,41 @@
     <reference id="persistentStore" interface="org.codice.ddf.persistence.PersistentStore"/>
     <reference id="clientFactoryFactory" interface="org.codice.ddf.cxf.client.ClientFactoryFactory"/>
 
-    <bean id="replicationPersistentStore"
-          class="org.codice.ditto.replication.api.impl.ReplicationPersistentStoreImpl">
+    <bean id="metacards" class="org.codice.ditto.replication.api.impl.persistence.Metacards">
+        <argument ref="catalog"/>
+        <argument ref="filterBuilder"/>
+    </bean>
+
+    <bean id="replicatorDeleterExecutorThreadFactory"
+          class="org.codice.ddf.platform.util.StandardThreadFactoryBuilder"
+          factory-method="newThreadFactory">
+        <argument value="replicatorDeleterThread"/>
+    </bean>
+    <bean id="replicatorDeleterExecutor" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadScheduledExecutor">
+        <argument ref="replicatorDeleterExecutorThreadFactory"/>
+    </bean>
+
+    <bean id="scheduleReplicatorDeleter"
+          class="org.codice.ditto.replication.api.impl.persistence.ScheduledReplicatorDeleter" destroy-method="destroy">
+        <argument ref="configManager"/>
+        <argument ref="replicatorDeleterExecutor"/>
+        <argument ref="replicationItemManager"/>
+        <argument ref="historyService"/>
+        <argument ref="metacards"/>
+    </bean>
+
+    <bean id="replicationItemManager"
+          class="org.codice.ditto.replication.api.impl.ReplicationItemManagerImpl">
         <argument ref="persistentStore"/>
     </bean>
 
     <bean id="newReplicationPersistentStore"
-        class="org.codice.ditto.replication.api.impl.persistence.ReplicationPersistentStore">
+          class="org.codice.ditto.replication.api.impl.persistence.ReplicationPersistentStore">
         <argument ref="persistentStore"/>
     </bean>
 
-    <bean id="siteManager" class="org.codice.ditto.replication.api.impl.persistence.SiteManagerImpl"  init-method="init">
+    <bean id="siteManager" class="org.codice.ditto.replication.api.impl.persistence.SiteManagerImpl" init-method="init">
         <argument ref="newReplicationPersistentStore"/>
     </bean>
 
@@ -81,7 +105,7 @@
     </bean>
 
     <service ref="catalogResourceStoreFactory" interface="org.codice.ditto.replication.api.ReplicatorStoreFactory"/>
-    <service ref="replicationPersistentStore" interface="org.codice.ditto.replication.api.ReplicationPersistentStore"/>
+    <service ref="replicationItemManager" interface="org.codice.ditto.replication.api.ReplicationItemManager"/>
     <service ref="siteManager" interface="org.codice.ditto.replication.api.persistence.SiteManager"/>
 
     <bean id="metacardHelper" class="org.codice.ditto.replication.api.impl.MetacardHelper">
@@ -109,7 +133,7 @@
           destroy-method="cleanUp">
         <argument ref="catalogResourceStoreFactory"/>
         <argument ref="historyService"/>
-        <argument ref="replicationPersistentStore"/>
+        <argument ref="replicationItemManager"/>
         <argument ref="siteManager"/>
         <argument ref="replicatorImplExecutor"/>
         <argument ref="filterBuilder"/>
@@ -126,7 +150,8 @@
         <argument value="replicatorImplProcessorThread"/>
     </bean>
 
-    <bean id="runner" class="org.codice.ditto.replication.api.impl.ReplicatorRunner" init-method="init" destroy-method="destroy">
+    <bean id="runner" class="org.codice.ditto.replication.api.impl.ReplicatorRunner" init-method="init"
+          destroy-method="destroy">
         <argument ref="replicatorRunnerExecutor"/>
         <argument ref="replicator"/>
         <argument ref="configManager"/>

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
@@ -28,15 +28,8 @@ import java.security.PrivilegedAction;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import org.codice.ddf.security.common.Security;
-import org.codice.ditto.replication.api.Direction;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
-import org.codice.ditto.replication.api.ReplicationStatus;
-import org.codice.ditto.replication.api.ReplicationStore;
-import org.codice.ditto.replication.api.ReplicationType;
-import org.codice.ditto.replication.api.ReplicatorHistory;
-import org.codice.ditto.replication.api.ReplicatorStoreFactory;
-import org.codice.ditto.replication.api.Status;
-import org.codice.ditto.replication.api.SyncRequest;
+import org.codice.ditto.replication.api.*;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.impl.data.ReplicationStatusImpl;
@@ -58,7 +51,7 @@ public class ReplicatorImplTest {
 
   @Mock ReplicatorStoreFactory replicatorStoreFactory;
   @Mock ReplicatorHistory history;
-  @Mock ReplicationPersistentStore persistentStore;
+  @Mock ReplicationItemManager persistentStore;
   @Mock SiteManager siteManager;
   @Mock ExecutorService executor;
   @Mock Security security;

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/SyncHelperTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/SyncHelperTest.java
@@ -42,7 +42,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import org.apache.shiro.util.ThreadContext;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.ReplicationStatus;
 import org.codice.ditto.replication.api.ReplicationStore;
 import org.codice.ditto.replication.api.ReplicatorHistory;
@@ -63,7 +63,7 @@ public class SyncHelperTest {
   @Mock ReplicationStore source;
   @Mock ReplicationStore destination;
   @Mock ReplicatorConfig config;
-  @Mock ReplicationPersistentStore persistentStore;
+  @Mock ReplicationItemManager persistentStore;
   @Mock ReplicatorHistory history;
 
   ReplicationStatus status;

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationItem.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationItem.java
@@ -21,6 +21,9 @@ import java.util.Date;
  */
 public interface ReplicationItem {
 
+  /** @return a globally unique ID */
+  String getId();
+
   String getMetacardId();
 
   Date getResourceModified();

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationItemManager.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationItemManager.java
@@ -17,9 +17,9 @@ import java.util.List;
 import java.util.Optional;
 import org.codice.ddf.persistence.PersistenceException;
 
-public interface ReplicationPersistentStore {
+public interface ReplicationItemManager {
 
-  Optional<ReplicationItem> getItem(String id, String source, String destination);
+  Optional<ReplicationItem> getItem(String metacardId, String source, String destination);
 
   List<ReplicationItem> getItemsForConfig(String configId, int startIndex, int pageSize)
       throws PersistenceException;
@@ -28,7 +28,9 @@ public interface ReplicationPersistentStore {
 
   void deleteAllItems() throws PersistenceException;
 
-  void deleteItem(String id, String source, String destination);
+  void deleteItem(String metacardId, String source, String destination);
+
+  void deleteItem(String id);
 
   List<String> getFailureList(int maximumFailureCount, String source, String destination);
 

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicatorHistory.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicatorHistory.java
@@ -29,15 +29,17 @@ public interface ReplicatorHistory {
   /**
    * Get all replication events for a given replication configuration
    *
-   * @param replicatorid replication configuration id
+   * @param replicationConfigId replication configuration id
    * @return List of associated replication events
    */
-  List<ReplicationStatus> getReplicationEvents(String replicatorid);
+  List<ReplicationStatus> getReplicationEvents(String replicationConfigId);
 
   /**
    * Add a replication event to the history
    *
    * @param replicationStatus ReplicationConfig event to store
+   * @throws ReplicationPersistenceException if there is an error adding the {@link
+   *     ReplicationStatus}
    */
   void addReplicationEvent(ReplicationStatus replicationStatus);
 
@@ -45,6 +47,8 @@ public interface ReplicatorHistory {
    * Remove a replication event from the history
    *
    * @param replicationStatus replication event to remove
+   * @throws ReplicationPersistenceException if there is an error deleting the {@link
+   *     ReplicationStatus}
    */
   void removeReplicationEvent(ReplicationStatus replicationStatus);
 
@@ -52,6 +56,7 @@ public interface ReplicatorHistory {
    * Remove set of replication events from the history
    *
    * @param ids replication event ids
+   * @throws ReplicationPersistenceException if there is an error deleting 1 or more provided ids.
    */
   void removeReplicationEvents(Set<String> ids);
 }

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicatorConfig.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicatorConfig.java
@@ -170,4 +170,31 @@ public interface ReplicatorConfig extends Persistable {
    * @param suspended the suspended state to give this config
    */
   void setSuspended(boolean suspended);
+
+  /**
+   * See {@link #deleteData()}.
+   *
+   * @return whether or not this {@code ReplicatorConfig} should be considered as deleted
+   */
+  boolean isDeleted();
+
+  /**
+   * Marks this {@code ReplicatorConfig} as deleted.
+   *
+   * @param deleted
+   */
+  void setDeleted(boolean deleted);
+
+  /**
+   * Applies only when {@link #isDeleted()} returns {@code true}.
+   *
+   * <p>Only data that has been replicated to this {@link ReplicationSite} from a remote {@link
+   * ReplicationSite} will be deleted.
+   *
+   * @return if {@code true}, delete the associated data replicated by this {@code
+   *     ReplicatorConfig}, otherwise retain the data.
+   */
+  boolean deleteData();
+
+  void setDeleteData(boolean deleteData);
 }

--- a/replication-commands/src/main/java/org/codice/ditto/replication/commands/ConfigDeleteCommand.java
+++ b/replication-commands/src/main/java/org/codice/ditto/replication/commands/ConfigDeleteCommand.java
@@ -44,7 +44,7 @@ import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.persistence.PersistenceException;
 import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.ReplicationItem;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.mcard.Replication;
 import org.codice.ditto.replication.api.mcard.ReplicationConfig;
@@ -106,7 +106,7 @@ public class ConfigDeleteCommand extends SubjectCommands {
 
   @Reference CatalogFramework framework;
 
-  @Reference ReplicationPersistentStore store;
+  @Reference ReplicationItemManager store;
 
   @Reference FilterBuilder builder;
 
@@ -281,7 +281,7 @@ public class ConfigDeleteCommand extends SubjectCommands {
         try {
           framework.delete(new DeleteRequestImpl(id));
         } catch (IngestException e) {
-          LOGGER.debug("Failed to delete metacard with id:%s because of exception {}", id, e);
+          LOGGER.debug("Failed to delete metacard with id: {}", id, e);
         }
       }
     }

--- a/ui/package.json
+++ b/ui/package.json
@@ -77,7 +77,7 @@
         "statements": 7,
         "branches": 6,
         "lines": 7,
-        "functions": 2
+        "functions": 1
       }
     },
     "collectCoverage": true,

--- a/ui/src/main/webapp/app.js
+++ b/ui/src/main/webapp/app.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import Home from './components/Home'
 import Navbar from './components/Navbar'

--- a/ui/src/main/webapp/client.js
+++ b/ui/src/main/webapp/client.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import ApolloClient from 'apollo-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { createHttpLink } from 'apollo-link-http'

--- a/ui/src/main/webapp/components/Home.js
+++ b/ui/src/main/webapp/components/Home.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import ReplicationsContainer from './replications/ReplicationsContainer'
 

--- a/ui/src/main/webapp/components/Navbar.js
+++ b/ui/src/main/webapp/components/Navbar.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 /* global localStorage */
 import React from 'react'
 import AppBar from '@material-ui/core/AppBar'

--- a/ui/src/main/webapp/components/common/CenteredCircularProgress.js
+++ b/ui/src/main/webapp/components/common/CenteredCircularProgress.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import { CircularProgress } from '@material-ui/core'
 

--- a/ui/src/main/webapp/components/common/Confirmable.js
+++ b/ui/src/main/webapp/components/common/Confirmable.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+import React from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  DialogContentText,
+} from '@material-ui/core'
+
+function Confirmable(props) {
+  const {
+    onConfirm,
+    children,
+    message,
+    subMessage,
+    Button: Trigger,
+    onClose,
+  } = props
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={() => {
+          onClose()
+          setOpen(false)
+        }}
+        fullWidth
+      >
+        <DialogTitle>{message}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{subMessage}</DialogContentText>
+          {children}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              onClose()
+              setOpen(false)
+            }}
+            color='primary'
+          >
+            Cancel
+          </Button>
+          <Button
+            autoFocus
+            onClick={() => {
+              onConfirm()
+              setOpen(false)
+            }}
+            color='primary'
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Trigger onClick={() => setOpen(true)} />
+    </>
+  )
+}
+
+export default Confirmable

--- a/ui/src/main/webapp/components/common/ServerError.js
+++ b/ui/src/main/webapp/components/common/ServerError.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import { Grid, Typography } from '@material-ui/core'
 

--- a/ui/src/main/webapp/components/replications/AddReplication.js
+++ b/ui/src/main/webapp/components/replications/AddReplication.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import {
   MenuItem,
@@ -83,6 +96,7 @@ const defaultFormState = {
   biDirectional: false,
   filterErrorText: '',
   nameErrorText: '',
+  disableSave: false,
 }
 
 class AddReplication extends React.Component {
@@ -141,6 +155,18 @@ class AddReplication extends React.Component {
     })
   }
 
+  disableSaveButton() {
+    this.setState({
+      disableSave: true,
+    })
+  }
+
+  enableSaveButton() {
+    this.setState({
+      disableSave: false,
+    })
+  }
+
   render() {
     const { Button: AddButton, classes } = this.props
     const {
@@ -152,6 +178,7 @@ class AddReplication extends React.Component {
       biDirectional,
       filterErrorText,
       nameErrorText,
+      disableSave = false,
     } = this.state
 
     return (
@@ -262,6 +289,7 @@ class AddReplication extends React.Component {
                     } else if (e.message === 'DUPLICATE_CONFIGURATION') {
                       this.handleInvalidName()
                     }
+                    this.enableSaveButton()
                   })
               }}
               onCompleted={() => {
@@ -271,9 +299,13 @@ class AddReplication extends React.Component {
               {(createReplication, { loading }) => (
                 <div>
                   <Button
-                    disabled={!(name && sourceId && destinationId && filter)}
+                    disabled={
+                      !(name && sourceId && destinationId && filter) ||
+                      disableSave
+                    }
                     color='primary'
                     onClick={() => {
+                      this.disableSaveButton()
                       createReplication({
                         variables: {
                           name: name,

--- a/ui/src/main/webapp/components/replications/ReplicationsContainer.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsContainer.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React, { Fragment } from 'react'
 import { Query } from 'react-apollo'
 import { allReplications } from './gql/queries'
@@ -62,7 +75,7 @@ function ReplicationsContainer(props) {
   const { classes } = props
 
   return (
-    <Query query={allReplications} pollInterval={10000}>
+    <Query query={allReplications} pollInterval={3000}>
       {({ data, loading, error }) => {
         if (loading) return <CenteredCircularProgress />
         if (error) return <ServerError />

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import PropTypes from 'prop-types'
 import {

--- a/ui/src/main/webapp/components/replications/__tests__/actionsMenu.spec.js
+++ b/ui/src/main/webapp/components/replications/__tests__/actionsMenu.spec.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
 /*global test, shallow, expect */
 import React from 'react'
 import ActionsMenu from '../ActionsMenu'

--- a/ui/src/main/webapp/components/replications/gql/mutations.js
+++ b/ui/src/main/webapp/components/replications/gql/mutations.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import gql from 'graphql-tag'
 
 export const addReplication = gql`
@@ -56,7 +69,7 @@ export const cancelReplication = gql`
 `
 
 export const deleteReplication = gql`
-  mutation deleteReplication($id: Pid!) {
-    deleteReplication(id: $id)
+  mutation deleteReplication($id: Pid!, $deleteData: Boolean) {
+    deleteReplication(id: $id, deleteData: $deleteData)
   }
 `

--- a/ui/src/main/webapp/components/replications/gql/queries.js
+++ b/ui/src/main/webapp/components/replications/gql/queries.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import gql from 'graphql-tag'
 
 export const allReplications = gql`

--- a/ui/src/main/webapp/components/replications/replications.js
+++ b/ui/src/main/webapp/components/replications/replications.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 const Status = {
   SUCCESS: 'SUCCESS',
   PENDING: 'PENDING',

--- a/ui/src/main/webapp/components/sites/AddSite.js
+++ b/ui/src/main/webapp/components/sites/AddSite.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import { Mutation } from 'react-apollo'
 import Button from '@material-ui/core/Button'

--- a/ui/src/main/webapp/components/sites/Site.js
+++ b/ui/src/main/webapp/components/sites/Site.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import CardContent from '@material-ui/core/CardContent'
 import {

--- a/ui/src/main/webapp/components/sites/Sites.js
+++ b/ui/src/main/webapp/components/sites/Sites.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React, { Fragment } from 'react'
 import Site from './Site'
 import PropTypes from 'prop-types'

--- a/ui/src/main/webapp/components/sites/SitesContainer.js
+++ b/ui/src/main/webapp/components/sites/SitesContainer.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import { allSites } from './gql/queries'
 import { Query } from 'react-apollo'

--- a/ui/src/main/webapp/components/sites/__tests__/site.spec.js
+++ b/ui/src/main/webapp/components/sites/__tests__/site.spec.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 /*global test, shallow, expect */
 import React from 'react'
 import Site from '../Site'

--- a/ui/src/main/webapp/components/sites/gql/mutations.js
+++ b/ui/src/main/webapp/components/sites/gql/mutations.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import gql from 'graphql-tag'
 
 export const deleteSite = gql`

--- a/ui/src/main/webapp/components/sites/gql/queries.js
+++ b/ui/src/main/webapp/components/sites/gql/queries.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import gql from 'graphql-tag'
 
 export const allSites = gql`

--- a/ui/src/main/webapp/index.html
+++ b/ui/src/main/webapp/index.html
@@ -1,4 +1,19 @@
 <!DOCTYPE html>
+<!-- 
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */ 
+-->
 <html lang="en">
   <head>
     <style>

--- a/ui/src/main/webapp/index.js
+++ b/ui/src/main/webapp/index.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 /*global document, require, process, module */
 import React from 'react'
 import ReactDOM from 'react-dom'


### PR DESCRIPTION
#### What does this PR do?
Tests coming.

- Fixes an issue with erroneous data transfer if 2 replications had overlapping filters. The fix was making sure a replication item always has a unique id (changed from metacard id)
- Fixes an issue with karaf configuration delete command not cleaning up replication items.
- Adds option to delete replicated data when deleting a configuration. Only data replicated from another node to the local node will be deleted.
- Add a scheduled deleter that checks for deleted configurations and cleans them up (runs every minute)
- Add checks for deleting orphaned replication items (replication items without corresponding configurations or metacards).

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @paouelle @kcover @mcalcote 

#### How should this be tested? (List steps with links to updated documentation)
- Replicate and verify deleting data along with the replication.
- Replicate and delete a config (preserver data). Delete a metacard and verify its corresponding replication item entry gets cleaned up.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #45 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/17572782/55033144-b3825b00-4fcf-11e9-9445-bce3c76ab7e5.png)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
