### PR TITLE
[WIP] REP-45 Add option to delete replication data through UI

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>replication</artifactId>
         <groupId>replication</groupId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>replication</artifactId>
         <groupId>replication</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -90,7 +90,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.71</minimum>
+                                            <minimum>0.72</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>

--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>replication-admin</artifactId>
         <groupId>replication</groupId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>replication-admin</artifactId>
         <groupId>replication</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/discover/GetReplications.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/discover/GetReplications.java
@@ -41,7 +41,7 @@ public class GetReplications extends BaseFunctionField<ListField<ReplicationFiel
 
   @Override
   public ListField<ReplicationField> performFunction() {
-    return replicationUtils.getReplications();
+    return replicationUtils.getReplications(true);
   }
 
   @Override

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/persist/DeleteReplication.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/persist/DeleteReplication.java
@@ -29,11 +29,15 @@ public class DeleteReplication extends BaseFunctionField<BooleanField> {
 
   public static final String FIELD_NAME = "deleteReplication";
 
-  public static final String DESCRIPTION = "Deletes a replication.";
+  public static final String DESCRIPTION =
+      "Deletes a Replication. Optionally delete the data of the Replication. Deleting data will delete "
+          + "any local resources and metadata that were replicated by this Replication, but not any resources replicated to a remote Node.";
 
   public static final BooleanField RETURN_TYPE = new BooleanField();
 
   private PidField id;
+
+  private BooleanField deleteData;
 
   private ReplicationUtils replicationUtils;
 
@@ -41,12 +45,16 @@ public class DeleteReplication extends BaseFunctionField<BooleanField> {
     super(FIELD_NAME, DESCRIPTION);
     this.replicationUtils = replicationUtils;
     id = new PidField("id");
+    deleteData = new BooleanField("deleteData");
+    deleteData.setValue(false);
+
+    id.isRequired();
   }
 
   @Override
   public BooleanField performFunction() {
     BooleanField successful = new BooleanField();
-    successful.setValue(replicationUtils.deleteConfig(id.getValue()));
+    successful.setValue(replicationUtils.markConfigDeleted(id.getValue(), deleteData.getValue()));
 
     return successful;
   }
@@ -70,7 +78,7 @@ public class DeleteReplication extends BaseFunctionField<BooleanField> {
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(id);
+    return ImmutableList.of(id, deleteData);
   }
 
   @Override

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSite.java
@@ -60,7 +60,7 @@ public class DeleteReplicationSite extends BaseFunctionField<BooleanField> {
       return;
     }
 
-    ListField<ReplicationField> repFields = replicationUtils.getReplications();
+    ListField<ReplicationField> repFields = replicationUtils.getReplications(false);
     String idToDelete = id.getValue();
     for (ReplicationField repField : repFields.getList()) {
       if (idToDelete.equals(repField.source().id())

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/replications/persist/DeleteReplicationTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/replications/persist/DeleteReplicationTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.replications.persist;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.codice.ddf.admin.api.report.ErrorMessage;
+import org.codice.ddf.admin.api.report.FunctionReport;
+import org.codice.ditto.replication.admin.query.ReplicationMessages;
+import org.codice.ditto.replication.admin.query.ReplicationUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeleteReplicationTest {
+
+  private static final String ID = "abc123";
+
+  DeleteReplication deleteReplication;
+
+  Map<String, Object> args;
+
+  @Mock ReplicationUtils utils;
+
+  @Before
+  public void setup() {
+    deleteReplication = new DeleteReplication(utils);
+    args = new HashMap<>();
+    args.put("id", ID);
+  }
+
+  @Test
+  public void testValidateNoConfig() {
+    when(utils.configExists(ID)).thenReturn(false);
+    FunctionReport report =
+        deleteReplication.execute(args, Collections.singletonList(DeleteReplication.FIELD_NAME));
+    assertThat(report.getErrorMessages().size(), is(1));
+    assertThat(
+        ((ErrorMessage) report.getErrorMessages().get(0)).getCode(),
+        is(ReplicationMessages.CONFIG_DOES_NOT_EXIST));
+  }
+
+  @Test
+  public void testGetFunctionErrorCodes() {
+    assertThat(
+        deleteReplication
+            .getFunctionErrorCodes()
+            .contains(ReplicationMessages.CONFIG_DOES_NOT_EXIST),
+        is(true));
+  }
+
+  @Test
+  public void testDeleteDataArgDefaultsToFalse() {
+    when(utils.configExists(ID)).thenReturn(true);
+    FunctionReport report =
+        deleteReplication.execute(args, Collections.singletonList(DeleteReplication.FIELD_NAME));
+    assertThat(report.getErrorMessages().size(), is(0));
+    verify(utils, times(1)).markConfigDeleted(ID, false);
+  }
+}

--- a/distributions/osgi/features/pom.xml
+++ b/distributions/osgi/features/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>osgi</artifactId>
         <groupId>replication.distributions</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <name>Replication :: Features</name>
     <groupId>replication.distributions.features</groupId>

--- a/distributions/osgi/features/pom.xml
+++ b/distributions/osgi/features/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>osgi</artifactId>
         <groupId>replication.distributions</groupId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <name>Replication :: Features</name>
     <groupId>replication.distributions.features</groupId>

--- a/distributions/osgi/features/replication/pom.xml
+++ b/distributions/osgi/features/replication/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>replication.distributions.features</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Replication :: Features :: Replication</name>

--- a/distributions/osgi/features/replication/pom.xml
+++ b/distributions/osgi/features/replication/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>features</artifactId>
         <groupId>replication.distributions.features</groupId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Replication :: Features :: Replication</name>

--- a/distributions/osgi/pom.xml
+++ b/distributions/osgi/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <artifactId>osgi</artifactId>
     <name>Replication :: OSGI</name>

--- a/distributions/osgi/pom.xml
+++ b/distributions/osgi/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication.distributions</groupId>
         <artifactId>distributions</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <artifactId>osgi</artifactId>
     <name>Replication :: OSGI</name>

--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <groupId>replication.distributions</groupId>
     <artifactId>distributions</artifactId>

--- a/distributions/pom.xml
+++ b/distributions/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <groupId>replication.distributions</groupId>
     <artifactId>distributions</artifactId>

--- a/distributions/test/itests/pom.xml
+++ b/distributions/test/itests/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>test</artifactId>
         <groupId>replication.distributions</groupId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DITTO :: Admin Console :: Test :: ITests</name>

--- a/distributions/test/itests/pom.xml
+++ b/distributions/test/itests/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>test</artifactId>
         <groupId>replication.distributions</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DITTO :: Admin Console :: Test :: ITests</name>

--- a/distributions/test/pom.xml
+++ b/distributions/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>distributions</artifactId>
         <groupId>replication.distributions</groupId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DITTO :: Admin Console :: Test</name>

--- a/distributions/test/pom.xml
+++ b/distributions/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>distributions</artifactId>
         <groupId>replication.distributions</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DITTO :: Admin Console :: Test</name>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>replication</artifactId>
         <groupId>replication</groupId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>docs</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>replication</artifactId>
         <groupId>replication</groupId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>docs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,11 @@
  *
  **/
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>replication</groupId>
     <artifactId>replication</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>0.2.1</version>
     <packaging>pom</packaging>
     <name>Replication</name>
     <organization>
@@ -81,7 +80,7 @@
         <connection>scm:git:http://github.com/connexta/replication.git</connection>
         <developerConnection>scm:git:http://github.com/connexta/replication.git
         </developerConnection>
-        <tag>HEAD</tag>
+        <tag>replication-0.2.1</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>replication</groupId>
     <artifactId>replication</artifactId>
-    <version>0.2.1</version>
+    <version>0.2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Replication</name>
     <organization>
@@ -80,7 +80,7 @@
         <connection>scm:git:http://github.com/connexta/replication.git</connection>
         <developerConnection>scm:git:http://github.com/connexta/replication.git
         </developerConnection>
-        <tag>replication-0.2.1</tag>
+        <tag>HEAD</tag>
     </scm>
     <distributionManagement>
         <snapshotRepository>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <artifactId>replication-api-impl</artifactId>
     <name>Replication :: API Impl</name>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <artifactId>replication-api-impl</artifactId>
     <name>Replication :: API Impl</name>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -331,17 +331,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>0.48</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.47</minimum>
+                                            <minimum>0.52</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicationItemImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicationItemImpl.java
@@ -14,6 +14,7 @@
 package org.codice.ditto.replication.api.impl;
 
 import java.util.Date;
+import java.util.UUID;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ditto.replication.api.ReplicationItem;
 
@@ -31,6 +32,8 @@ public class ReplicationItemImpl implements ReplicationItem {
 
   private final String configurationId;
 
+  private final String id;
+
   private int failureCount;
 
   public ReplicationItemImpl(
@@ -40,10 +43,19 @@ public class ReplicationItemImpl implements ReplicationItem {
       String source,
       String destination,
       String configId) {
-    this(metacardId, resourceModified, metacardModified, source, destination, configId, 0);
+    this(
+        UUID.randomUUID().toString(),
+        metacardId,
+        resourceModified,
+        metacardModified,
+        source,
+        destination,
+        configId,
+        0);
   }
 
   public ReplicationItemImpl(
+      String id,
       String metacardId,
       Date resourceModified,
       Date metacardModified,
@@ -51,6 +63,7 @@ public class ReplicationItemImpl implements ReplicationItem {
       String destination,
       String configId,
       int failureCount) {
+    this.id = id;
     this.metacardId = notBlank(metacardId);
     // TODO these dates don't matter for delete requests that fail. Need to make a way to
     // instantiate a failed ReplicationItem for failed deletes.
@@ -70,6 +83,11 @@ public class ReplicationItemImpl implements ReplicationItem {
     } else {
       throw new IllegalArgumentException("String argument may not be empty");
     }
+  }
+
+  @Override
+  public String getId() {
+    return id;
   }
 
   @Override

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicationItemManagerImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicationItemManagerImpl.java
@@ -23,20 +23,21 @@ import org.codice.ddf.persistence.PersistenceException;
 import org.codice.ddf.persistence.PersistentItem;
 import org.codice.ddf.persistence.PersistentStore;
 import org.codice.ditto.replication.api.ReplicationItem;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ReplicationPersistentStoreImpl implements ReplicationPersistentStore {
+public class ReplicationItemManagerImpl implements ReplicationItemManager {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(ReplicationPersistentStoreImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationItemManagerImpl.class);
 
   private static final String ID_KEY = "id";
 
   private static final String RESOURCE_MODIFIED_KEY = "resource-modified";
 
   private static final String METACARD_MODIFIED_KEY = "metacard-modified";
+
+  private static final String METACARD_ID_KEY = "metacard-id";
 
   private static final String SOURCE_NAME_KEY = "source";
 
@@ -54,15 +55,16 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
 
   private final PersistentStore persistentStore;
 
-  public ReplicationPersistentStoreImpl(PersistentStore persistentStore) {
+  public ReplicationItemManagerImpl(PersistentStore persistentStore) {
     this.persistentStore = persistentStore;
   }
 
   @Override
-  public Optional<ReplicationItem> getItem(String id, String source, String destination) {
+  public Optional<ReplicationItem> getItem(String metacardId, String source, String destination) {
     String cqlFilter =
         String.format(
-            "'id' = '%s' AND 'source' = '%s' AND 'destination' = '%s'", id, source, destination);
+            "'%s' = '%s' AND 'source' = '%s' AND 'destination' = '%s'",
+            METACARD_ID_KEY, metacardId, source, destination);
     List<Map<String, Object>> matchingPersistentItems;
 
     try {
@@ -70,7 +72,7 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
     } catch (PersistenceException e) {
       LOGGER.debug(
           "failed to retrieve item with id: {}, source: {}, and destination: {}",
-          id,
+          metacardId,
           source,
           destination);
       return Optional.empty();
@@ -79,14 +81,14 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
     if (matchingPersistentItems == null || matchingPersistentItems.isEmpty()) {
       LOGGER.debug(
           "couldn't find persisted item with id: {}, source: {}, and destination: {}. This is expected during initial replication.",
-          id,
+          metacardId,
           source,
           destination);
       return Optional.empty();
     } else if (matchingPersistentItems.size() > 1) {
       throw new IllegalStateException(
           "Found multiple persistent items with id: "
-              + id
+              + metacardId
               + ", source: "
               + source
               + ", and destination: "
@@ -102,7 +104,7 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
     // translation currently does not work.
     String cql = "";
     int index = DEFAULT_START_INDEX;
-    long itemsDeleted = 0;
+    long itemsDeleted;
     do {
       itemsDeleted = persistentStore.delete(PERSISTENCE_TYPE, cql, index, DEFAULT_PAGE_SIZE);
       index += DEFAULT_PAGE_SIZE;
@@ -112,7 +114,7 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
   @Override
   public List<ReplicationItem> getItemsForConfig(String configId, int startIndex, int pageSize)
       throws PersistenceException {
-    String cql = String.format("'config-id' = '%s'", configId);
+    String cql = String.format("'%s' = '%s'", CONFIGURATION_ID_KEY, configId);
     List<Map<String, Object>> matchingPersistentItems;
 
     matchingPersistentItems = persistentStore.get(PERSISTENCE_TYPE, cql, startIndex, pageSize);
@@ -133,18 +135,29 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
   }
 
   @Override
-  public void deleteItem(String id, String source, String destination) {
+  public void deleteItem(String metacardId, String source, String destination) {
     String cqlFilter =
         String.format(
-            "'id' = '%s' AND 'source' = '%s' AND 'destination' = '%s'", id, source, destination);
+            "'%s' = '%s' AND 'source' = '%s' AND 'destination' = '%s'",
+            METACARD_ID_KEY, metacardId, source, destination);
     try {
       persistentStore.delete(PERSISTENCE_TYPE, cqlFilter);
     } catch (PersistenceException e) {
       LOGGER.error(
           "error deleting persisted item with id: {}, source: {}, and destination: {}",
-          id,
+          metacardId,
           source,
           destination);
+    }
+  }
+
+  @Override
+  public void deleteItem(String id) {
+    String cqlFilter = String.format("'id' = '%s'", id);
+    try {
+      persistentStore.delete(PERSISTENCE_TYPE, cqlFilter);
+    } catch (PersistenceException e) {
+      LOGGER.debug("Failed to delete item of type {} with id: {}", PERSISTENCE_TYPE, id, e);
     }
   }
 
@@ -175,7 +188,7 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
 
   @Override
   public void deleteItemsForConfig(String configId) throws PersistenceException {
-    String cql = String.format("'config-id' = '%s'", configId);
+    String cql = String.format("'%s' = '%s'", CONFIGURATION_ID_KEY, configId);
     int itemsDeleted;
 
     do {
@@ -186,7 +199,8 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
 
   private PersistentItem replicationToPersistentItem(ReplicationItem replicationItem) {
     PersistentItem persistentItem = new PersistentItem();
-    persistentItem.addIdProperty(replicationItem.getMetacardId());
+    persistentItem.addIdProperty(replicationItem.getId());
+    persistentItem.addProperty(METACARD_ID_KEY, replicationItem.getMetacardId());
     persistentItem.addProperty(RESOURCE_MODIFIED_KEY, replicationItem.getResourceModified());
     persistentItem.addProperty(METACARD_MODIFIED_KEY, replicationItem.getMetacardModified());
     persistentItem.addProperty(FAILURE_COUNT_KEY, replicationItem.getFailureCount());
@@ -200,7 +214,7 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
   private ReplicationItem mapToReplicationItem(Map<String, Object> persistedMap) {
     Map<String, Object> attributes = PersistentItem.stripSuffixes(persistedMap);
 
-    final String metacardId = (String) attributes.get(ID_KEY);
+    final String metacardId = (String) attributes.get(METACARD_ID_KEY);
     final Date resourceModified = (Date) attributes.get(RESOURCE_MODIFIED_KEY);
     final Date metacardModified = (Date) attributes.get(METACARD_MODIFIED_KEY);
     final String source = (String) attributes.get(SOURCE_NAME_KEY);
@@ -209,6 +223,7 @@ public class ReplicationPersistentStoreImpl implements ReplicationPersistentStor
     final int failureCount = (int) attributes.get(FAILURE_COUNT_KEY);
 
     return new ReplicationItemImpl(
+        (String) attributes.get(ID_KEY),
         metacardId,
         resourceModified,
         metacardModified,

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorHistoryImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorHistoryImpl.java
@@ -58,7 +58,7 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
 
   private final FilterBuilder filterBuilder;
 
-  private final MetacardHelper helper;
+  private final Metacards helper;
 
   private final MetacardType metacardType;
 
@@ -66,7 +66,7 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
       CatalogFramework framework,
       CatalogProvider provider,
       FilterBuilder filterBuilder,
-      MetacardHelper helper,
+      Metacards helper,
       MetacardType metacardType) {
     this(framework, provider, filterBuilder, helper, metacardType, Security.getInstance());
   }
@@ -76,7 +76,7 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
       CatalogFramework framework,
       CatalogProvider provider,
       FilterBuilder filterBuilder,
-      MetacardHelper helper,
+      Metacards helper,
       MetacardType metacardType,
       Security security) {
     this.framework = framework;
@@ -113,7 +113,7 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
   }
 
   @Override
-  public List<ReplicationStatus> getReplicationEvents(String replicatorid) {
+  public List<ReplicationStatus> getReplicationEvents(String replicationConfigId) {
     return helper.getTypeForFilter(
         filterBuilder.allOf(
             filterBuilder
@@ -121,7 +121,11 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
                 .is()
                 .equalTo()
                 .text(ReplicationHistory.METACARD_TAG),
-            filterBuilder.attribute(ReplicationConfig.NAME).is().equalTo().text(replicatorid)),
+            filterBuilder
+                .attribute(ReplicationConfig.NAME)
+                .is()
+                .equalTo()
+                .text(replicationConfigId)),
         this::getStatusFromMetacard);
   }
 
@@ -164,7 +168,7 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
   @Override
   public void removeReplicationEvents(Set<String> ids) {
     try {
-      provider.delete(new DeleteRequestImpl(ids.toArray(new String[ids.size()])));
+      provider.delete(new DeleteRequestImpl(ids.toArray(new String[0])));
     } catch (IngestException e) {
       throw new ReplicationPersistenceException(
           "Error deleting replication history items " + ids, e);

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
@@ -38,7 +38,7 @@ import net.jodah.failsafe.RetryPolicy;
 import org.apache.commons.collections4.queue.UnmodifiableQueue;
 import org.codice.ddf.security.common.Security;
 import org.codice.ditto.replication.api.ReplicationException;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.ReplicationStatus;
 import org.codice.ditto.replication.api.ReplicationStore;
 import org.codice.ditto.replication.api.Replicator;
@@ -60,7 +60,7 @@ public class ReplicatorImpl implements Replicator {
 
   private final ReplicatorHistory history;
 
-  private final ReplicationPersistentStore persistentStore;
+  private final ReplicationItemManager persistentStore;
 
   private final SiteManager siteManager;
 
@@ -81,7 +81,7 @@ public class ReplicatorImpl implements Replicator {
   public ReplicatorImpl(
       ReplicatorStoreFactory replicatorStoreFactory,
       ReplicatorHistory history,
-      ReplicationPersistentStore persistentStore,
+      ReplicationItemManager persistentStore,
       SiteManager siteManager,
       ExecutorService executor,
       FilterBuilder builder) {
@@ -98,7 +98,7 @@ public class ReplicatorImpl implements Replicator {
   public ReplicatorImpl(
       ReplicatorStoreFactory replicatorStoreFactory,
       ReplicatorHistory history,
-      ReplicationPersistentStore persistentStore,
+      ReplicationItemManager persistentStore,
       SiteManager siteManager,
       ExecutorService executor,
       FilterBuilder builder,

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ScheduledReplicatorDeleter.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ScheduledReplicatorDeleter.java
@@ -1,0 +1,282 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api.impl;
+
+import com.google.common.annotations.VisibleForTesting;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.security.service.SecurityServiceException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.codice.ddf.configuration.SystemInfo;
+import org.codice.ddf.persistence.PersistenceException;
+import org.codice.ddf.security.common.Security;
+import org.codice.ditto.replication.api.ReplicationItem;
+import org.codice.ditto.replication.api.ReplicationItemManager;
+import org.codice.ditto.replication.api.ReplicationPersistenceException;
+import org.codice.ditto.replication.api.ReplicationStatus;
+import org.codice.ditto.replication.api.ReplicatorHistory;
+import org.codice.ditto.replication.api.data.ReplicatorConfig;
+import org.codice.ditto.replication.api.persistence.ReplicatorConfigManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Periodically polls for available {@link ReplicatorConfig}s and deletes them based on the {@link
+ * ReplicatorConfig#isDeleted()} and {@link ReplicatorConfig#deleteData()} properties. A {@link
+ * ReplicatorConfig} marked as deleted always has its history deleted.
+ */
+public class ScheduledReplicatorDeleter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledReplicatorDeleter.class);
+
+  private static final int DEFAULT_PAGE_SIZE = 1000;
+
+  private final ReplicatorConfigManager replicatorConfigManager;
+
+  private final ReplicationItemManager replicationItemManager;
+
+  private final ReplicatorHistory replicatorHistory;
+
+  private final Metacards metacards;
+
+  private final ScheduledExecutorService scheduledExecutorService;
+
+  private final Security security;
+
+  private final int pageSize;
+
+  public ScheduledReplicatorDeleter(
+      ReplicatorConfigManager replicatorConfigManager,
+      ScheduledExecutorService scheduledExecutorService,
+      ReplicationItemManager replicationItemManager,
+      ReplicatorHistory replicatorHistory,
+      Metacards metacards) {
+    this(
+        replicatorConfigManager,
+        scheduledExecutorService,
+        replicationItemManager,
+        replicatorHistory,
+        metacards,
+        Security.getInstance(),
+        TimeUnit.MINUTES.toMillis(1),
+        DEFAULT_PAGE_SIZE);
+  }
+
+  ScheduledReplicatorDeleter(
+      ReplicatorConfigManager replicatorConfigManager,
+      ScheduledExecutorService scheduledExecutorService,
+      ReplicationItemManager replicationItemManager,
+      ReplicatorHistory replicatorHistory,
+      Metacards metacards,
+      Security security,
+      long pollPeriod,
+      int pageSize) {
+    this.replicatorConfigManager = replicatorConfigManager;
+    this.scheduledExecutorService = scheduledExecutorService;
+    this.replicationItemManager = replicationItemManager;
+    this.replicatorHistory = replicatorHistory;
+    this.metacards = metacards;
+    this.security = security;
+    this.pageSize = pageSize;
+
+    LOGGER.info(
+        "Scheduling replicator config cleanup every {} seconds",
+        TimeUnit.MILLISECONDS.toSeconds(pollPeriod));
+    scheduledExecutorService.scheduleAtFixedRate(
+        this::cleanup, 0, pollPeriod, TimeUnit.MILLISECONDS);
+  }
+
+  public void destroy() {
+    scheduledExecutorService.shutdownNow();
+  }
+
+  public void cleanup() {
+    security.runAsAdmin(
+        () -> {
+          try {
+            security.runWithSubjectOrElevate(
+                () -> {
+                  List<ReplicatorConfig> replicatorConfigs =
+                      replicatorConfigManager.objects().collect(Collectors.toList());
+
+                  cleanupOrphanedReplicationItems(replicatorConfigs);
+                  cleanupDeletedConfigs(replicatorConfigs);
+
+                  return null;
+                });
+          } catch (SecurityServiceException | InvocationTargetException e) {
+            LOGGER.debug("Failed scheduled cleanup of deleted replicator configs", e);
+          }
+
+          return null;
+        });
+  }
+
+  /**
+   * Deletes {@link ReplicationItem}s which have no corresponding data store entry or {@link
+   * ReplicatorConfig}. This occurs when a {@link ReplicatorConfig} was deleted without cleaning up
+   * data, but the data was then deleted manually afterwards.
+   */
+  private void cleanupOrphanedReplicationItems(List<ReplicatorConfig> replicatorConfigs) {
+    Set<String> replicatorConfigIds =
+        replicatorConfigs.stream().map(ReplicatorConfig::getId).collect(Collectors.toSet());
+
+    int startIndex = 0;
+    List<ReplicationItem> replicationItems;
+
+    do {
+      try {
+
+        replicationItems = replicationItemManager.getItemsForConfig("", startIndex, pageSize);
+
+        Set<ReplicationItem> configlessItems =
+            replicationItems
+                .stream()
+                .filter(item -> !replicatorConfigIds.contains(item.getConfigurationId()))
+                .collect(Collectors.toSet());
+
+        if (!configlessItems.isEmpty()) {
+          Set<String> itemMetacardIds =
+              configlessItems
+                  .stream()
+                  .map(ReplicationItem::getMetacardId)
+                  .collect(Collectors.toSet());
+
+          Set<String> idsInTheCatalog = metacards.getIdsOfMetacardsInCatalog(itemMetacardIds);
+
+          Set<ReplicationItem> orphanedItems =
+              configlessItems
+                  .stream()
+                  .filter(item -> itemNotInCatalog(item, idsInTheCatalog))
+                  .collect(Collectors.toSet());
+
+          orphanedItems
+              .stream()
+              .map(ReplicationItem::getId)
+              .forEach(replicationItemManager::deleteItem);
+
+          startIndex += replicationItems.size() - orphanedItems.size();
+        } else {
+          startIndex += replicationItems.size();
+        }
+      } catch (PersistenceException e) {
+        LOGGER.debug(
+            "Failed to delete orphaned replication items. Deletion will be retried next poll interval.",
+            e);
+        return;
+      }
+    } while (!replicationItems.isEmpty());
+  }
+
+  private boolean itemNotInCatalog(ReplicationItem item, Set<String> idsInCatalog) {
+    return !idsInCatalog.contains(item.getId());
+  }
+
+  private void cleanupDeletedConfigs(List<ReplicatorConfig> replicatorConfigs) {
+    List<ReplicatorConfig> deletedConfigs =
+        replicatorConfigs.stream().filter(ReplicatorConfig::isDeleted).collect(Collectors.toList());
+
+    for (ReplicatorConfig config : deletedConfigs) {
+      final String configId = config.getId();
+      final String configName = config.getName();
+
+      if (config.deleteData()) {
+        try {
+          deleteMetacards(configId);
+        } catch (PersistenceException e) {
+          LOGGER.debug(
+              "Failed to retrieve replication items for config: {}. Deletion will be retried next poll interval.",
+              configName,
+              e);
+          return;
+        } catch (SourceUnavailableException e) {
+          LOGGER.debug(
+              "Failed to delete metacards replicated by config: {}. Deletion will be retried next poll interval.",
+              configName,
+              e);
+          return;
+        }
+      }
+
+      try {
+        replicationItemManager.deleteItemsForConfig(configId);
+      } catch (PersistenceException e) {
+        LOGGER.debug(
+            "Failed to delete replication items for config: {}. Deletion will be retried next poll interval",
+            configName,
+            e);
+        return;
+      }
+
+      try {
+        deleteReplicatorHistory(config);
+      } catch (ReplicationPersistenceException e) {
+        LOGGER.debug(
+            "History for replicator configuration {} could not be deleted. Deletion will be retried next polling interval.",
+            configName,
+            e);
+        return;
+      }
+
+      replicatorConfigManager.remove(configId);
+    }
+  }
+
+  private void deleteMetacards(String configId)
+      throws PersistenceException, SourceUnavailableException {
+    int startIndex = 0;
+    List<ReplicationItem> replicationItems;
+
+    do {
+      replicationItems = replicationItemManager.getItemsForConfig(configId, startIndex, pageSize);
+
+      Set<String> idsToDelete =
+          replicationItems
+              .stream()
+              .filter(item -> item.getDestination().equals(getSiteName()))
+              .map(ReplicationItem::getMetacardId)
+              .collect(Collectors.toSet());
+
+      if (!idsToDelete.isEmpty()) {
+        Set<String> idsInTheCatalog = metacards.getIdsOfMetacardsInCatalog(idsToDelete);
+        metacards.doDelete(idsInTheCatalog.toArray(new String[0]));
+        startIndex += idsToDelete.size();
+      } else {
+        startIndex += pageSize;
+      }
+
+    } while (!replicationItems.isEmpty());
+  }
+
+  private void deleteReplicatorHistory(ReplicatorConfig config) {
+    Set<String> eventIds =
+        replicatorHistory
+            .getReplicationEvents(config.getName())
+            .stream()
+            .map(ReplicationStatus::getId)
+            .collect(Collectors.toSet());
+
+    replicatorHistory.removeReplicationEvents(eventIds);
+  }
+
+  /** Solely for mocking out a static call. */
+  @VisibleForTesting
+  String getSiteName() {
+    return SystemInfo.getSiteName();
+  }
+}

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/SyncHelper.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/SyncHelper.java
@@ -67,7 +67,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.shiro.SecurityUtils;
 import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.ReplicationItem;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.ReplicationStatus;
 import org.codice.ditto.replication.api.ReplicationStore;
 import org.codice.ditto.replication.api.ReplicatorHistory;
@@ -95,7 +95,7 @@ class SyncHelper {
 
   private final ReplicatorConfig config;
 
-  private final ReplicationPersistentStore persistentStore;
+  private final ReplicationItemManager persistentStore;
 
   private final ReplicatorHistory history;
 
@@ -120,7 +120,7 @@ class SyncHelper {
       ReplicationStore destination,
       ReplicatorConfig config,
       ReplicationStatus status,
-      ReplicationPersistentStore persistentStore,
+      ReplicationItemManager persistentStore,
       ReplicatorHistory history,
       FilterBuilder builder) {
     this.source = source;

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicatorConfigImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicatorConfigImpl.java
@@ -41,11 +41,27 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
 
   private static final String SUSPENDED_KEY = "suspended";
 
+  private static final String DELETED_KEY = "deleted";
+
+  private static final String DELETE_DATA_KEY = "deleteData";
+
   /**
-   * 0/No Version - initial version of configs which were saved in the catalog framework. 1 - the
-   * first version of configs to be saved in the replication persistent store.
+   * Field specifying the version of the configuration. Possible versions include:
+   *
+   * <ol>
+   *   <li>0 (No version) - initial version of configs which were saved in the catalog framework
+   *   <li>1 - The first version of configs to be saved in the replication persistent store
+   *       <ul>
+   *         <li>Add <b>suspended</b> field of type boolean
+   *         <li>Add <b>deleted</b> field of type boolean
+   *       </ul>
+   * </ol>
    */
   public static final int CURRENT_VERSION = 1;
+
+  private boolean deleted = false;
+
+  private boolean deleteData = false;
 
   private String name;
 
@@ -78,6 +94,8 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
     result.put(RETRY_COUNT_KEY, getFailureRetryCount());
     result.put(DESCRIPTION_KEY, getDescription());
     result.put(SUSPENDED_KEY, Boolean.toString(isSuspended()));
+    result.put(DELETED_KEY, Boolean.toString(isDeleted()));
+    result.put(DELETE_DATA_KEY, Boolean.toString(deleteData()));
     return result;
   }
 
@@ -92,6 +110,8 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
     setFailureRetryCount((int) properties.get(RETRY_COUNT_KEY));
     setDescription((String) properties.get(DESCRIPTION_KEY));
     setSuspended(Boolean.valueOf((String) properties.get(SUSPENDED_KEY)));
+    setDeleted(Boolean.valueOf((String) properties.get(DELETED_KEY)));
+    setDeleteData(Boolean.valueOf((String) properties.get(DELETE_DATA_KEY)));
   }
 
   @Override
@@ -172,5 +192,25 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
   @Override
   public void setSuspended(boolean suspended) {
     this.suspended = suspended;
+  }
+
+  @Override
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  @Override
+  public void setDeleted(boolean deleted) {
+    this.deleted = deleted;
+  }
+
+  @Override
+  public boolean deleteData() {
+    return deleteData;
+  }
+
+  @Override
+  public void setDeleteData(boolean deleteData) {
+    this.deleteData = deleteData;
   }
 }

--- a/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -30,13 +30,32 @@
     <reference id="persistentStore" interface="org.codice.ddf.persistence.PersistentStore"/>
     <reference id="clientFactoryFactory" interface="org.codice.ddf.cxf.client.ClientFactoryFactory"/>
 
-    <bean id="replicationPersistentStore"
-          class="org.codice.ditto.replication.api.impl.ReplicationPersistentStoreImpl">
+    <bean id="replicatorDeleterExecutorThreadFactory"
+          class="org.codice.ddf.platform.util.StandardThreadFactoryBuilder"
+          factory-method="newThreadFactory">
+        <argument value="replicatorDeleterThread"/>
+    </bean>
+    <bean id="replicatorDeleterExecutor" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadScheduledExecutor">
+        <argument ref="replicatorDeleterExecutorThreadFactory"/>
+    </bean>
+
+    <bean id="scheduleReplicatorDeleter"
+          class="org.codice.ditto.replication.api.impl.ScheduledReplicatorDeleter" destroy-method="destroy">
+        <argument ref="configManager"/>
+        <argument ref="replicatorDeleterExecutor"/>
+        <argument ref="replicationItemManager"/>
+        <argument ref="historyService"/>
+        <argument ref="metacards"/>
+    </bean>
+
+    <bean id="replicationItemManager"
+          class="org.codice.ditto.replication.api.impl.ReplicationItemManagerImpl">
         <argument ref="persistentStore"/>
     </bean>
 
     <bean id="newReplicationPersistentStore"
-            class="org.codice.ditto.replication.api.impl.persistence.ReplicationPersistentStore">
+          class="org.codice.ditto.replication.api.impl.persistence.ReplicationPersistentStore">
         <argument ref="persistentStore"/>
     </bean>
 
@@ -45,13 +64,13 @@
         init-method="init">
         <argument ref="catalog"/>
         <argument ref="filterBuilder"/>
-        <argument ref="metacardHelper"/>
+        <argument ref="metacards"/>
         <argument ref="siteManager"/>
         <argument ref="configManager"/>
         <argument ref="newReplicationPersistentStore" />
     </bean>
 
-    <bean id="siteManager" class="org.codice.ditto.replication.api.impl.persistence.SiteManagerImpl"  init-method="init">
+    <bean id="siteManager" class="org.codice.ditto.replication.api.impl.persistence.SiteManagerImpl" init-method="init">
         <argument ref="newReplicationPersistentStore"/>
     </bean>
 
@@ -92,10 +111,10 @@
     </bean>
 
     <service ref="catalogResourceStoreFactory" interface="org.codice.ditto.replication.api.ReplicatorStoreFactory"/>
-    <service ref="replicationPersistentStore" interface="org.codice.ditto.replication.api.ReplicationPersistentStore"/>
+    <service ref="replicationItemManager" interface="org.codice.ditto.replication.api.ReplicationItemManager"/>
     <service ref="siteManager" interface="org.codice.ditto.replication.api.persistence.SiteManager"/>
 
-    <bean id="metacardHelper" class="org.codice.ditto.replication.api.impl.MetacardHelper">
+    <bean id="metacards" class="org.codice.ditto.replication.api.impl.Metacards">
         <argument ref="catalog"/>
         <argument ref="filterBuilder"/>
     </bean>
@@ -110,7 +129,7 @@
         <argument ref="catalog"/>
         <argument ref="provider"/>
         <argument ref="filterBuilder"/>
-        <argument ref="metacardHelper"/>
+        <argument ref="metacards"/>
         <argument ref="replicationHistory"/>
     </bean>
 
@@ -120,7 +139,7 @@
           destroy-method="cleanUp">
         <argument ref="catalogResourceStoreFactory"/>
         <argument ref="historyService"/>
-        <argument ref="replicationPersistentStore"/>
+        <argument ref="replicationItemManager"/>
         <argument ref="siteManager"/>
         <argument ref="replicatorImplExecutor"/>
         <argument ref="filterBuilder"/>
@@ -137,7 +156,8 @@
         <argument value="replicatorImplProcessorThread"/>
     </bean>
 
-    <bean id="runner" class="org.codice.ditto.replication.api.impl.ReplicatorRunner" init-method="init" destroy-method="destroy">
+    <bean id="runner" class="org.codice.ditto.replication.api.impl.ReplicatorRunner" init-method="init"
+          destroy-method="destroy">
         <argument ref="replicatorRunnerExecutor"/>
         <argument ref="replicator"/>
         <argument ref="configManager"/>

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/MetacardsTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/MetacardsTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api.impl;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Sets;
+import ddf.catalog.CatalogFramework;
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.Result;
+import ddf.catalog.federation.FederationException;
+import ddf.catalog.filter.FilterBuilder;
+import ddf.catalog.filter.proxy.builder.GeotoolsFilterBuilder;
+import ddf.catalog.operation.DeleteRequest;
+import ddf.catalog.operation.DeleteResponse;
+import ddf.catalog.operation.QueryRequest;
+import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.source.IngestException;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.catalog.source.UnsupportedQueryException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetacardsTest {
+
+  private Metacards metacards;
+
+  @Mock CatalogFramework catalogFramework;
+
+  @Before
+  public void setup() {
+    FilterBuilder filterBuilder = new GeotoolsFilterBuilder();
+    metacards = new Metacards(catalogFramework, filterBuilder);
+  }
+
+  @Test
+  public void testGetIdsOfMetacardsInCatalog()
+      throws UnsupportedQueryException, FederationException, SourceUnavailableException {
+    Set<String> ids = Sets.newHashSet(getIds(5));
+    QueryResponse queryResponse = mock(QueryResponse.class);
+    List<Result> results = mockResults(ids);
+    when(queryResponse.getResults()).thenReturn(results);
+    when(catalogFramework.query(any(QueryRequest.class))).thenReturn(queryResponse);
+
+    assertThat(metacards.getIdsOfMetacardsInCatalog(ids), equalTo(ids));
+  }
+
+  @Test
+  public void testBatchDelete() throws SourceUnavailableException, IngestException {
+    final int batchSize = 5;
+    String[] idsToDelete = getIds(batchSize * 3 + 1);
+
+    metacards.doDelete(idsToDelete, batchSize);
+    verify(catalogFramework, times(4)).delete(any(DeleteRequest.class));
+  }
+
+  @Test
+  public void testBatchDeleteWithSomeFailures() throws SourceUnavailableException, IngestException {
+    final int batchSize = 5;
+    String[] idsToDelete = getIds(batchSize * 3);
+
+    when(catalogFramework.delete(any(DeleteRequest.class)))
+        .thenReturn(mock(DeleteResponse.class))
+        .thenThrow(IngestException.class)
+        .thenReturn(mock(DeleteResponse.class));
+
+    metacards.doDelete(idsToDelete, batchSize);
+    verify(catalogFramework, times(8)).delete(any(DeleteRequest.class));
+  }
+
+  private String[] getIds(int size) {
+    String[] ids = new String[size];
+    for (int i = 0; i < size; i++) {
+      ids[i] = i + "";
+    }
+    return ids;
+  }
+
+  private List<Result> mockResults(Set<String> ids) {
+    List<Result> results = new ArrayList<>();
+    ids.forEach(id -> results.add(mockResult(id)));
+    return results;
+  }
+
+  private Result mockResult(String metacardId) {
+    Result result = mock(Result.class);
+    Metacard metacard = mock(Metacard.class);
+    when(metacard.getId()).thenReturn(metacardId);
+    when(result.getMetacard()).thenReturn(metacard);
+    return result;
+  }
+}

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorHistoryImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorHistoryImplTest.java
@@ -70,7 +70,7 @@ public class ReplicatorHistoryImplTest {
 
   @Mock CatalogProvider provider;
 
-  @Mock MetacardHelper helper;
+  @Mock Metacards metacards;
 
   @Before
   public void setUp() throws Exception {
@@ -80,10 +80,10 @@ public class ReplicatorHistoryImplTest {
     types.add(new ReplicationHistoryAttributes());
     MetacardType type = new MetacardTypeImpl("replication-history", types);
     doCallRealMethod()
-        .when(helper)
+        .when(metacards)
         .setIfPresent(any(Metacard.class), any(String.class), any(Serializable.class));
     doCallRealMethod()
-        .when(helper)
+        .when(metacards)
         .setIfPresentOrDefault(
             any(Metacard.class),
             any(String.class),
@@ -94,7 +94,7 @@ public class ReplicatorHistoryImplTest {
         .thenAnswer(invocation -> invocation.getArgumentAt(0, Callable.class).call());
     when(security.runAsAdmin(any(PrivilegedAction.class)))
         .thenAnswer(invocation -> invocation.getArgumentAt(0, PrivilegedAction.class).run());
-    history = new ReplicatorHistoryImpl(framework, provider, builder, helper, type, security);
+    history = new ReplicatorHistoryImpl(framework, provider, builder, metacards, type, security);
   }
 
   @Test
@@ -103,7 +103,7 @@ public class ReplicatorHistoryImplTest {
         generateOldStatus(
             "test", new Date(0), new Date(TimeUnit.DAYS.toMillis(1)), TimeUnit.MINUTES.toMillis(5));
 
-    when(helper.getTypeForFilter(any(Filter.class), any(Function.class))).thenReturn(events);
+    when(metacards.getTypeForFilter(any(Filter.class), any(Function.class))).thenReturn(events);
     history.init();
     ArgumentCaptor<CreateRequest> captor = ArgumentCaptor.forClass(CreateRequest.class);
     verify(framework).create(captor.capture());
@@ -140,7 +140,7 @@ public class ReplicatorHistoryImplTest {
     oldStatus.setLastRun(origTime);
     oldStatus.setLastSuccess(origTime);
     oldStatus.setStatus(Status.SUCCESS);
-    when(helper.getTypeForFilter(any(Filter.class), any(Function.class)))
+    when(metacards.getTypeForFilter(any(Filter.class), any(Function.class)))
         .thenReturn(Collections.singletonList(oldStatus));
     history.init();
     verify(framework, never()).create(any(CreateRequest.class));
@@ -149,7 +149,7 @@ public class ReplicatorHistoryImplTest {
 
   @Test
   public void addReplicationEventNoPreviousEventsSuccess() throws Exception {
-    when(helper.getTypeForFilter(any(Filter.class), any(Function.class)))
+    when(metacards.getTypeForFilter(any(Filter.class), any(Function.class)))
         .thenReturn(new ArrayList());
     Date start = new Date();
     ReplicationStatus status = new ReplicationStatusImpl("test");
@@ -166,7 +166,7 @@ public class ReplicatorHistoryImplTest {
 
   @Test
   public void addReplicationEventNoPreviousEventsFailure() throws Exception {
-    when(helper.getTypeForFilter(any(Filter.class), any(Function.class)))
+    when(metacards.getTypeForFilter(any(Filter.class), any(Function.class)))
         .thenReturn(new ArrayList());
     Date start = new Date();
     ReplicationStatus status = new ReplicationStatusImpl("test");
@@ -190,7 +190,7 @@ public class ReplicatorHistoryImplTest {
     oldStatus.setLastSuccess(origTime);
     oldStatus.setStatus(Status.SUCCESS);
 
-    when(helper.getTypeForFilter(any(Filter.class), any(Function.class)))
+    when(metacards.getTypeForFilter(any(Filter.class), any(Function.class)))
         .thenReturn(Collections.singletonList(oldStatus));
     Date start = new Date();
     ReplicationStatus status = new ReplicationStatusImpl("test");
@@ -210,7 +210,7 @@ public class ReplicatorHistoryImplTest {
 
   @Test(expected = ReplicationPersistenceException.class)
   public void addReplicationEventStorageException() throws Exception {
-    when(helper.getTypeForFilter(any(Filter.class), any(Function.class)))
+    when(metacards.getTypeForFilter(any(Filter.class), any(Function.class)))
         .thenReturn(new ArrayList());
     when(framework.create(any(CreateRequest.class))).thenThrow(new IngestException());
     Date start = new Date();

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
@@ -28,7 +28,7 @@ import java.security.PrivilegedAction;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import org.codice.ddf.security.common.Security;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.ReplicationStatus;
 import org.codice.ditto.replication.api.ReplicationStore;
 import org.codice.ditto.replication.api.ReplicatorHistory;
@@ -56,7 +56,7 @@ public class ReplicatorImplTest {
 
   @Mock ReplicatorStoreFactory replicatorStoreFactory;
   @Mock ReplicatorHistory history;
-  @Mock ReplicationPersistentStore persistentStore;
+  @Mock ReplicationItemManager persistentStore;
   @Mock SiteManager siteManager;
   @Mock ExecutorService executor;
   @Mock Security security;

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorStoreFactoryImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorStoreFactoryImplTest.java
@@ -14,7 +14,7 @@
 package org.codice.ditto.replication.api.impl;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.spy;
 
 import com.thoughtworks.xstream.converters.Converter;

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ScheduledReplicatorDeleterTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ScheduledReplicatorDeleterTest.java
@@ -1,0 +1,408 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api.impl;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anySet;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import ddf.catalog.source.SourceUnavailableException;
+import ddf.security.service.SecurityServiceException;
+import java.lang.reflect.InvocationTargetException;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.codice.ddf.configuration.SystemInfo;
+import org.codice.ddf.persistence.PersistenceException;
+import org.codice.ddf.security.common.Security;
+import org.codice.ditto.replication.api.ReplicationItem;
+import org.codice.ditto.replication.api.ReplicationItemManager;
+import org.codice.ditto.replication.api.ReplicationPersistenceException;
+import org.codice.ditto.replication.api.ReplicationStatus;
+import org.codice.ditto.replication.api.ReplicatorHistory;
+import org.codice.ditto.replication.api.data.ReplicatorConfig;
+import org.codice.ditto.replication.api.persistence.ReplicatorConfigManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScheduledReplicatorDeleterTest {
+
+  private static final String SITE_NAME = "siteName";
+
+  private TestSheduledReplicatorDeleter scheduledReplicatorDeleter;
+
+  private final int pageSize = 1;
+
+  @Mock ReplicatorConfigManager replicatorConfigManager;
+
+  @Mock ScheduledExecutorService scheduledExecutorService;
+
+  @Mock ReplicationItemManager replicationItemManager;
+
+  @Mock ReplicatorHistory replicatorHistory;
+
+  @Mock Metacards metacards;
+
+  @Mock Security security;
+
+  @Before
+  public void setup() throws SecurityServiceException, InvocationTargetException {
+    when(security.runWithSubjectOrElevate(any(Callable.class)))
+        .thenAnswer(invocation -> invocation.getArgumentAt(0, Callable.class).call());
+    when(security.runAsAdmin(any(PrivilegedAction.class)))
+        .thenAnswer(invocation -> invocation.getArgumentAt(0, PrivilegedAction.class).run());
+
+    scheduledReplicatorDeleter =
+        new TestSheduledReplicatorDeleter(
+            replicatorConfigManager,
+            scheduledExecutorService,
+            replicationItemManager,
+            replicatorHistory,
+            metacards,
+            security,
+            1,
+            pageSize);
+  }
+
+  @Test
+  public void testCleanupOrphanedItems() throws PersistenceException {
+    final int pageSize = 2;
+    scheduledReplicatorDeleter =
+        new TestSheduledReplicatorDeleter(
+            replicatorConfigManager,
+            scheduledExecutorService,
+            replicationItemManager,
+            replicatorHistory,
+            metacards,
+            security,
+            1,
+            pageSize);
+
+    final String configId = "configId";
+    final String configName = "configName";
+    ReplicatorConfig config = mockConfig(configId, configName, false, false);
+    when(replicatorConfigManager.objects()).thenReturn(Stream.of(config));
+
+    final String metacardId1 = "mId1";
+    final String metacardId2 = "mId2";
+    final String metacardId3 = "mId3";
+    final String metacardId4 = "mId4";
+    final String metacardId5 = "mId5";
+    final String metacardId6 = "mId6";
+
+    ReplicationItem rep1 = mockRepItem("id1", metacardId1, SITE_NAME);
+    ReplicationItem rep2 = mockRepItem("id2", metacardId2, SITE_NAME);
+    ReplicationItem rep3 = mockRepItem("id3", metacardId3, SITE_NAME);
+    ReplicationItem rep4 = mockRepItem("id4", metacardId4, SITE_NAME);
+    ReplicationItem rep5 = mockRepItem("id5", metacardId5, SITE_NAME);
+    ReplicationItem rep6 = mockRepItem("id6", metacardId6, SITE_NAME);
+    when(rep1.getConfigurationId()).thenReturn("noExistingConfigId");
+    when(rep2.getConfigurationId()).thenReturn(configId);
+    when(rep3.getConfigurationId()).thenReturn(configId);
+    when(rep4.getConfigurationId()).thenReturn(configId);
+    when(rep5.getConfigurationId()).thenReturn(configId);
+    when(rep6.getConfigurationId()).thenReturn("noExistingConfigId");
+
+    when(replicationItemManager.getItemsForConfig("", 0, pageSize))
+        .thenReturn(ImmutableList.of(rep1, rep2));
+    when(replicationItemManager.getItemsForConfig("", 1, pageSize))
+        .thenReturn(ImmutableList.of(rep3, rep4));
+    when(replicationItemManager.getItemsForConfig("", 3, pageSize))
+        .thenReturn(ImmutableList.of(rep5, rep6));
+
+    when(metacards.getIdsOfMetacardsInCatalog(ImmutableSet.of(metacardId1)))
+        .thenReturn(Collections.singleton(metacardId1));
+    when(metacards.getIdsOfMetacardsInCatalog(ImmutableSet.of(metacardId6)))
+        .thenReturn(Collections.singleton(metacardId6));
+
+    scheduledReplicatorDeleter.cleanup();
+
+    verify(replicationItemManager, times(1)).deleteItem("id1");
+    verify(replicationItemManager, never()).deleteItem("id2");
+    verify(replicationItemManager, never()).deleteItem("id3");
+    verify(replicationItemManager, never()).deleteItem("id4");
+    verify(replicationItemManager, never()).deleteItem("id5");
+    verify(replicationItemManager, times(1)).deleteItem("id6");
+  }
+
+  @Test
+  public void testOrphanedItemsToFailGetItems() throws PersistenceException {
+    final String configId = "configId";
+    final String configName = "configName";
+    ReplicatorConfig config = mockConfig(configId, configName, true, true);
+
+    when(replicatorConfigManager.objects()).thenReturn(Stream.of(config));
+
+    doThrow(PersistenceException.class).when(replicationItemManager).getItemsForConfig("", 0, 1);
+    verify(replicationItemManager, never()).deleteItem(anyString());
+
+    scheduledReplicatorDeleter.cleanup();
+  }
+
+  @Test
+  public void testCleanupDeletedConfigs() throws PersistenceException, SourceUnavailableException {
+    final String deletedConfigId = "deletedConfigId";
+    final String deletedConfigName = "deletedConfigName";
+    final String metacardId1 = "mId1";
+    final String metacardId2 = "mId2";
+    final String metacardId3 = "mId3";
+    ReplicatorConfig deletedConfig = mockConfig(deletedConfigId, deletedConfigName, true, true);
+
+    final String configId = "configId";
+    final String configName = "configName";
+    ReplicatorConfig config = mockConfig(configId, configName, false, false);
+
+    when(replicatorConfigManager.objects()).thenReturn(Stream.of(config, deletedConfig));
+
+    ReplicationItem rep1 = mockRepItem("id1", metacardId1, SITE_NAME);
+    ReplicationItem rep2 = mockRepItem("id2", metacardId2, "anotherSite");
+    ReplicationItem rep3 = mockRepItem("id3", metacardId3, SITE_NAME);
+
+    when(replicationItemManager.getItemsForConfig(deletedConfigId, 0, pageSize))
+        .thenReturn(Collections.singletonList(rep1));
+    when(replicationItemManager.getItemsForConfig(deletedConfigId, 1, pageSize))
+        .thenReturn(Collections.singletonList(rep2));
+    when(replicationItemManager.getItemsForConfig(deletedConfigId, 2, pageSize))
+        .thenReturn(Collections.singletonList(rep3));
+
+    when(metacards.getIdsOfMetacardsInCatalog(Collections.singleton(metacardId1)))
+        .thenReturn(Collections.singleton(metacardId1));
+    when(metacards.getIdsOfMetacardsInCatalog(Collections.singleton(metacardId3)))
+        .thenReturn(Collections.singleton(metacardId3));
+
+    ReplicationStatus mockStatus = mockRepStatus("id");
+    List<ReplicationStatus> replicationStatuses = Collections.singletonList(mockStatus);
+
+    when(replicatorHistory.getReplicationEvents(deletedConfigName)).thenReturn(replicationStatuses);
+    Set<String> eventIds =
+        replicationStatuses.stream().map(ReplicationStatus::getId).collect(Collectors.toSet());
+
+    scheduledReplicatorDeleter.cleanup();
+
+    // deleted config
+    verify(metacards, times(1)).doDelete(Collections.singleton(metacardId1).toArray(new String[0]));
+    verify(metacards, times(1)).doDelete(Collections.singleton(metacardId3).toArray(new String[0]));
+    verify(replicatorHistory, times(1)).getReplicationEvents(deletedConfigName);
+    verify(replicatorHistory, times(1)).removeReplicationEvents(eventIds);
+    verify(replicatorConfigManager, times(1)).remove(deletedConfigId);
+
+    // not deleted config
+    verify(replicationItemManager, never()).getItemsForConfig(configId, 0, pageSize);
+    verify(replicatorHistory, never()).getReplicationEvents(configName);
+    verify(replicatorConfigManager, times(1)).remove(deletedConfigId);
+  }
+
+  @Test
+  public void testConfigNotMarkedForDeleteData()
+      throws PersistenceException, SourceUnavailableException {
+    final String configId = "configId";
+    final String configName = "configName";
+    final String metacardId = "metacardId";
+    ReplicatorConfig config = mockConfig(configId, configName, true, false);
+    when(replicatorConfigManager.objects()).thenReturn(Stream.of(config));
+
+    List<ReplicationItem> mockItems = new ArrayList<>();
+    mockItems.add(mockRepItem("id", metacardId, SITE_NAME));
+    when(replicationItemManager.getItemsForConfig(configId, 0, pageSize)).thenReturn(mockItems);
+
+    ReplicationStatus mockStatus = mockRepStatus("id");
+    List<ReplicationStatus> replicationStatuses = Collections.singletonList(mockStatus);
+
+    when(replicatorHistory.getReplicationEvents(configName)).thenReturn(replicationStatuses);
+    Set<String> eventIds =
+        replicationStatuses.stream().map(ReplicationStatus::getId).collect(Collectors.toSet());
+
+    scheduledReplicatorDeleter.cleanup();
+
+    verify(metacards, never()).doDelete(any());
+    verify(replicatorHistory, times(1)).getReplicationEvents(configName);
+    verify(replicatorHistory, times(1)).removeReplicationEvents(eventIds);
+    verify(replicatorConfigManager, times(1)).remove(configId);
+  }
+
+  @Test
+  public void testFailToRetrieveItemsDoesntRemoveMetacardsOrHistoryOrConfig()
+      throws SourceUnavailableException, PersistenceException {
+    final String configId = "configId";
+    ReplicatorConfig config = mockConfig(configId, "name", true, true);
+    when(replicatorConfigManager.objects()).thenReturn(Stream.of(config));
+
+    when(replicationItemManager.getItemsForConfig(configId, 0, pageSize))
+        .thenThrow(PersistenceException.class);
+
+    scheduledReplicatorDeleter.cleanup();
+
+    verify(metacards, never()).doDelete(any());
+    verify(replicationItemManager, never()).deleteItemsForConfig(configId);
+    verify(replicatorHistory, never()).getReplicationEvents(configId);
+    verify(replicatorHistory, never()).removeReplicationEvents(anySet());
+    verify(replicatorConfigManager, never()).remove(configId);
+  }
+
+  @Test
+  public void testFailDeleteMetacardsDoesntRemoveItemsOrConfig()
+      throws SourceUnavailableException, PersistenceException {
+    final String configId = "configId";
+    ReplicatorConfig config = mockConfig(configId, "name", true, true);
+    when(replicatorConfigManager.objects()).thenReturn(Stream.of(config));
+
+    List<ReplicationItem> mockItems = new ArrayList<>();
+    mockItems.add(mockRepItem("id", "metcardId", SITE_NAME));
+    when(replicationItemManager.getItemsForConfig(configId, 0, pageSize)).thenReturn(mockItems);
+
+    doThrow(SourceUnavailableException.class).when(metacards).doDelete(any());
+
+    scheduledReplicatorDeleter.cleanup();
+
+    verify(replicationItemManager, never()).deleteItemsForConfig(configId);
+    verify(replicatorHistory, never()).getReplicationEvents(configId);
+    verify(replicatorHistory, never()).removeReplicationEvents(anySet());
+    verify(replicatorConfigManager, never()).remove(configId);
+  }
+
+  @Test
+  public void testFailCleanupReplicationItemsDoesntRemoveConfig()
+      throws PersistenceException, SourceUnavailableException {
+    final String configId = "configId";
+    final String metacardId1 = "mId1";
+    ReplicatorConfig config = mockConfig(configId, "name", true, true);
+    when(replicatorConfigManager.objects()).thenReturn(Stream.of(config));
+
+    List<ReplicationItem> mockItems = new ArrayList<>();
+    mockItems.add(mockRepItem("id", metacardId1, SITE_NAME));
+    when(replicationItemManager.getItemsForConfig(configId, 0, pageSize)).thenReturn(mockItems);
+
+    doThrow(PersistenceException.class).when(replicationItemManager).deleteItemsForConfig(configId);
+
+    Set<String> itemMetacardIds = Collections.singleton(metacardId1);
+    Set<String> idsInCatalog = Collections.singleton(metacardId1);
+    when(metacards.getIdsOfMetacardsInCatalog(itemMetacardIds)).thenReturn(idsInCatalog);
+
+    scheduledReplicatorDeleter.cleanup();
+
+    verify(metacards, times(1)).doDelete(idsInCatalog.toArray(new String[0]));
+    verify(replicatorHistory, never()).getReplicationEvents(configId);
+    verify(replicatorHistory, never()).removeReplicationEvents(anySet());
+    verify(replicatorConfigManager, never()).remove(configId);
+  }
+
+  @Test
+  public void testFailCleanupHistoryDoesntRemoveConfig()
+      throws PersistenceException, SourceUnavailableException {
+    final String configId = "configId";
+    final String configName = "configName";
+    final String metacardId1 = "mId1";
+    ReplicatorConfig config = mockConfig(configId, configName, true, true);
+    when(replicatorConfigManager.objects()).thenReturn(Stream.of(config));
+
+    List<ReplicationItem> mockItems = new ArrayList<>();
+    mockItems.add(mockRepItem("id", metacardId1, SITE_NAME));
+    when(replicationItemManager.getItemsForConfig(configId, 0, pageSize)).thenReturn(mockItems);
+
+    Set<String> itemMetacardIds = Collections.singleton(metacardId1);
+    Set<String> idsInCatalog = Collections.singleton(metacardId1);
+    when(metacards.getIdsOfMetacardsInCatalog(itemMetacardIds)).thenReturn(idsInCatalog);
+
+    ReplicationStatus mockStatus = mockRepStatus("id");
+    List<ReplicationStatus> replicationStatuses = Collections.singletonList(mockStatus);
+
+    when(replicatorHistory.getReplicationEvents(configName)).thenReturn(replicationStatuses);
+    Set<String> eventIds =
+        replicationStatuses.stream().map(ReplicationStatus::getId).collect(Collectors.toSet());
+    doThrow(ReplicationPersistenceException.class)
+        .when(replicatorHistory)
+        .removeReplicationEvents(eventIds);
+
+    scheduledReplicatorDeleter.cleanup();
+
+    verify(metacards, times(1)).doDelete(idsInCatalog.toArray(new String[0]));
+    verify(replicatorHistory, times(1)).getReplicationEvents(configName);
+    verify(replicatorHistory, times(1)).removeReplicationEvents(eventIds);
+    verify(replicatorConfigManager, never()).remove(configId);
+  }
+
+  private ReplicatorConfig mockConfig(
+      String id, String name, boolean isDeleted, boolean deleteData) {
+    ReplicatorConfig config = mock(ReplicatorConfig.class);
+    when(config.getId()).thenReturn(id);
+    when(config.getName()).thenReturn(name);
+    when(config.isDeleted()).thenReturn(isDeleted);
+    when(config.deleteData()).thenReturn(deleteData);
+    return config;
+  }
+
+  private ReplicationStatus mockRepStatus(String id) {
+    ReplicationStatus status = mock(ReplicationStatus.class);
+    when(status.getId()).thenReturn(id);
+    return status;
+  }
+
+  private ReplicationItem mockRepItem(String itemId, String metacardId, String destination) {
+    ReplicationItem item = mock(ReplicationItem.class);
+    when(item.getId()).thenReturn(itemId);
+    when(item.getMetacardId()).thenReturn(metacardId);
+    when(item.getDestination()).thenReturn(destination);
+    return item;
+  }
+
+  /**
+   * {@link ScheduledReplicatorDeleter} extension solely for overriding a static method call to
+   * {@link SystemInfo#getSiteName()}
+   */
+  private class TestSheduledReplicatorDeleter extends ScheduledReplicatorDeleter {
+
+    public TestSheduledReplicatorDeleter(
+        ReplicatorConfigManager replicatorConfigManager,
+        ScheduledExecutorService scheduledExecutorService,
+        ReplicationItemManager replicationItemManager,
+        ReplicatorHistory replicatorHistory,
+        Metacards metacards,
+        Security security,
+        long pollPeriod,
+        int pageSize) {
+      super(
+          replicatorConfigManager,
+          scheduledExecutorService,
+          replicationItemManager,
+          replicatorHistory,
+          metacards,
+          security,
+          pollPeriod,
+          pageSize);
+    }
+
+    @Override
+    String getSiteName() {
+      return SITE_NAME;
+    }
+  }
+}

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/SyncHelperTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/SyncHelperTest.java
@@ -42,7 +42,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import org.apache.shiro.util.ThreadContext;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.ReplicationStatus;
 import org.codice.ditto.replication.api.ReplicationStore;
 import org.codice.ditto.replication.api.ReplicatorHistory;
@@ -63,7 +63,7 @@ public class SyncHelperTest {
   @Mock ReplicationStore source;
   @Mock ReplicationStore destination;
   @Mock ReplicatorConfig config;
-  @Mock ReplicationPersistentStore persistentStore;
+  @Mock ReplicationItemManager persistentStore;
   @Mock ReplicatorHistory history;
 
   ReplicationStatus status;

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/legacy/LegacyDataConverterTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/legacy/LegacyDataConverterTest.java
@@ -19,7 +19,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import ddf.catalog.CatalogFramework;
 import ddf.catalog.data.Metacard;
@@ -49,7 +54,7 @@ import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.ReplicationPersistenceException;
 import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
-import org.codice.ditto.replication.api.impl.MetacardHelper;
+import org.codice.ditto.replication.api.impl.Metacards;
 import org.codice.ditto.replication.api.impl.data.ReplicationSiteImpl;
 import org.codice.ditto.replication.api.impl.data.ReplicatorConfigImpl;
 import org.codice.ditto.replication.api.impl.mcard.ReplicationConfigAttributes;
@@ -72,16 +77,14 @@ import org.opengis.filter.Filter;
 @RunWith(MockitoJUnitRunner.class)
 public class LegacyDataConverterTest {
 
-  // @Rule public Timeout globalTimeout = Timeout.seconds(10);
-
   @Rule
   public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-  LegacyDataConverter converter;
+  private LegacyDataConverter converter;
 
   @Mock CatalogFramework framework;
 
-  @Mock MetacardHelper helper;
+  @Mock Metacards helper;
 
   @Mock SiteManager siteManager;
 
@@ -91,7 +94,7 @@ public class LegacyDataConverterTest {
 
   @Mock Security security;
 
-  MetacardType type;
+  private MetacardType type;
 
   @Before
   public void setUp() throws Exception {
@@ -122,13 +125,7 @@ public class LegacyDataConverterTest {
     oldSite.setName("oldSiteName");
     oldSite.setUrl("https://oldurl:8080");
     when(persistentStore.objects(eq(OldSite.class)))
-        .thenAnswer(
-            new Answer<Stream<OldSite>>() {
-              @Override
-              public Stream<OldSite> answer(InvocationOnMock invocation) throws Throwable {
-                return Stream.of(oldSite);
-              }
-            });
+        .thenAnswer((Answer<Stream<OldSite>>) invocation -> Stream.of(oldSite));
     when(siteManager.createSite(anyString(), anyString())).thenReturn(new ReplicationSiteImpl());
     converter =
         new LegacyDataConverter(

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
@@ -116,6 +116,8 @@ public class ReplicationPersistentStoreTest {
     map.put(RETRY_COUNT, num);
     map.put(BIDIRECTIONAL, "true");
     map.put(SUSPENDED, "false");
+    map.put("deleted", "false");
+    map.put("deleteData", "false");
     map.put(DESCRIPTION, DESCRIPTION + num);
     map.put(VERSION, ReplicatorConfigImpl.CURRENT_VERSION);
     return map;

--- a/replication-api/pom.xml
+++ b/replication-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <artifactId>replication-api</artifactId>
     <name>Replication :: API</name>

--- a/replication-api/pom.xml
+++ b/replication-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <artifactId>replication-api</artifactId>
     <name>Replication :: API</name>

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationItem.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationItem.java
@@ -21,6 +21,9 @@ import java.util.Date;
  */
 public interface ReplicationItem {
 
+  /** @return a globally unique ID */
+  String getId();
+
   String getMetacardId();
 
   Date getResourceModified();

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationItemManager.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationItemManager.java
@@ -17,9 +17,9 @@ import java.util.List;
 import java.util.Optional;
 import org.codice.ddf.persistence.PersistenceException;
 
-public interface ReplicationPersistentStore {
+public interface ReplicationItemManager {
 
-  Optional<ReplicationItem> getItem(String id, String source, String destination);
+  Optional<ReplicationItem> getItem(String metacardId, String source, String destination);
 
   List<ReplicationItem> getItemsForConfig(String configId, int startIndex, int pageSize)
       throws PersistenceException;
@@ -28,7 +28,9 @@ public interface ReplicationPersistentStore {
 
   void deleteAllItems() throws PersistenceException;
 
-  void deleteItem(String id, String source, String destination);
+  void deleteItem(String metacardId, String source, String destination);
+
+  void deleteItem(String id);
 
   List<String> getFailureList(int maximumFailureCount, String source, String destination);
 

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicatorHistory.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicatorHistory.java
@@ -29,15 +29,17 @@ public interface ReplicatorHistory {
   /**
    * Get all replication events for a given replication configuration
    *
-   * @param replicatorid replication configuration id
+   * @param replicationConfigId replication configuration id
    * @return List of associated replication events
    */
-  List<ReplicationStatus> getReplicationEvents(String replicatorid);
+  List<ReplicationStatus> getReplicationEvents(String replicationConfigId);
 
   /**
    * Add a replication event to the history
    *
    * @param replicationStatus ReplicationConfig event to store
+   * @throws ReplicationPersistenceException if there is an error adding the {@link
+   *     ReplicationStatus}
    */
   void addReplicationEvent(ReplicationStatus replicationStatus);
 
@@ -45,6 +47,8 @@ public interface ReplicatorHistory {
    * Remove a replication event from the history
    *
    * @param replicationStatus replication event to remove
+   * @throws ReplicationPersistenceException if there is an error deleting the {@link
+   *     ReplicationStatus}
    */
   void removeReplicationEvent(ReplicationStatus replicationStatus);
 
@@ -52,6 +56,7 @@ public interface ReplicatorHistory {
    * Remove set of replication events from the history
    *
    * @param ids replication event ids
+   * @throws ReplicationPersistenceException if there is an error deleting 1 or more provided ids.
    */
   void removeReplicationEvents(Set<String> ids);
 }

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicatorConfig.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicatorConfig.java
@@ -136,4 +136,31 @@ public interface ReplicatorConfig extends Persistable {
    * @param suspended the suspended state to give this config
    */
   void setSuspended(boolean suspended);
+
+  /**
+   * See {@link #deleteData()}.
+   *
+   * @return whether or not this {@code ReplicatorConfig} should be considered as deleted
+   */
+  boolean isDeleted();
+
+  /**
+   * Marks this {@code ReplicatorConfig} as deleted.
+   *
+   * @param deleted
+   */
+  void setDeleted(boolean deleted);
+
+  /**
+   * Applies only when {@link #isDeleted()} returns {@code true}.
+   *
+   * <p>Only data that has been replicated to this {@link ReplicationSite} from a remote {@link
+   * ReplicationSite} will be deleted.
+   *
+   * @return if {@code true}, delete the associated data replicated by this {@code
+   *     ReplicatorConfig}, otherwise retain the data.
+   */
+  boolean deleteData();
+
+  void setDeleteData(boolean deleteData);
 }

--- a/replication-commands/pom.xml
+++ b/replication-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
     <artifactId>replication-commands</artifactId>
     <name>Replication :: Commands</name>

--- a/replication-commands/pom.xml
+++ b/replication-commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
     <artifactId>replication-commands</artifactId>
     <name>Replication :: Commands</name>

--- a/replication-commands/src/main/java/org/codice/ditto/replication/commands/ConfigDeleteCommand.java
+++ b/replication-commands/src/main/java/org/codice/ditto/replication/commands/ConfigDeleteCommand.java
@@ -44,7 +44,7 @@ import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.persistence.PersistenceException;
 import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.ReplicationItem;
-import org.codice.ditto.replication.api.ReplicationPersistentStore;
+import org.codice.ditto.replication.api.ReplicationItemManager;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.mcard.Replication;
 import org.codice.ditto.replication.api.mcard.ReplicationConfig;
@@ -106,7 +106,7 @@ public class ConfigDeleteCommand extends SubjectCommands {
 
   @Reference CatalogFramework framework;
 
-  @Reference ReplicationPersistentStore store;
+  @Reference ReplicationItemManager store;
 
   @Reference FilterBuilder builder;
 
@@ -281,7 +281,7 @@ public class ConfigDeleteCommand extends SubjectCommands {
         try {
           framework.delete(new DeleteRequestImpl(id));
         } catch (IngestException e) {
-          LOGGER.debug("Failed to delete metacard with id:%s because of exception {}", id, e);
+          LOGGER.debug("Failed to delete metacard with id: {}", id, e);
         }
       }
     }

--- a/ui/package.json
+++ b/ui/package.json
@@ -74,10 +74,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 7,
+        "statements": 6,
         "branches": 6,
         "lines": 7,
-        "functions": 2
+        "functions": 1
       }
     },
     "collectCoverage": true,

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>0.2.1</version>
     </parent>
 
     <artifactId>replication-ui</artifactId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>replication</groupId>
         <artifactId>replication</artifactId>
-        <version>0.2.1</version>
+        <version>0.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>replication-ui</artifactId>

--- a/ui/src/main/webapp/app.js
+++ b/ui/src/main/webapp/app.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import Home from './components/Home'
 import Navbar from './components/Navbar'

--- a/ui/src/main/webapp/client.js
+++ b/ui/src/main/webapp/client.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import ApolloClient from 'apollo-client'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { createHttpLink } from 'apollo-link-http'

--- a/ui/src/main/webapp/components/Home.js
+++ b/ui/src/main/webapp/components/Home.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import ReplicationsContainer from './replications/ReplicationsContainer'
 

--- a/ui/src/main/webapp/components/Navbar.js
+++ b/ui/src/main/webapp/components/Navbar.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 /* global localStorage */
 import React from 'react'
 import AppBar from '@material-ui/core/AppBar'

--- a/ui/src/main/webapp/components/common/CenteredCircularProgress.js
+++ b/ui/src/main/webapp/components/common/CenteredCircularProgress.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import { CircularProgress } from '@material-ui/core'
 

--- a/ui/src/main/webapp/components/common/Confirmable.js
+++ b/ui/src/main/webapp/components/common/Confirmable.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+import React from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  DialogContentText,
+} from '@material-ui/core'
+
+function Confirmable(props) {
+  const {
+    onConfirm,
+    children,
+    message,
+    subMessage,
+    Button: Trigger,
+    onClose,
+  } = props
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={() => {
+          onClose()
+          setOpen(false)
+        }}
+        fullWidth
+      >
+        <DialogTitle>{message}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{subMessage}</DialogContentText>
+          {children}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              onClose()
+              setOpen(false)
+            }}
+            color='primary'
+          >
+            Cancel
+          </Button>
+          <Button
+            autoFocus
+            onClick={() => {
+              onConfirm()
+              setOpen(false)
+            }}
+            color='primary'
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Trigger onClick={() => setOpen(true)} />
+    </>
+  )
+}
+
+export default Confirmable

--- a/ui/src/main/webapp/components/common/ServerError.js
+++ b/ui/src/main/webapp/components/common/ServerError.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import { Grid, Typography } from '@material-ui/core'
 

--- a/ui/src/main/webapp/components/replications/AddReplication.js
+++ b/ui/src/main/webapp/components/replications/AddReplication.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import {
   MenuItem,
@@ -83,6 +96,7 @@ const defaultFormState = {
   biDirectional: false,
   filterErrorText: '',
   nameErrorText: '',
+  disableSave: false,
 }
 
 class AddReplication extends React.Component {
@@ -141,6 +155,18 @@ class AddReplication extends React.Component {
     })
   }
 
+  disableSaveButton() {
+    this.setState({
+      disableSave: true,
+    })
+  }
+
+  enableSaveButton() {
+    this.setState({
+      disableSave: false,
+    })
+  }
+
   render() {
     const { Button: AddButton, classes } = this.props
     const {
@@ -152,6 +178,7 @@ class AddReplication extends React.Component {
       biDirectional,
       filterErrorText,
       nameErrorText,
+      disableSave = false,
     } = this.state
 
     return (
@@ -262,6 +289,7 @@ class AddReplication extends React.Component {
                     } else if (e.message === 'DUPLICATE_CONFIGURATION') {
                       this.handleInvalidName()
                     }
+                    this.enableSaveButton()
                   })
               }}
               onCompleted={() => {
@@ -271,9 +299,13 @@ class AddReplication extends React.Component {
               {(createReplication, { loading }) => (
                 <div>
                   <Button
-                    disabled={!(name && sourceId && destinationId && filter)}
+                    disabled={
+                      !(name && sourceId && destinationId && filter) ||
+                      disableSave
+                    }
                     color='primary'
                     onClick={() => {
+                      this.disableSaveButton()
                       createReplication({
                         variables: {
                           name: name,

--- a/ui/src/main/webapp/components/replications/ReplicationsContainer.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsContainer.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React, { Fragment } from 'react'
 import { Query } from 'react-apollo'
 import { allReplications } from './gql/queries'
@@ -62,7 +75,7 @@ function ReplicationsContainer(props) {
   const { classes } = props
 
   return (
-    <Query query={allReplications} pollInterval={10000}>
+    <Query query={allReplications} pollInterval={3000}>
       {({ data, loading, error }) => {
         if (loading) return <CenteredCircularProgress />
         if (error) return <ServerError />

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import PropTypes from 'prop-types'
 import {

--- a/ui/src/main/webapp/components/replications/__tests__/actionsMenu.spec.js
+++ b/ui/src/main/webapp/components/replications/__tests__/actionsMenu.spec.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
 /*global test, shallow, expect */
 import React from 'react'
 import ActionsMenu from '../ActionsMenu'

--- a/ui/src/main/webapp/components/replications/gql/mutations.js
+++ b/ui/src/main/webapp/components/replications/gql/mutations.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import gql from 'graphql-tag'
 
 export const addReplication = gql`
@@ -56,7 +69,7 @@ export const cancelReplication = gql`
 `
 
 export const deleteReplication = gql`
-  mutation deleteReplication($id: Pid!) {
-    deleteReplication(id: $id)
+  mutation deleteReplication($id: Pid!, $deleteData: Boolean) {
+    deleteReplication(id: $id, deleteData: $deleteData)
   }
 `

--- a/ui/src/main/webapp/components/replications/gql/queries.js
+++ b/ui/src/main/webapp/components/replications/gql/queries.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import gql from 'graphql-tag'
 
 export const allReplications = gql`

--- a/ui/src/main/webapp/components/replications/replications.js
+++ b/ui/src/main/webapp/components/replications/replications.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 const Status = {
   SUCCESS: 'SUCCESS',
   PENDING: 'PENDING',

--- a/ui/src/main/webapp/components/sites/AddSite.js
+++ b/ui/src/main/webapp/components/sites/AddSite.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import { Mutation } from 'react-apollo'
 import Button from '@material-ui/core/Button'

--- a/ui/src/main/webapp/components/sites/Site.js
+++ b/ui/src/main/webapp/components/sites/Site.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import CardContent from '@material-ui/core/CardContent'
 import {

--- a/ui/src/main/webapp/components/sites/Sites.js
+++ b/ui/src/main/webapp/components/sites/Sites.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React, { Fragment } from 'react'
 import Site from './Site'
 import PropTypes from 'prop-types'

--- a/ui/src/main/webapp/components/sites/SitesContainer.js
+++ b/ui/src/main/webapp/components/sites/SitesContainer.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import React from 'react'
 import { allSites } from './gql/queries'
 import { Query } from 'react-apollo'

--- a/ui/src/main/webapp/components/sites/__tests__/site.spec.js
+++ b/ui/src/main/webapp/components/sites/__tests__/site.spec.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 /*global test, shallow, expect */
 import React from 'react'
 import Site from '../Site'

--- a/ui/src/main/webapp/components/sites/gql/mutations.js
+++ b/ui/src/main/webapp/components/sites/gql/mutations.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import gql from 'graphql-tag'
 
 export const deleteSite = gql`

--- a/ui/src/main/webapp/components/sites/gql/queries.js
+++ b/ui/src/main/webapp/components/sites/gql/queries.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 import gql from 'graphql-tag'
 
 export const allSites = gql`

--- a/ui/src/main/webapp/index.html
+++ b/ui/src/main/webapp/index.html
@@ -1,4 +1,19 @@
 <!DOCTYPE html>
+<!-- 
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */ 
+-->
 <html lang="en">
   <head>
     <style>

--- a/ui/src/main/webapp/index.js
+++ b/ui/src/main/webapp/index.js
@@ -1,3 +1,16 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 /*global document, require, process, module */
 import React from 'react'
 import ReactDOM from 'react-dom'


### PR DESCRIPTION
#### What does this PR do?
More tests coming.

- Fixes an issue with erroneous data transfer if 2 replications had overlapping filters. The fix was making sure a replication item always has a unique id (changed from metacard id)
- Fixes an issue with karaf configuration delete command not cleaning up replication items.
- Fixes an issue in the UI where clicking the save configuration button twice quickly would save 2 configurations with the same name
- Adds option to delete replicated data when deleting a configuration. Only data replicated from another node to the local node will be deleted.
- Add a scheduled deleter that checks for deleted configurations and cleans them up (runs every minute)
- Add checks for deleting orphaned replication items (replication items without corresponding configurations or metacards).

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @paouelle @kcover @mcalcote 

#### How should this be tested? (List steps with links to updated documentation)
- Replicate and verify deleting data along with the replication.
- Replicate and delete a config (preserver data). Delete a metacard and verify its corresponding replication item entry gets cleaned up.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #45 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/17572782/55033144-b3825b00-4fcf-11e9-9445-bce3c76ab7e5.png)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
