### PR TITLE
Fix missing metadata due to system time differences

### DIFF
--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorHistoryImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorHistoryImpl.java
@@ -204,6 +204,9 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
         helper.getAttributeValueOrDefault(metacard, ReplicationHistory.LAST_SUCCESS, null));
     status.setLastRun(
         helper.getAttributeValueOrDefault(metacard, ReplicationHistory.LAST_RUN, null));
+    status.setLastMetadataModified(
+        helper.getAttributeValueOrDefault(
+            metacard, ReplicationHistory.LAST_METADATA_MODIFIED, null));
 
     return status;
   }
@@ -224,6 +227,10 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
     helper.setIfPresent(mcard, ReplicationHistory.STATUS, replicationStatus.getStatus().name());
     helper.setIfPresent(mcard, ReplicationHistory.LAST_SUCCESS, replicationStatus.getLastSuccess());
     helper.setIfPresent(mcard, ReplicationHistory.LAST_RUN, replicationStatus.getLastRun());
+    helper.setIfPresent(
+        mcard,
+        ReplicationHistory.LAST_METADATA_MODIFIED,
+        replicationStatus.getLastMetadataModified());
     mcard.setId(replicationStatus.getId());
     mcard.setTags(Collections.singleton(ReplicationHistory.METACARD_TAG));
     return mcard;
@@ -239,6 +246,10 @@ public class ReplicatorHistoryImpl implements ReplicatorHistory {
     if (base.getLastRun() == null || status.getStartTime().after(base.getLastRun())) {
       base.setLastRun(status.getStartTime());
       base.setStatus(status.getStatus());
+    }
+
+    if (status.getLastMetadataModified() != null) {
+      base.setLastMetadataModified(status.getLastMetadataModified());
     }
 
     if (base.getStartTime().after(status.getStartTime())) {

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationStatusImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationStatusImpl.java
@@ -31,6 +31,8 @@ public class ReplicationStatusImpl implements ReplicationStatus {
 
   @Nullable private Date lastRun;
 
+  @Nullable private Date lastMetadataModified;
+
   private long duration = -1;
 
   private Status status = Status.PENDING;
@@ -95,6 +97,24 @@ public class ReplicationStatusImpl implements ReplicationStatus {
   @Override
   public void setLastSuccess(@Nullable Date lastSuccess) {
     this.lastSuccess = lastSuccess;
+  }
+
+  @Override
+  public void setLastMetadataModified(Date lastMetadataModified) {
+    this.lastMetadataModified = lastMetadataModified;
+  }
+
+  @Nullable
+  @Override
+  public Date getLastMetadataModified() {
+    if (lastMetadataModified != null) {
+      return lastMetadataModified;
+    }
+
+    // Preserve this behavior so that existing configurations will not attempt to re-sync all
+    // items. After the first run of an existing config with these changes, last metadata modified
+    // will always be used.
+    return lastSuccess;
   }
 
   @Override
@@ -194,7 +214,7 @@ public class ReplicationStatusImpl implements ReplicationStatus {
   @Override
   public String toString() {
     return String.format(
-        "ReplicationStatus{id='%s', replicatorName='%s', startTime=%s, duration=%d, status=%s, pushCount=%d, pullCount=%d, pushFailCount=%d, pullFailCount=%d, pushBytes=%d, pullBytes=%d}",
+        "ReplicationStatus{id='%s', replicatorName='%s', startTime=%s, duration=%d, status=%s, pushCount=%d, pullCount=%d, pushFailCount=%d, pullFailCount=%d, pushBytes=%d, pullBytes=%d, lastMetadataModified=%s}",
         id,
         replicatorName,
         startTime,
@@ -205,7 +225,8 @@ public class ReplicationStatusImpl implements ReplicationStatus {
         pushFailCount,
         pullFailCount,
         pushBytes,
-        pullBytes);
+        pullBytes,
+        lastMetadataModified);
   }
 
   @Override

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/mcard/ReplicationHistoryAttributes.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/mcard/ReplicationHistoryAttributes.java
@@ -60,6 +60,14 @@ public class ReplicationHistoryAttributes implements ReplicationHistory, Metacar
             BasicTypes.DATE_TYPE));
     descriptors.add(
         new AttributeDescriptorImpl(
+            ReplicationHistory.LAST_METADATA_MODIFIED,
+            true,
+            true,
+            false,
+            false,
+            BasicTypes.DATE_TYPE));
+    descriptors.add(
+        new AttributeDescriptorImpl(
             ReplicationHistory.DURATION,
             true /* indexed */,
             true /* stored */,

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/ReplicationStatusImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/ReplicationStatusImplTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api.impl.data;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Date;
+import java.util.Random;
+import org.codice.ditto.replication.api.ReplicationStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReplicationStatusImplTest {
+
+  private static final String REPLICATOR_NAME = "replicatorName";
+
+  private ReplicationStatus replicationStatus;
+
+  @Before
+  public void setup() {
+    replicationStatus = new ReplicationStatusImpl(REPLICATOR_NAME);
+  }
+
+  @Test
+  public void testNoLastMetadataModifiedReturnsLastSuccess() {
+    final Date lastSuccess = new Date();
+    replicationStatus.setLastSuccess(lastSuccess);
+    assertThat(replicationStatus.getLastMetadataModified(), is(lastSuccess));
+  }
+
+  @Test
+  public void testLastMetadataModifiedPresent() {
+    Random r = new Random();
+    final Date lastSuccess = new Date(r.nextInt());
+    final Date lastMetadataModified = new Date(r.nextInt());
+    replicationStatus.setLastSuccess(lastSuccess);
+    replicationStatus.setLastMetadataModified(lastMetadataModified);
+
+    assertThat(replicationStatus.getLastMetadataModified(), is(lastMetadataModified));
+  }
+}

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationStatus.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/ReplicationStatus.java
@@ -69,6 +69,22 @@ public interface ReplicationStatus {
   void setLastSuccess(@Nullable Date lastSuccess);
 
   /**
+   * See {@link #getLastMetadataModified()}.
+   *
+   * @param lastMetadataModified the metadata's modified date
+   */
+  void setLastMetadataModified(Date lastMetadataModified);
+
+  /**
+   * A {@link Date} which represents the modified date of the last metadata that was attempted to be
+   * replicated. If available, this should be used when determining what metadata to replicate.
+   *
+   * @return the {@link Date}
+   */
+  @Nullable
+  Date getLastMetadataModified();
+
+  /**
    * Gets the runtime duration of the referenced configuration in seconds
    *
    * @return

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/mcard/ReplicationHistory.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/mcard/ReplicationHistory.java
@@ -38,4 +38,6 @@ public interface ReplicationHistory {
   String LAST_RUN = "replication-history.last-run";
 
   String LAST_SUCCESS = "replication-history.last-success";
+
+  String LAST_METADATA_MODIFIED = "replication-history.last-metadata-modified";
 }


### PR DESCRIPTION
#### What does this PR do?
- Records the last modified time of the last metacard to be processed, and uses that as the modified after date as part of the next query when determining the metacard change set to replicate.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @kcover @paouelle 

#### How should this be tested? (List steps with links to updated documentation)
Setup a replication and do in order:

- Verify creates.
- Verify updates.
- Verify deletes.
- Verify create, update, and delete at once in the same run.

#### Any background context you want to provide?
This was an issue when system time between machines varied. This solution makes it so the query does not rely on a different system time.

For example, if machine A is replicating to B, and machine A time is 1:30, but machine B time is 1:31, machine B will record its last success run at 1:31 and use that as its next query's modified after time. So machine A will receive a query, "give me metadata modified after 1:31", but if any new data is uploaded to A between 1:30 and 1:31, B will not receive those updates.

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
