### PR TITLE
[0.2.x] REP-64 Addresses a timing issue in itests

### DIFF
--- a/distributions/replication-dominion/src/main/java/org/codice/ditto/replication/dominion/options/ReplicationOptions.java
+++ b/distributions/replication-dominion/src/main/java/org/codice/ditto/replication/dominion/options/ReplicationOptions.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
 import org.codice.ddf.dominion.options.DDFOptions;
 import org.codice.dominion.options.Option;
 import org.codice.dominion.options.karaf.KarafOptions;
@@ -43,7 +44,9 @@ public class ReplicationOptions {
           type = "xml",
           classifier = "features"
         ),
-    boot = false
+    boot = false,
+    timeout = 10L,
+    units = TimeUnit.MINUTES
   )
   @Option.Annotation
   @Target(ElementType.TYPE)

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
 
         <admin-query.version>1.2.7</admin-query.version>
         <ddf.support.version>2.3.12</ddf.support.version>
-        <ddf.version>2.13.8</ddf.version>
+        <ddf.version>2.13.9-SNAPSHOT</ddf.version>
         <codice-maven.version>0.2</codice-maven.version>
-        <codice-test.version>0.7</codice-test.version>
+        <codice-test.version>0.9</codice-test.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
         <admin-query.version>1.2.7</admin-query.version>
         <ddf.support.version>2.3.12</ddf.support.version>
-        <ddf.version>2.13.9-SNAPSHOT</ddf.version>
+        <ddf.version>2.13.9</ddf.version>
         <codice-maven.version>0.2</codice-maven.version>
         <codice-test.version>0.9</codice-test.version>
 


### PR DESCRIPTION
#### What does this PR do?
It fixes the timing issue during integration testing by updating the codice-test and ddf dependencies to take advantage of their fix for the issue.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @kcover @clockard @mcalcote 

#### How should this be tested? (List steps with links to updated documentation)
build passing

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #64 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
