### PR TITLE
REP-77 Add root context to sites

### DIFF
--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>replication-api-impl</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang3.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
@@ -37,6 +37,8 @@ public class ReplicationSiteField extends BaseObjectField {
 
   private AddressField address;
 
+  private StringField rootContext;
+
   public ReplicationSiteField() {
     this(DEFAULT_FIELD_NAME);
   }
@@ -46,6 +48,7 @@ public class ReplicationSiteField extends BaseObjectField {
     this.id = new PidField("id");
     this.name = new StringField("name");
     this.address = new AddressField();
+    this.rootContext = new StringField("rootContext");
   }
 
   public ReplicationSiteField id(String id) {
@@ -60,6 +63,11 @@ public class ReplicationSiteField extends BaseObjectField {
 
   public ReplicationSiteField address(AddressField address) {
     this.address = address;
+    return this;
+  }
+
+  public ReplicationSiteField rootContext(String context) {
+    this.rootContext.setValue(context);
     return this;
   }
 
@@ -83,9 +91,13 @@ public class ReplicationSiteField extends BaseObjectField {
     return address;
   }
 
+  public StringField rootContext() {
+    return rootContext;
+  }
+
   @Override
   public List<Field> getFields() {
-    return ImmutableList.of(id, name, address);
+    return ImmutableList.of(id, name, address, rootContext);
   }
 
   public static class ListImpl extends BaseListField<ReplicationSiteField> {

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/CreateReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/CreateReplicationSite.java
@@ -30,13 +30,16 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
 
   public static final String FIELD_NAME = "createReplicationSite";
 
-  public static final String DESCRIPTION = "Creates a replication site.";
+  public static final String DESCRIPTION =
+      "Creates a replication site. If no rootContext is provided, it will default to 'services'";
 
   public static final ReplicationSiteField RETURN_TYPE = new ReplicationSiteField();
 
   private StringField name;
 
   private AddressField address;
+
+  private StringField rootContext;
 
   private ReplicationUtils replicationUtils;
 
@@ -46,11 +49,15 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
     this.replicationUtils = replicationUtils;
     name = new StringField("name");
     address = new AddressField();
+    rootContext = new StringField("rootContext");
+    name.isRequired(true);
+    address.isRequired(true);
+    rootContext.isRequired(true);
   }
 
   @Override
   public ReplicationSiteField performFunction() {
-    return replicationUtils.createSite(name.getValue(), address);
+    return replicationUtils.createSite(name.getValue(), address, rootContext.getValue());
   }
 
   @Override
@@ -60,7 +67,7 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(name, address);
+    return ImmutableList.of(name, address, rootContext);
   }
 
   @Override

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSite.java
@@ -40,6 +40,8 @@ public class UpdateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
 
   private AddressField address;
 
+  private StringField rootContext;
+
   private ReplicationUtils replicationUtils;
 
   public UpdateReplicationSite(ReplicationUtils replicationUtils) {
@@ -49,11 +51,13 @@ public class UpdateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
     id = new PidField("id");
     name = new StringField("name");
     address = new AddressField();
+    rootContext = new StringField("rootContext");
   }
 
   @Override
   public ReplicationSiteField performFunction() {
-    return replicationUtils.updateSite(id.getValue(), name.getValue(), address);
+    return replicationUtils.updateSite(
+        id.getValue(), name.getValue(), address, rootContext.getValue());
   }
 
   @Override
@@ -63,7 +67,7 @@ public class UpdateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(id, name, address);
+    return ImmutableList.of(id, name, address, rootContext);
   }
 
   @Override

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/CreateReplicationSiteTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/CreateReplicationSiteTest.java
@@ -44,11 +44,20 @@ public class CreateReplicationSiteTest {
   @Before
   public void setUp() throws Exception {
     site = new CreateReplicationSite(utils);
-    when(utils.createSite(any(String.class), any(AddressField.class)))
+    when(utils.createSite(any(String.class), any(AddressField.class), any(String.class)))
         .thenReturn(new ReplicationSiteField());
     input = new HashMap<>();
     input.put("id", "myid");
     input.put("name", "myname");
+    input.put("rootContext", "services");
+
+    Map<String, Object> addressField = new HashMap<>();
+    Map<String, Object> hostMap = new HashMap<>();
+    hostMap.put("hostname", "localhost");
+    hostMap.put("port", 1234);
+    addressField.put("host", hostMap);
+
+    input.put("address", addressField);
   }
 
   @Test

--- a/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/ITReplicationQuery.java
+++ b/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/ITReplicationQuery.java
@@ -45,7 +45,7 @@ public class ITReplicationQuery {
   @Interpolate
   private static String GRAPHQL_ENDPOINT = "https://localhost:{port.https}/admin/hub/graphql";
 
-  private static final String URL = "https://localhost:9999";
+  private static final String URL = "https://localhost:9999/services";
 
   // ----------------------------------- Site Tests -----------------------------------//
 
@@ -72,7 +72,7 @@ public class ITReplicationQuery {
     asAdmin()
         .body(
             String.format(
-                "{\"query\":\"mutation{ createReplicationSite(name: \\\"%s\\\", address: { host: { hostname: \\\"localhost\\\" port: 9999 }}){ id name address{ host{ hostname port } url }}}\"}",
+                "{\"query\":\"mutation{ createReplicationSite(name: \\\"%s\\\", address: { host: { hostname: \\\"localhost\\\" port: 9999 }}, rootContext: \\\"services\\\"){ id name address{ host{ hostname port } url }}}\"}",
                 name))
         .when()
         .post(GRAPHQL_ENDPOINT)
@@ -115,7 +115,7 @@ public class ITReplicationQuery {
     asAdmin()
         .body(
             String.format(
-                "{\"query\":\"mutation{ createReplicationSite(name: 25, address: { url: \\\"%s\\\"}){ id name address{ host{ hostname port } url }}}\"}",
+                "{\"query\":\"mutation{ createReplicationSite(name: 25, address: { url: \\\"%s\\\"}, rootContext: \\\"services\\\"){ id name address{ host{ hostname port } url }}}\"}",
                 URL))
         .when()
         .post(GRAPHQL_ENDPOINT)
@@ -196,7 +196,7 @@ public class ITReplicationQuery {
 
   private static String makeCreateSiteQuery(String name, String url) {
     return String.format(
-        "{\"query\":\"mutation{ createReplicationSite(name: \\\"%s\\\", address: { url: \\\"%s\\\"}){ id name address{ host{ hostname port } url }}}\"}",
+        "{\"query\":\"mutation{ createReplicationSite(name: \\\"%s\\\", address: { url: \\\"%s\\\"}, rootContext: \\\"services\\\"){ id name address{ host{ hostname port } url }}}\"}",
         name, url);
   }
 
@@ -206,7 +206,7 @@ public class ITReplicationQuery {
 
   private static String makeUpdateSiteQuery(String id, String name, String url) {
     return String.format(
-        "{\"query\":\"mutation{ updateReplicationSite(id: \\\"%s\\\", name: \\\"%s\\\", address: { url: \\\"%s\\\"}){ id name address{ host{ hostname port } url }}}\"}",
+        "{\"query\":\"mutation{ updateReplicationSite(id: \\\"%s\\\", name: \\\"%s\\\", address: { url: \\\"%s\\\"}, rootContext: \\\"services\\\"){ id name address{ host{ hostname port } url }}}\"}",
         id, name, url);
   }
 

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/HybridStore.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/HybridStore.java
@@ -105,7 +105,7 @@ public class HybridStore extends AbstractCswStore implements ReplicationStore {
     super(context, cswSourceConfiguration, provider, clientFactoryFactory, encryptionService);
     this.restClientFactory =
         clientFactoryFactory.getSecureCxfClientFactory(
-            url.toString() + "/services/catalog", RESTService.class);
+            url.toString() + "/catalog", RESTService.class);
   }
 
   @Override
@@ -159,8 +159,7 @@ public class HybridStore extends AbstractCswStore implements ReplicationStore {
       throw new ResourceNotFoundException(
           "Error retrieving resource. Code " + response.getStatus());
     }
-    // TODO: There is a ECP bug that will cause this not to work unless the /services/catalog
-    // endpoint doesn't use the IDP
+
     String filename = null;
     if (response.getHeaderString(CONTENT_DISPOSITION) != null) {
       filename =

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorStoreFactoryImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorStoreFactoryImpl.java
@@ -23,6 +23,7 @@ import ddf.catalog.resource.ResourceReader;
 import ddf.security.encryption.EncryptionService;
 import ddf.security.service.SecurityManager;
 import java.net.URL;
+import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.cxf.client.ClientFactoryFactory;
 import org.codice.ddf.spatial.ogc.csw.catalog.common.CswAxisOrder;
@@ -88,8 +89,13 @@ public class ReplicatorStoreFactoryImpl implements ReplicatorStoreFactory {
       return new LocalCatalogResourceStore(framework);
     }
 
+    String baseUrl = url.toString();
+    if (StringUtils.isEmpty(url.getPath())) {
+      baseUrl = baseUrl + "/services";
+    }
+
     CswSourceConfiguration cswConfiguration = new CswSourceConfiguration(encryptionService);
-    cswConfiguration.setCswUrl(url.toString() + "/services/csw");
+    cswConfiguration.setCswUrl(baseUrl + "/csw");
     cswConfiguration.setConnectionTimeout(CONNECTION_TIMEOUT);
     cswConfiguration.setCswAxisOrder(COORDINATE_ORDER);
     cswConfiguration.setDisableCnCheck(DISABLE_CN_CHECK);

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/SiteManagerImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/SiteManagerImpl.java
@@ -37,7 +37,7 @@ public class SiteManagerImpl implements SiteManager {
       ReplicationSite site = new ReplicationSiteImpl();
       site.setId(LOCAL_SITE_ID);
       site.setName(SystemInfo.getSiteName());
-      site.setUrl(SystemBaseUrl.EXTERNAL.getBaseUrl());
+      site.setUrl(SystemBaseUrl.EXTERNAL.constructUrl(null, true));
       save(site);
     }
   }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/SiteManagerImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/SiteManagerImplTest.java
@@ -48,6 +48,7 @@ public class SiteManagerImplTest {
   @Before
   public void setUp() {
     System.setProperty("org.codice.ddf.system.siteName", "testSite");
+    System.setProperty("org.codice.ddf.system.rootContext", "services");
     siteManager = new SiteManagerImpl(persistentStore);
   }
 
@@ -59,7 +60,7 @@ public class SiteManagerImplTest {
     verify(persistentStore).save(captor.capture());
     ReplicationSite site = captor.getValue();
     assertThat(site.getName(), is(SystemInfo.getSiteName()));
-    assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.getBaseUrl()));
+    assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
   }
 
   @Test
@@ -74,7 +75,7 @@ public class SiteManagerImplTest {
     verify(persistentStore).save(captor.capture());
     ReplicationSiteImpl site = captor.getValue();
     assertThat(site.getName(), is(SystemInfo.getSiteName()));
-    assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.getBaseUrl()));
+    assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
   }
 
   @Test
@@ -89,7 +90,7 @@ public class SiteManagerImplTest {
     verify(persistentStore).save(captor.capture());
     ReplicationSiteImpl site = captor.getValue();
     assertThat(site.getName(), is(SystemInfo.getSiteName()));
-    assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.getBaseUrl()));
+    assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
   }
 
   @Test

--- a/ui/src/main/webapp/components/sites/AddSite.js
+++ b/ui/src/main/webapp/components/sites/AddSite.js
@@ -51,6 +51,7 @@ const defaultState = {
   name: '',
   hostname: '',
   port: 0,
+  rootContext: 'services',
   nameErrorText: '',
   hostnameErrorText: '',
   portErrorText: '',
@@ -94,6 +95,7 @@ const AddSite = class extends React.Component {
       name,
       hostname,
       port,
+      rootContext,
       nameErrorText,
       hostnameErrorText,
       portErrorText,
@@ -149,6 +151,16 @@ const AddSite = class extends React.Component {
               helperText={portErrorText ? portErrorText : ''}
               error={portErrorText ? true : false}
             />
+            <TextField
+              margin='dense'
+              id='rootContext'
+              label='Root Context *'
+              type='text'
+              onChange={this.handleChange('rootContext')}
+              fullWidth
+              helperText='The path under which the replication services can be found. Typically this is under `services`'
+              value={rootContext}
+            />
           </DialogContent>
           <DialogActions>
             <Button onClick={this.handleClose} color='primary'>
@@ -178,7 +190,7 @@ const AddSite = class extends React.Component {
               {(createReplicationSite, { loading }) => (
                 <div>
                   <Button
-                    disabled={!(name && hostname && port)}
+                    disabled={!(name && hostname && port && rootContext)}
                     color='primary'
                     onClick={() => {
                       createReplicationSite({
@@ -190,6 +202,7 @@ const AddSite = class extends React.Component {
                               port: port,
                             },
                           },
+                          rootContext: rootContext,
                         },
                         update: (
                           store,

--- a/ui/src/main/webapp/components/sites/gql/mutations.js
+++ b/ui/src/main/webapp/components/sites/gql/mutations.js
@@ -19,13 +19,22 @@ export const deleteSite = gql`
   }
 `
 export const addSite = gql`
-  mutation createReplicationSite($name: String!, $address: Address!) {
-    createReplicationSite(name: $name, address: $address) {
+  mutation createReplicationSite(
+    $name: String!
+    $address: Address!
+    $rootContext: String!
+  ) {
+    createReplicationSite(
+      name: $name
+      address: $address
+      rootContext: $rootContext
+    ) {
       id
       name
       address {
         url
       }
+      rootContext
     }
   }
 `


### PR DESCRIPTION
#### What does this PR do?
 Add root context to sites so replication works with systems with non default root contexts
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @kcover @paouelle 
#### How should this be tested? (List steps with links to updated documentation)
Install and create a new site.
- verify that there is a root context field that is defaulted to 'services'
- verify that after creating the site the url shows the context
- verify that replication still works

#### What are the relevant tickets?
Fixes #77 

#### Screenshots (if appropriate)
![Screen Shot 2019-04-23 at 2 55 10 PM](https://user-images.githubusercontent.com/5248090/56618565-d6f0f380-65d7-11e9-84d6-e825f89880ba.png)

