### PR TITLE
REP-75 Add modified time to configs

### DIFF
--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
@@ -126,6 +126,7 @@ public class ReplicationUtils {
     config.setFilter(filter);
     config.setBidirectional(biDirectional);
     config.setFailureRetryCount(5);
+    config.setModified();
     configManager.save(config);
 
     return getReplicationFieldForConfig(config);
@@ -145,6 +146,7 @@ public class ReplicationUtils {
     setIfPresent(config::setDestination, destinationId);
     setIfPresent(config::setFilter, filter);
     setIfPresent(config::setBidirectional, biDirectional);
+    config.setModified();
 
     configManager.save(config);
     return getReplicationFieldForConfig(config);
@@ -254,6 +256,7 @@ public class ReplicationUtils {
     }
 
     config.setSuspended(suspended);
+    config.setModified();
     configManager.save(config);
     if (suspended) {
       replicator.cancelSyncRequest(id);

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicatorConfigImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicatorConfigImpl.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ditto.replication.api.impl.data;
 
+import java.util.Date;
 import java.util.Map;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 
@@ -41,9 +42,19 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
 
   private static final String SUSPENDED_KEY = "suspended";
 
+  private static final String MODIFIED_KEY = "modified";
+
   /**
-   * 0/No Version - initial version of configs which were saved in the catalog framework. 1 - the
-   * first version of configs to be saved in the replication persistent store.
+   * Field specifying the version of the configuration. Possible versions include:
+   *
+   * <ol>
+   *   <li>0 (No version) - initial version of configs which were saved in the catalog framework
+   *   <li>1 - The first version of configs to be saved in the replication persistent store
+   *       <ul>
+   *         <li>Add <b>suspended</b> field of type boolean with default of false
+   *       </ul>
+   *   <li>2 - Add <b>modified</b> field of type Date
+   * </ol>
    */
   public static final int CURRENT_VERSION = 1;
 
@@ -63,6 +74,8 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
 
   private boolean suspended;
 
+  private Date modified;
+
   public ReplicatorConfigImpl() {
     super.setVersion(CURRENT_VERSION);
   }
@@ -78,6 +91,7 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
     result.put(RETRY_COUNT_KEY, getFailureRetryCount());
     result.put(DESCRIPTION_KEY, getDescription());
     result.put(SUSPENDED_KEY, Boolean.toString(isSuspended()));
+    result.put(MODIFIED_KEY, getModified());
     return result;
   }
 
@@ -92,6 +106,7 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
     setFailureRetryCount((int) properties.get(RETRY_COUNT_KEY));
     setDescription((String) properties.get(DESCRIPTION_KEY));
     setSuspended(Boolean.valueOf((String) properties.get(SUSPENDED_KEY)));
+    setModified((Date) properties.get(MODIFIED_KEY));
   }
 
   @Override
@@ -172,5 +187,20 @@ public class ReplicatorConfigImpl extends AbstractPersistable implements Replica
   @Override
   public void setSuspended(boolean suspended) {
     this.suspended = suspended;
+  }
+
+  @Override
+  public Date getModified() {
+    return modified;
+  }
+
+  @Override
+  public void setModified(Date modified) {
+    this.modified = modified;
+  }
+
+  @Override
+  public void setModified() {
+    modified = new Date();
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/ReplicatorConfigImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/ReplicatorConfigImplTest.java
@@ -16,6 +16,7 @@ package org.codice.ditto.replication.api.impl.data;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Before;
@@ -39,6 +40,8 @@ public class ReplicatorConfigImplTest {
 
   private static final String VERSION_KEY = "version";
 
+  private static final String MODIFIED_KEY = "modified";
+
   private ReplicatorConfigImpl config;
 
   @Before
@@ -55,6 +58,8 @@ public class ReplicatorConfigImplTest {
     config.setFilter("filter");
     config.setBidirectional(true);
     config.setFailureRetryCount(5);
+    Date modified = new Date();
+    config.setModified(modified);
 
     Map<String, Object> props = config.toMap();
 
@@ -66,6 +71,7 @@ public class ReplicatorConfigImplTest {
     assertThat(props.get(BIDIRECTIONAL_KEY), is("true"));
     assertThat(props.get(RETRY_COUNT_KEY), is(5));
     assertThat(props.get(VERSION_KEY), is(1));
+    assertThat(props.get(MODIFIED_KEY), is(modified));
   }
 
   @Test
@@ -79,6 +85,8 @@ public class ReplicatorConfigImplTest {
     props.put(BIDIRECTIONAL_KEY, "true");
     props.put(RETRY_COUNT_KEY, 5);
     props.put(VERSION_KEY, 1);
+    Date modified = new Date();
+    props.put(MODIFIED_KEY, modified);
 
     config.fromMap(props);
 
@@ -90,5 +98,6 @@ public class ReplicatorConfigImplTest {
     assertThat(config.isBidirectional(), is(true));
     assertThat(config.getFailureRetryCount(), is(5));
     assertThat(config.getVersion(), is(1));
+    assertThat(config.getModified(), is(modified));
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +75,8 @@ public class ReplicationPersistentStoreTest {
 
   private static final String VERSION = "version";
 
+  private static final String MODIFIED = "modified";
+
   private PersistentStore mockPersistentStore;
 
   private ReplicationPersistentStore persistentStore;
@@ -118,6 +121,7 @@ public class ReplicationPersistentStoreTest {
     map.put(SUSPENDED, "false");
     map.put(DESCRIPTION, DESCRIPTION + num);
     map.put(VERSION, ReplicatorConfigImpl.CURRENT_VERSION);
+    map.put(MODIFIED, new Date(num));
     return map;
   }
 

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicatorConfig.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicatorConfig.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ditto.replication.api.data;
 
+import java.util.Date;
 import javax.annotation.Nullable;
 import org.codice.ditto.replication.api.ReplicationItem;
 
@@ -136,4 +137,21 @@ public interface ReplicatorConfig extends Persistable {
    * @param suspended the suspended state to give this config
    */
   void setSuspended(boolean suspended);
+
+  /**
+   * Gets the date on which this config was last modified.
+   *
+   * @return Date the date on which this config was last modified.
+   */
+  Date getModified();
+
+  /**
+   * Sets this config's modified date to the given date.
+   *
+   * @param modified the date to set as the modified date.
+   */
+  void setModified(Date modified);
+
+  /** Sets this config's modified date to the current time. */
+  void setModified();
 }


### PR DESCRIPTION
#### What does this PR do?
Adds a modified field to the ReplicationConfig class which tells the last time the config was modified.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)? @peterhuffer @paouelle @clockard 

#### How should this be tested? (List steps with links to updated documentation)
Install replication on a DDF where you can access solr.
Create a config and verify it has a modified date in solr.
Suspend the config and verify the modified date has changed.

#### What are the relevant tickets?
Fixes #75 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
