### PR TITLE
REP-75 Add modified time to configs and sites

### DIFF
--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
@@ -168,6 +168,8 @@ public class ReplicationUtils {
     field.destination(getSiteFieldForSite(siteManager.get(config.getDestination())));
     field.filter(config.getFilter());
     field.biDirectional(config.isBidirectional());
+    field.modified(config.getModified());
+    field.version(config.getVersion());
     List<ReplicationStatus> statusList = history.getReplicationEvents(config.getName());
     if (!statusList.isEmpty()) {
       ReplicationStatus lastStatus = statusList.get(0);
@@ -208,6 +210,8 @@ public class ReplicationUtils {
     ReplicationSiteField field = new ReplicationSiteField();
     field.id(site.getId());
     field.name(site.getName());
+    field.modified(site.getModified());
+    field.version(site.getVersion());
     AddressField address = new AddressField();
     URL url;
 

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/fields/ReplicationField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/fields/ReplicationField.java
@@ -58,6 +58,10 @@ public class ReplicationField extends BaseObjectField {
 
   private DateField lastSuccess;
 
+  private DateField modified;
+
+  private IntegerField version;
+
   public ReplicationField() {
     super("replication", "ReplicationConfig", DESCRIPTION);
     id = new PidField("id");
@@ -73,6 +77,8 @@ public class ReplicationField extends BaseObjectField {
     lastRun = new DateField("lastRun");
     firstRun = new DateField("firstRun");
     lastSuccess = new DateField("lastSuccess");
+    modified = new DateField("modified");
+    version = new IntegerField("version");
   }
 
   // setters
@@ -156,6 +162,21 @@ public class ReplicationField extends BaseObjectField {
     return this;
   }
 
+  public ReplicationField modified(String modified) {
+    this.modified.setValue(modified);
+    return this;
+  }
+
+  public ReplicationField modified(Date modified) {
+    this.modified.setValue(getInstantOrNull(modified));
+    return this;
+  }
+
+  public ReplicationField version(int version) {
+    this.version.setValue(version);
+    return this;
+  }
+
   private Instant getInstantOrNull(Date date) {
     if (date != null) {
       return date.toInstant();
@@ -236,6 +257,14 @@ public class ReplicationField extends BaseObjectField {
     return firstRun;
   }
 
+  public DateField modified() {
+    return modified;
+  }
+
+  public IntegerField version() {
+    return version;
+  }
+
   @Override
   public List<Field> getFields() {
     return ImmutableList.of(
@@ -251,7 +280,9 @@ public class ReplicationField extends BaseObjectField {
         suspended,
         lastRun,
         lastSuccess,
-        firstRun);
+        firstRun,
+        modified,
+        version);
   }
 
   public static class ListImpl extends BaseListField<ReplicationField> {

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
@@ -14,14 +14,18 @@
 package org.codice.ditto.replication.admin.query.sites.fields;
 
 import com.google.common.collect.ImmutableList;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.common.fields.base.BaseListField;
 import org.codice.ddf.admin.common.fields.base.BaseObjectField;
+import org.codice.ddf.admin.common.fields.base.scalar.IntegerField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ditto.replication.admin.query.replications.fields.DateField;
 
 public class ReplicationSiteField extends BaseObjectField {
 
@@ -39,6 +43,10 @@ public class ReplicationSiteField extends BaseObjectField {
 
   private StringField rootContext;
 
+  private DateField modified;
+
+  private IntegerField version;
+
   public ReplicationSiteField() {
     this(DEFAULT_FIELD_NAME);
   }
@@ -49,6 +57,8 @@ public class ReplicationSiteField extends BaseObjectField {
     this.name = new StringField("name");
     this.address = new AddressField();
     this.rootContext = new StringField("rootContext");
+    this.modified = new DateField("modified");
+    this.version = new IntegerField("version");
   }
 
   public ReplicationSiteField id(String id) {
@@ -69,6 +79,23 @@ public class ReplicationSiteField extends BaseObjectField {
   public ReplicationSiteField rootContext(String context) {
     this.rootContext.setValue(context);
     return this;
+  }
+
+  public ReplicationSiteField modified(Date modified) {
+    this.modified.setValue(getInstantOrNull(modified));
+    return this;
+  }
+
+  public ReplicationSiteField version(int version) {
+    this.version.setValue(version);
+    return this;
+  }
+
+  private static Instant getInstantOrNull(Date date) {
+    if (date != null) {
+      return date.toInstant();
+    }
+    return null;
   }
 
   public String id() {
@@ -95,9 +122,17 @@ public class ReplicationSiteField extends BaseObjectField {
     return rootContext;
   }
 
+  public DateField modified() {
+    return modified;
+  }
+
+  public IntegerField version() {
+    return version;
+  }
+
   @Override
   public List<Field> getFields() {
-    return ImmutableList.of(id, name, address, rootContext);
+    return ImmutableList.of(id, name, address, rootContext, modified, version);
   }
 
   public static class ListImpl extends BaseListField<ReplicationSiteField> {

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/AbstractPersistable.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/AbstractPersistable.java
@@ -13,9 +13,11 @@
  */
 package org.codice.ditto.replication.api.impl.data;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.codice.ditto.replication.api.data.Persistable;
 
 /**
@@ -28,9 +30,13 @@ public abstract class AbstractPersistable implements Persistable {
 
   private static final String VERSION_KEY = "version";
 
+  private static final String MODIFIED_KEY = "modified";
+
   private String id;
 
   private int version;
+
+  private Date modified;
 
   protected AbstractPersistable() {
     this.id = UUID.randomUUID().toString();
@@ -55,9 +61,20 @@ public abstract class AbstractPersistable implements Persistable {
     this.version = version;
   }
 
+  @Override
+  public Date getModified() {
+    return modified;
+  }
+
+  private void setModified(@Nullable Date modified) {
+    this.modified = modified != null ? modified : new Date(0);
+  }
+
   /**
-   * Writes the variables of the persistable to a map. Any implementation of this method in a
-   * subclass should first make a call to the super version before performing its own functionality.
+   * Writes the variables of the persistable to a map. Since this method is intended to be called
+   * just before the persistable is saved, it will set the modified date to the current time. Any
+   * implementation of this method in a subclass should first make a call to the super version
+   * before performing its own functionality.
    *
    * @return a map containing the variable of the persistable
    */
@@ -65,6 +82,7 @@ public abstract class AbstractPersistable implements Persistable {
     Map<String, Object> result = new HashMap<>();
     result.put(ID_KEY, getId());
     result.put(VERSION_KEY, getVersion());
+    result.put(MODIFIED_KEY, new Date());
     return result;
   }
 
@@ -78,5 +96,6 @@ public abstract class AbstractPersistable implements Persistable {
   public void fromMap(Map<String, Object> properties) {
     setId((String) properties.get(ID_KEY));
     setVersion((int) properties.get(VERSION_KEY));
+    setModified((Date) properties.get(MODIFIED_KEY));
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStore.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStore.java
@@ -82,9 +82,7 @@ public class ReplicationPersistentStore {
             String.format("Found two objects in persistence of type %s with ID %s", typeName, id));
       }
 
-      T persistable = createPersistable(klass);
-      persistable.fromMap(PersistentItem.stripSuffixes(storedMaps.get(0)));
-      return persistable;
+      return getPersistableFromMap(klass, storedMaps.get(0));
     }
   }
 

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/AbstractPersistableTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/AbstractPersistableTest.java
@@ -14,9 +14,11 @@
 package org.codice.ditto.replication.api.impl.data;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -27,6 +29,8 @@ public class AbstractPersistableTest {
   private static final String ID = "id";
 
   private static final String VERSION = "version";
+
+  private static final String MODIFIED = "modified";
 
   @Test
   public void testAbstractPersistable() {
@@ -66,10 +70,27 @@ public class AbstractPersistableTest {
 
     assertThat(map.get(ID), is("test"));
     assertThat(map.get(VERSION), is(1));
+    assertThat(map.get(MODIFIED), notNullValue());
   }
 
   @Test
   public void fromMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put(ID, "test");
+    map.put(VERSION, 1);
+    Date modified = new Date();
+    map.put(MODIFIED, modified);
+
+    AbstractPersistable persistable = new TestPersistable();
+    persistable.fromMap(map);
+
+    assertThat(persistable.getId(), is("test"));
+    assertThat(persistable.getVersion(), is(1));
+    assertThat(persistable.getModified(), is(modified));
+  }
+
+  @Test
+  public void fromMapNoModifiedDate() {
     Map<String, Object> map = new HashMap<>();
     map.put(ID, "test");
     map.put(VERSION, 1);
@@ -79,6 +100,7 @@ public class AbstractPersistableTest {
 
     assertThat(persistable.getId(), is("test"));
     assertThat(persistable.getVersion(), is(1));
+    assertThat(persistable.getModified(), is(new Date(0)));
   }
 
   private class TestPersistable extends AbstractPersistable {}

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/Persistable.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/Persistable.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ditto.replication.api.data;
 
+import java.util.Date;
+
 /** A Persistable is an object that can be saved in persistence. */
 public interface Persistable {
 
@@ -36,4 +38,11 @@ public interface Persistable {
    * @return integer version of the persistable
    */
   int getVersion();
+
+  /**
+   * Returns a {@link Date} at which the persistable was last modified
+   *
+   * @return when the persistable was last modified
+   */
+  Date getModified();
 }


### PR DESCRIPTION
#### What does this PR do?
Adds a modified time field to configs and sites and allows it to be read
through the graphql endpoint. Also makes the version of configs and sites readable from the graphql endpoint.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @clockard @paouelle 

#### How should this be tested? (List steps with links to updated documentation)
Install replication.
create sites and configurations.
query the graphql endoint for sites and configurations.
verify they contain accurate modified dates and versions.

#### What are the relevant tickets?
Fixes #75 

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
