### PR TITLE
Node delete confirmation. Relative time display.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -77,7 +77,7 @@
         "statements": 7,
         "branches": 6,
         "lines": 7,
-        "functions": 2
+        "functions": 1
       }
     },
     "collectCoverage": true,

--- a/ui/src/main/webapp/components/common/Confirmable.js
+++ b/ui/src/main/webapp/components/common/Confirmable.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+import React from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  DialogContentText,
+} from '@material-ui/core'
+
+function Confirmable(props) {
+  const {
+    onConfirm,
+    children,
+    message,
+    subMessage,
+    Button: Trigger,
+    onClose: close,
+  } = props
+  const [open, setOpen] = React.useState(false)
+
+  function handleClose() {
+    if (close !== undefined) {
+      close()
+    }
+  }
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        onClose={() => {
+          handleClose()
+          setOpen(false)
+        }}
+        fullWidth
+      >
+        <DialogTitle>{message}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{subMessage}</DialogContentText>
+          {children}
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => {
+              handleClose()
+              setOpen(false)
+            }}
+            color='primary'
+          >
+            Cancel
+          </Button>
+          <Button
+            autoFocus
+            onClick={() => {
+              onConfirm()
+              setOpen(false)
+            }}
+            color='primary'
+          >
+            Confirm
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Trigger onClick={() => setOpen(true)} />
+    </>
+  )
+}
+
+export default Confirmable

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -29,12 +29,7 @@ const styles = {
 }
 
 const format = utc => {
-  return utc
-    ? moment
-        .utc(utc)
-        .format('MMM DD YYYY HH:mm zZ')
-        .toString()
-    : '-'
+  return utc ? moment.utc(utc).fromNow() : '-'
 }
 
 class ReplicationsTable extends React.Component {

--- a/ui/src/main/webapp/components/sites/Site.js
+++ b/ui/src/main/webapp/components/sites/Site.js
@@ -15,6 +15,7 @@ import { allSites } from './gql/queries'
 import PropTypes from 'prop-types'
 import { withSnackbar } from 'notistack'
 import { deleteSite } from './gql/mutations'
+import Confirmable from '../common/Confirmable'
 
 const styles = {
   centered: {
@@ -70,9 +71,8 @@ class Site extends React.Component {
           >
             {(deleteReplicationSite, { loading }) => (
               <div>
-                <IconButton
-                  color='primary'
-                  onClick={() => {
+                <Confirmable
+                  onConfirm={() => {
                     deleteReplicationSite({
                       variables: {
                         id: id,
@@ -97,9 +97,16 @@ class Site extends React.Component {
                       },
                     })
                   }}
-                >
-                  <DeleteForever />
-                </IconButton>
+                  message={`Are you sure you want to delete the node ${name}?`}
+                  Button={props => {
+                    const { onClick } = props
+                    return (
+                      <IconButton color='primary' onClick={onClick}>
+                        <DeleteForever />
+                      </IconButton>
+                    )
+                  }}
+                />
                 {loading && <CircularProgress size={10} />}
               </div>
             )}


### PR DESCRIPTION
#### What does this PR do?
- Cherry picks Node deletion confirmation
- Cherry picks relative time display in configuration table.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @kcover @paouelle 

#### How should this be tested? (List steps with links to updated documentation)
- Delete a Node and confirm the confirmation
- Confirm time display in replication table.

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
