### PR TITLE
Support disabling local replication by site

### DIFF
--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -100,12 +100,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.77</minimum>
+                                            <minimum>0.79</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.66</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -95,12 +95,12 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.81</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.78</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -95,17 +95,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.81</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.74</minimum>
+                                            <minimum>0.78</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.61</minimum>
+                                            <minimum>0.66</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
@@ -131,7 +131,7 @@ public class ReplicationUtils {
 
     final String oldHostname = url.getHost();
     final int oldPort = url.getPort();
-    final String oldContext = stipStartingSlashes(url.getPath());
+    final String oldContext = stripStartingSlashes(url.getPath());
 
     final String newHostname;
     final int newPort;
@@ -150,7 +150,7 @@ public class ReplicationUtils {
     }
 
     if (context != null) {
-      newContext = stipStartingSlashes(context);
+      newContext = stripStartingSlashes(context);
     } else {
       newContext = oldContext;
     }
@@ -165,13 +165,13 @@ public class ReplicationUtils {
     }
   }
 
-  private String stipStartingSlashes(String str) {
+  private String stripStartingSlashes(String str) {
     return str.trim().replaceFirst("^[/\\s]*", "");
   }
 
   private String addressFieldToUrlString(AddressField address, @Nullable String rootContext) {
     final String context =
-        (rootContext != null) ? stipStartingSlashes(rootContext) : DEFAULT_CONTEXT;
+        (rootContext != null) ? stripStartingSlashes(rootContext) : DEFAULT_CONTEXT;
 
     return address.host().hostname() == null
         ? address.url()

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/discover/GetReplicationSites.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/discover/GetReplicationSites.java
@@ -32,7 +32,7 @@ public class GetReplicationSites extends BaseFunctionField<ListField<Replication
   public static final String FIELD_NAME = "sites";
 
   public static final String DESCRIPTION =
-      "Retrieves all the sites currently configured for replication, or a single site identified by a pid.";
+      "Retrieves all the sites currently configured for replication, or a site given its identifier.";
 
   private static final ListField<ReplicationSiteField> RETURN_TYPE =
       new ReplicationSiteField.ListImpl();

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/IsDisabledLocalField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/IsDisabledLocalField.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.sites.fields;
+
+import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+
+public class IsDisabledLocalField extends BooleanField {
+
+  private static final String DESCRIPTION =
+      "Whether or not to exclude replications including this Node from running locally.";
+
+  private static final String FIELD_NAME = "isDisabledLocal";
+
+  public IsDisabledLocalField() {
+    super(FIELD_NAME, null, DESCRIPTION);
+  }
+}

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/IsRemoteManagedField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/IsRemoteManagedField.java
@@ -15,14 +15,14 @@ package org.codice.ditto.replication.admin.query.sites.fields;
 
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 
-public class IsDisabledLocalField extends BooleanField {
+public class IsRemoteManagedField extends BooleanField {
 
   private static final String DESCRIPTION =
-      "Whether or not to exclude replications including this Node from running locally.";
+      "Whether or not replications including this Node should run locally.";
 
-  private static final String FIELD_NAME = "isDisabledLocal";
+  private static final String FIELD_NAME = "isRemoteManaged";
 
-  public IsDisabledLocalField() {
+  public IsRemoteManagedField() {
     super(FIELD_NAME, null, DESCRIPTION);
   }
 }

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/RemoteManagedField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/RemoteManagedField.java
@@ -15,14 +15,14 @@ package org.codice.ditto.replication.admin.query.sites.fields;
 
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 
-public class IsRemoteManagedField extends BooleanField {
+public class RemoteManagedField extends BooleanField {
 
   private static final String DESCRIPTION =
-      "Whether or not replications including this Node should run locally.";
+      "Specifies if replications including this Site are remotely managed. If not remotely managed, replications including this Site will run locally.";
 
-  private static final String FIELD_NAME = "isRemoteManaged";
+  private static final String FIELD_NAME = "remoteManaged";
 
-  public IsRemoteManagedField() {
+  public RemoteManagedField() {
     super(FIELD_NAME, null, DESCRIPTION);
   }
 }

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
@@ -47,7 +47,7 @@ public class ReplicationSiteField extends BaseObjectField {
 
   private IntegerField version;
 
-  private IsDisabledLocalField isDisabledLocal;
+  private IsRemoteManagedField isDisabledLocal;
 
   public ReplicationSiteField() {
     this(DEFAULT_FIELD_NAME);
@@ -61,7 +61,7 @@ public class ReplicationSiteField extends BaseObjectField {
     this.rootContext = new StringField("rootContext");
     this.modified = new DateField("modified");
     this.version = new IntegerField("version");
-    this.isDisabledLocal = new IsDisabledLocalField();
+    this.isDisabledLocal = new IsRemoteManagedField();
   }
 
   public ReplicationSiteField id(String id) {

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
@@ -47,6 +47,8 @@ public class ReplicationSiteField extends BaseObjectField {
 
   private IntegerField version;
 
+  private IsDisabledLocalField isDisabledLocal;
+
   public ReplicationSiteField() {
     this(DEFAULT_FIELD_NAME);
   }
@@ -59,6 +61,7 @@ public class ReplicationSiteField extends BaseObjectField {
     this.rootContext = new StringField("rootContext");
     this.modified = new DateField("modified");
     this.version = new IntegerField("version");
+    this.isDisabledLocal = new IsDisabledLocalField();
   }
 
   public ReplicationSiteField id(String id) {
@@ -88,6 +91,11 @@ public class ReplicationSiteField extends BaseObjectField {
 
   public ReplicationSiteField version(int version) {
     this.version.setValue(version);
+    return this;
+  }
+
+  public ReplicationSiteField isDisableLocal(boolean isDisableLocal) {
+    this.isDisabledLocal.setValue(isDisableLocal);
     return this;
   }
 
@@ -130,9 +138,13 @@ public class ReplicationSiteField extends BaseObjectField {
     return version;
   }
 
+  public boolean isDisabledLocal() {
+    return isDisabledLocal.getValue();
+  }
+
   @Override
   public List<Field> getFields() {
-    return ImmutableList.of(id, name, address, rootContext, modified, version);
+    return ImmutableList.of(id, name, address, rootContext, modified, version, isDisabledLocal);
   }
 
   public static class ListImpl extends BaseListField<ReplicationSiteField> {

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
@@ -33,7 +33,7 @@ public class ReplicationSiteField extends BaseObjectField {
 
   private static final String FIELD_TYPE_NAME = "ReplicationSite";
 
-  private static final String DESCRIPTION = "Contains the name and address of a site.";
+  private static final String DESCRIPTION = "Contains information about a Site.";
 
   private PidField id;
 
@@ -47,7 +47,7 @@ public class ReplicationSiteField extends BaseObjectField {
 
   private IntegerField version;
 
-  private IsRemoteManagedField isDisabledLocal;
+  private RemoteManagedField remoteManaged;
 
   public ReplicationSiteField() {
     this(DEFAULT_FIELD_NAME);
@@ -61,7 +61,7 @@ public class ReplicationSiteField extends BaseObjectField {
     this.rootContext = new StringField("rootContext");
     this.modified = new DateField("modified");
     this.version = new IntegerField("version");
-    this.isDisabledLocal = new IsRemoteManagedField();
+    this.remoteManaged = new RemoteManagedField();
   }
 
   public ReplicationSiteField id(String id) {
@@ -95,7 +95,7 @@ public class ReplicationSiteField extends BaseObjectField {
   }
 
   public ReplicationSiteField isDisableLocal(boolean isDisableLocal) {
-    this.isDisabledLocal.setValue(isDisableLocal);
+    this.remoteManaged.setValue(isDisableLocal);
     return this;
   }
 
@@ -139,12 +139,12 @@ public class ReplicationSiteField extends BaseObjectField {
   }
 
   public boolean isDisabledLocal() {
-    return isDisabledLocal.getValue();
+    return remoteManaged.getValue();
   }
 
   @Override
   public List<Field> getFields() {
-    return ImmutableList.of(id, name, address, rootContext, modified, version, isDisabledLocal);
+    return ImmutableList.of(id, name, address, rootContext, modified, version, remoteManaged);
   }
 
   public static class ListImpl extends BaseListField<ReplicationSiteField> {

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/CreateReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/CreateReplicationSite.java
@@ -24,7 +24,6 @@ import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ditto.replication.admin.query.ReplicationMessages;
 import org.codice.ditto.replication.admin.query.ReplicationUtils;
-import org.codice.ditto.replication.admin.query.sites.fields.IsDisabledLocalField;
 import org.codice.ditto.replication.admin.query.sites.fields.ReplicationSiteField;
 
 public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteField> {
@@ -44,8 +43,6 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
 
   private ReplicationUtils replicationUtils;
 
-  private IsDisabledLocalField isDisabledLocal;
-
   public CreateReplicationSite(ReplicationUtils replicationUtils) {
     super(FIELD_NAME, DESCRIPTION);
 
@@ -53,18 +50,14 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
     this.name = new StringField("name");
     this.address = new AddressField();
     this.rootContext = new StringField("rootContext");
-    this.isDisabledLocal = new IsDisabledLocalField();
     this.name.isRequired(true);
     this.address.isRequired(true);
     this.rootContext.isRequired(true);
-
-    isDisabledLocal.setValue(false);
   }
 
   @Override
   public ReplicationSiteField performFunction() {
-    return replicationUtils.createSite(
-        name.getValue(), address, rootContext.getValue(), isDisabledLocal.getValue());
+    return replicationUtils.createSite(name.getValue(), address, rootContext.getValue(), false);
   }
 
   @Override

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSite.java
@@ -23,6 +23,7 @@ import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ditto.replication.admin.query.ReplicationMessages;
 import org.codice.ditto.replication.admin.query.ReplicationUtils;
 import org.codice.ditto.replication.admin.query.replications.fields.ReplicationField;
@@ -43,7 +44,8 @@ public class DeleteReplicationSite extends BaseFunctionField<BooleanField> {
     super(FIELD_NAME, DESCRIPTION);
 
     this.replicationUtils = replicationUtils;
-    id = new PidField("id");
+    this.id = new PidField("id");
+    this.id.isRequired(true);
   }
 
   @Override
@@ -60,8 +62,12 @@ public class DeleteReplicationSite extends BaseFunctionField<BooleanField> {
       return;
     }
 
-    ListField<ReplicationField> repFields = replicationUtils.getReplications(true);
     String idToDelete = id.getValue();
+    if (!replicationUtils.siteIdExists(idToDelete)) {
+      addErrorMessage(DefaultMessages.noExistingConfigError());
+    }
+
+    ListField<ReplicationField> repFields = replicationUtils.getReplications(true);
     for (ReplicationField repField : repFields.getList()) {
       if (idToDelete.equals(repField.source().id())
           || idToDelete.equals(repField.destination().id())) {
@@ -88,6 +94,6 @@ public class DeleteReplicationSite extends BaseFunctionField<BooleanField> {
 
   @Override
   public Set<String> getFunctionErrorCodes() {
-    return ImmutableSet.of();
+    return ImmutableSet.of(DefaultMessages.NO_EXISTING_CONFIG, ReplicationMessages.SITE_IN_USE);
   }
 }

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSite.java
@@ -92,15 +92,20 @@ public class UpdateReplicationSite extends BaseFunctionField<BooleanField> {
       return;
     }
 
-    final String updatedName = name.getValue();
     final String updateId = id.getValue();
     if (!replicationUtils.siteIdExists(updateId)) {
       addErrorMessage(DefaultMessages.noExistingConfigError());
     }
-    if (updatedName != null
-        && (replicationUtils.isNotUpdatedSiteName(updateId, updatedName)
-            || replicationUtils.isDuplicateSiteName(updatedName))) {
-      addErrorMessage(ReplicationMessages.duplicateSites());
+
+    final String updatedName = name.getValue();
+    if (updatedName != null) {
+      if ((replicationUtils.isUpdatedSitesName(updateId, updatedName))) {
+        return;
+      }
+
+      if (replicationUtils.isDuplicateSiteName(updatedName)) {
+        addErrorMessage(ReplicationMessages.duplicateSites());
+      }
     }
   }
 }

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSite.java
@@ -20,22 +20,21 @@ import java.util.Set;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
+import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ditto.replication.admin.query.ReplicationMessages;
 import org.codice.ditto.replication.admin.query.ReplicationUtils;
-import org.codice.ditto.replication.admin.query.sites.fields.IsDisabledLocalField;
-import org.codice.ditto.replication.admin.query.sites.fields.ReplicationSiteField;
 
-public class UpdateReplicationSite extends BaseFunctionField<ReplicationSiteField> {
+public class UpdateReplicationSite extends BaseFunctionField<BooleanField> {
 
   public static final String FIELD_NAME = "updateReplicationSite";
 
-  public static final String DESCRIPTION = "Updates a replication Site.";
+  public static final String DESCRIPTION = "Updates a Replication Site.";
 
-  public static final ReplicationSiteField RETURN_TYPE = new ReplicationSiteField();
+  public static final BooleanField RETURN_TYPE = new BooleanField();
 
   private PidField id;
 
@@ -44,8 +43,6 @@ public class UpdateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
   private AddressField address;
 
   private StringField rootContext;
-
-  private IsDisabledLocalField isDisabledLocal;
 
   private ReplicationUtils replicationUtils;
 
@@ -57,33 +54,29 @@ public class UpdateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
     this.name = new StringField("name");
     this.address = new AddressField();
     this.rootContext = new StringField("rootContext");
-    this.isDisabledLocal = new IsDisabledLocalField();
 
     this.id.isRequired(true);
   }
 
   @Override
-  public ReplicationSiteField performFunction() {
-    return replicationUtils.updateSite(
-        id.getValue(),
-        name.getValue(),
-        address,
-        rootContext.getValue(),
-        isDisabledLocal.getValue());
+  public BooleanField performFunction() {
+    return new BooleanField(
+        replicationUtils.updateSite(
+            id.getValue(), name.getValue(), address, rootContext.getValue()));
   }
 
   @Override
-  public ReplicationSiteField getReturnType() {
+  public BooleanField getReturnType() {
     return RETURN_TYPE;
   }
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(id, name, address, rootContext, isDisabledLocal);
+    return ImmutableList.of(id, name, address, rootContext);
   }
 
   @Override
-  public FunctionField<ReplicationSiteField> newInstance() {
+  public FunctionField<BooleanField> newInstance() {
     return new UpdateReplicationSite(replicationUtils);
   }
 

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
@@ -15,7 +15,6 @@ package org.codice.ditto.replication.admin.query;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
@@ -88,7 +87,7 @@ public class ReplicationUtilsTest {
               return site;
             });
     ReplicationSiteField field =
-        utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), null);
+        utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), null, false);
     assertThat(field.id(), is("id"));
     assertThat(field.name(), is("site"));
     assertThat(field.address().url(), is("https://localhost:1234/services"));
@@ -109,7 +108,7 @@ public class ReplicationUtilsTest {
               return site;
             });
     ReplicationSiteField field =
-        utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), "context");
+        utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), "context", false);
     assertThat(field.id(), is("id"));
     assertThat(field.name(), is("site"));
     assertThat(field.address().url(), is("https://localhost:1234/context"));
@@ -130,25 +129,11 @@ public class ReplicationUtilsTest {
               return site;
             });
     ReplicationSiteField field =
-        utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), " // context ");
+        utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), " // context ", false);
     assertThat(field.id(), is("id"));
     assertThat(field.name(), is("site"));
     assertThat(field.address().url(), is("https://localhost:1234/context"));
     verify(siteManager).save(any(ReplicationSiteImpl.class));
-  }
-
-  @Test
-  public void getSiteFieldForSiteReturnsNull() throws Exception {
-    ReplicationSiteImpl site = new ReplicationSiteImpl();
-    site.setId("id");
-    site.setName("site");
-    site.setUrl("https://localhost:1234");
-
-    when(siteManager.createSite(anyString(), anyString())).thenReturn(null);
-    when(siteManager.objects()).thenReturn(Stream.empty());
-    ReplicationSiteField field =
-        utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), null);
-    assertNull(field);
   }
 
   @Test(expected = ReplicationException.class)
@@ -161,7 +146,7 @@ public class ReplicationUtilsTest {
     when(siteManager.createSite(anyString(), anyString())).thenReturn(site);
     AddressField address = new AddressField();
     address.url(site.getUrl());
-    utils.createSite(site.getName(), address, null);
+    utils.createSite(site.getName(), address, null, false);
   }
 
   @Test
@@ -485,7 +470,7 @@ public class ReplicationUtilsTest {
     when(siteManager.get(anyString())).thenReturn(site);
     ReplicationSiteField field =
         utils.updateSite(
-            "id", "site", getAddress(new URL("https://localhost:1234")), "replication");
+            "id", "site", getAddress(new URL("https://localhost:1234")), "replication", false);
     assertThat(field.id(), is("id"));
     assertThat(field.name(), is("site"));
     assertThat(field.address().url(), is("https://localhost:1234/replication"));
@@ -503,7 +488,7 @@ public class ReplicationUtilsTest {
     when(siteManager.get(anyString())).thenReturn(site);
     AddressField address = new AddressField();
     address.url(site.getUrl());
-    ReplicationSiteField field = utils.updateSite("id", "site", address, null);
+    ReplicationSiteField field = utils.updateSite("id", "site", address, null, false);
     assertThat(field.id(), is("id"));
     assertThat(field.name(), is("site"));
     assertThat(field.address().url(), is("https://localhost:1234"));
@@ -561,7 +546,7 @@ public class ReplicationUtilsTest {
     site.setUrl("https://localhost:1234");
 
     when(siteManager.objects()).thenReturn(Stream.of(site));
-    assertThat(utils.siteExists("site"), is(true));
+    assertThat(utils.isDuplicateSiteName("site"), is(true));
   }
 
   @Test
@@ -572,7 +557,7 @@ public class ReplicationUtilsTest {
     site.setUrl("https://localhost:1234");
 
     when(siteManager.objects()).thenReturn(Stream.empty());
-    assertThat(utils.siteExists("site"), is(false));
+    assertThat(utils.isDuplicateSiteName("site"), is(false));
   }
 
   private AddressField getAddress(URL url) {

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSiteTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSiteTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.sites.persist;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.codice.ddf.admin.api.fields.ListField;
+import org.codice.ddf.admin.api.report.FunctionReport;
+import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
+import org.codice.ditto.replication.admin.query.ReplicationMessages;
+import org.codice.ditto.replication.admin.query.ReplicationUtils;
+import org.codice.ditto.replication.admin.query.replications.fields.ReplicationField;
+import org.codice.ditto.replication.admin.query.sites.fields.ReplicationSiteField;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DeleteReplicationSiteTest {
+
+  private static final String FUNCTION_PATH = "deleteReplicationSite";
+
+  private static final String SITE_ID = "siteId";
+
+  private static final String ID = "id";
+
+  private DeleteReplicationSite deleteReplicationSite;
+
+  @Mock ReplicationUtils replicationUtils;
+
+  private Map<String, Object> input;
+
+  @Before
+  public void setup() {
+    deleteReplicationSite = new DeleteReplicationSite(replicationUtils);
+
+    input = new HashMap<>();
+    input.put(ID, SITE_ID);
+  }
+
+  @Test
+  public void testDeleteSite() {
+    // setup
+    when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(true);
+    when(replicationUtils.deleteSite(SITE_ID)).thenReturn(true);
+    when(replicationUtils.getReplications(true)).thenReturn(new ReplicationField.ListImpl());
+
+    // when
+    FunctionReport<BooleanField> report = deleteReplicationSite.execute(input, null);
+
+    // then
+    assertThat(report.getErrorMessages().size(), is(0));
+    assertThat(report.getResult().getValue(), is(true));
+    verify(replicationUtils).deleteSite(SITE_ID);
+  }
+
+  @Test
+  public void testNoExistingSite() {
+    // setup
+    when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(false);
+    when(replicationUtils.getReplications(true)).thenReturn(new ReplicationField.ListImpl());
+
+    // when
+    FunctionReport<BooleanField> report =
+        deleteReplicationSite.execute(input, ImmutableList.of(FUNCTION_PATH));
+
+    // then
+    assertThat(report.getErrorMessages().size(), is(1));
+    assertThat(report.getErrorMessages().get(0).getCode(), is(DefaultMessages.NO_EXISTING_CONFIG));
+    assertThat(report.getErrorMessages().get(0).getPath(), is(ImmutableList.of(FUNCTION_PATH)));
+  }
+
+  @Test
+  public void testSiteInUseByReplication() {
+    // setup
+    when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(true);
+
+    ReplicationSiteField replicationSiteField = mock(ReplicationSiteField.class);
+    when(replicationSiteField.id()).thenReturn(SITE_ID);
+
+    ReplicationField replicationField = mock(ReplicationField.class);
+    when(replicationField.source()).thenReturn(replicationSiteField);
+    ListField<ReplicationField> replicationFieldList = mock(ListField.class);
+    when(replicationFieldList.getList()).thenReturn(Collections.singletonList(replicationField));
+    when(replicationUtils.getReplications(true)).thenReturn(replicationFieldList);
+
+    // when
+    FunctionReport<BooleanField> report =
+        deleteReplicationSite.execute(input, ImmutableList.of(FUNCTION_PATH));
+
+    // then
+    assertThat(report.getErrorMessages().size(), is(1));
+    assertThat(report.getErrorMessages().get(0).getCode(), is(ReplicationMessages.SITE_IN_USE));
+    assertThat(report.getErrorMessages().get(0).getPath(), is(ImmutableList.of(FUNCTION_PATH)));
+  }
+
+  @Test
+  public void testFunctionErrorCodes() {
+    assertThat(deleteReplicationSite.getFunctionErrorCodes().size(), is(2));
+    assertThat(
+        deleteReplicationSite.getFunctionErrorCodes(), hasItem(ReplicationMessages.SITE_IN_USE));
+    assertThat(
+        deleteReplicationSite.getFunctionErrorCodes(), hasItem(DefaultMessages.NO_EXISTING_CONFIG));
+  }
+
+  @Test
+  public void testMissingRequiredArguments() {
+    // when
+    FunctionReport<BooleanField> report =
+        deleteReplicationSite.execute(null, ImmutableList.of(FUNCTION_PATH));
+
+    // then
+    assertThat(report.getErrorMessages().size(), is(1));
+    assertThat(
+        report.getErrorMessages().get(0).getCode(), is(DefaultMessages.MISSING_REQUIRED_FIELD));
+    assertThat(report.getErrorMessages().get(0).getPath(), is(ImmutableList.of(FUNCTION_PATH, ID)));
+  }
+}

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSiteTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/DeleteReplicationSiteTest.java
@@ -94,7 +94,7 @@ public class DeleteReplicationSiteTest {
   }
 
   @Test
-  public void testSiteInUseByReplication() {
+  public void testSourceSiteInUseByReplication() {
     // setup
     when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(true);
 
@@ -103,6 +103,34 @@ public class DeleteReplicationSiteTest {
 
     ReplicationField replicationField = mock(ReplicationField.class);
     when(replicationField.source()).thenReturn(replicationSiteField);
+    ListField<ReplicationField> replicationFieldList = mock(ListField.class);
+    when(replicationFieldList.getList()).thenReturn(Collections.singletonList(replicationField));
+    when(replicationUtils.getReplications(true)).thenReturn(replicationFieldList);
+
+    // when
+    FunctionReport<BooleanField> report =
+        deleteReplicationSite.execute(input, ImmutableList.of(FUNCTION_PATH));
+
+    // then
+    assertThat(report.getErrorMessages().size(), is(1));
+    assertThat(report.getErrorMessages().get(0).getCode(), is(ReplicationMessages.SITE_IN_USE));
+    assertThat(report.getErrorMessages().get(0).getPath(), is(ImmutableList.of(FUNCTION_PATH)));
+  }
+
+  @Test
+  public void testDestinationSiteInUseByReplication() {
+    // setup
+    when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(true);
+
+    ReplicationSiteField sourceSiteField = mock(ReplicationSiteField.class);
+    when(sourceSiteField.id()).thenReturn("someOtherID");
+
+    ReplicationSiteField destinationSiteField = mock(ReplicationSiteField.class);
+    when(destinationSiteField.id()).thenReturn(SITE_ID);
+
+    ReplicationField replicationField = mock(ReplicationField.class);
+    when(replicationField.source()).thenReturn(sourceSiteField);
+    when(replicationField.destination()).thenReturn(destinationSiteField);
     ListField<ReplicationField> replicationFieldList = mock(ListField.class);
     when(replicationFieldList.getList()).thenReturn(Collections.singletonList(replicationField));
     when(replicationUtils.getReplications(true)).thenReturn(replicationFieldList);

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSiteTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSiteTest.java
@@ -17,9 +17,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,11 +27,11 @@ import java.util.List;
 import java.util.Map;
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.api.report.FunctionReport;
+import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ditto.replication.admin.query.ReplicationMessages;
 import org.codice.ditto.replication.admin.query.ReplicationUtils;
-import org.codice.ditto.replication.admin.query.sites.fields.ReplicationSiteField;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,7 +52,7 @@ public class UpdateReplicationSiteTest {
 
   private static final String ADDRESS = "address";
 
-  private static final String IS_DISABLED_LOCAL = "isDisabledLocal";
+  private static final String IS_DISABLED_LOCAL = "isRemoteManaged";
 
   private static final String SITE_ID = "siteId";
 
@@ -99,30 +97,28 @@ public class UpdateReplicationSiteTest {
     when(replicationUtils.isDuplicateSiteName(SITE_NAME)).thenReturn(false);
     when(replicationUtils.isNotUpdatedSiteName(SITE_ID, SITE_NAME)).thenReturn(false);
 
-    ReplicationSiteField replicationSiteField = mock(ReplicationSiteField.class);
+    final boolean updateResult = true;
     when(replicationUtils.updateSite(
-            anyString(), anyString(), any(AddressField.class), anyString(), anyBoolean()))
-        .thenReturn(replicationSiteField);
+            anyString(), anyString(), any(AddressField.class), anyString()))
+        .thenReturn(updateResult);
 
     ArgumentCaptor<AddressField> addressFieldCaptor = ArgumentCaptor.forClass(AddressField.class);
     ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> contextCaptor = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<Boolean> disabledLocalCaptor = ArgumentCaptor.forClass(Boolean.class);
     ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
 
     // when
-    FunctionReport<ReplicationSiteField> report = updateReplicationSite.execute(input, null);
+    FunctionReport<BooleanField> report = updateReplicationSite.execute(input, null);
 
     // then
     assertThat(report.getErrorMessages().size(), is(0));
-    assertThat(report.getResult(), is(replicationSiteField));
+    assertThat(report.getResult().getValue(), is(updateResult));
     verify(replicationUtils)
         .updateSite(
             idCaptor.capture(),
             nameCaptor.capture(),
             addressFieldCaptor.capture(),
-            contextCaptor.capture(),
-            disabledLocalCaptor.capture());
+            contextCaptor.capture());
 
     AddressField address = addressFieldCaptor.getValue();
     assertThat(address.host().hostname(), is(SITE_HOSTNAME));
@@ -130,7 +126,6 @@ public class UpdateReplicationSiteTest {
     assertThat(idCaptor.getValue(), is(SITE_ID));
     assertThat(nameCaptor.getValue(), is(SITE_NAME));
     assertThat(contextCaptor.getValue(), is(SITE_CONTEXT));
-    assertThat(disabledLocalCaptor.getValue(), is(SITE_IS_DISABLED_LOCAL));
   }
 
   @Test

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSiteTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSiteTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,7 +53,7 @@ public class UpdateReplicationSiteTest {
 
   private static final String ADDRESS = "address";
 
-  private static final String IS_DISABLED_LOCAL = "isRemoteManaged";
+  private static final String REMOTE_MANAGED = "remoteManaged";
 
   private static final String SITE_ID = "siteId";
 
@@ -87,7 +88,7 @@ public class UpdateReplicationSiteTest {
     input.put(NAME, SITE_NAME);
     input.put(ROOT_CONTEXT, SITE_CONTEXT);
     input.put(ADDRESS, addressField);
-    input.put(IS_DISABLED_LOCAL, SITE_IS_DISABLED_LOCAL);
+    input.put(REMOTE_MANAGED, SITE_IS_DISABLED_LOCAL);
   }
 
   @Test
@@ -95,7 +96,7 @@ public class UpdateReplicationSiteTest {
     // setup
     when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(true);
     when(replicationUtils.isDuplicateSiteName(SITE_NAME)).thenReturn(false);
-    when(replicationUtils.isNotUpdatedSiteName(SITE_ID, SITE_NAME)).thenReturn(false);
+    when(replicationUtils.isUpdatedSitesName(SITE_ID, SITE_NAME)).thenReturn(false);
 
     final boolean updateResult = true;
     when(replicationUtils.updateSite(
@@ -133,7 +134,7 @@ public class UpdateReplicationSiteTest {
     // setup
     when(replicationUtils.isDuplicateSiteName(SITE_NAME)).thenReturn(true);
     when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(true);
-    when(replicationUtils.isNotUpdatedSiteName(SITE_ID, SITE_NAME)).thenReturn(false);
+    when(replicationUtils.isUpdatedSitesName(SITE_ID, SITE_NAME)).thenReturn(false);
 
     // when
     List<ErrorMessage> errors =
@@ -146,11 +147,24 @@ public class UpdateReplicationSiteTest {
   }
 
   @Test
+  public void testIsUpdatedSitesNameNeverChecksForDuplicate() {
+    // setup
+    when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(true);
+    when(replicationUtils.isUpdatedSitesName(SITE_ID, SITE_NAME)).thenReturn(true);
+
+    // when
+    updateReplicationSite.execute(input, ImmutableList.of(FUNCTION_PATH)).getErrorMessages();
+
+    // then
+    verify(replicationUtils, never()).isDuplicateSiteName(SITE_NAME);
+  }
+
+  @Test
   public void testNoExistingSite() {
     // setup
     when(replicationUtils.isDuplicateSiteName(SITE_NAME)).thenReturn(false);
     when(replicationUtils.siteIdExists(SITE_ID)).thenReturn(false);
-    when(replicationUtils.isNotUpdatedSiteName(SITE_ID, SITE_NAME)).thenReturn(false);
+    when(replicationUtils.isUpdatedSitesName(SITE_ID, SITE_NAME)).thenReturn(false);
 
     // when
     List<ErrorMessage> errors =

--- a/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/ITReplicationQuery.java
+++ b/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/ITReplicationQuery.java
@@ -42,6 +42,8 @@ import org.junit.runner.RunWith;
 @RunWith(Dominion.class)
 public class ITReplicationQuery {
 
+  private static final String NO_EXISTING_CONFIG = "NO_EXISTING_CONFIG";
+
   @Interpolate
   private static String GRAPHQL_ENDPOINT = "https://localhost:{port.https}/admin/hub/graphql";
 
@@ -148,12 +150,7 @@ public class ITReplicationQuery {
         .then()
         .statusCode(200)
         .header("Content-Type", is("application/json;charset=utf-8"))
-        .body(
-            "errors.message",
-            hasItem(
-                "Internal Server Error(s) while executing query")); // what we currently get when a
-    // site with the given ID
-    // doesn't exist
+        .body("errors.message", hasItem(NO_EXISTING_CONFIG));
   }
 
   @Test
@@ -165,7 +162,7 @@ public class ITReplicationQuery {
         .then()
         .statusCode(200)
         .header("Content-Type", is("application/json;charset=utf-8"))
-        .body("data.deleteReplicationSite", is(false));
+        .body("errors.message", hasItem(NO_EXISTING_CONFIG));
   }
 
   // ----------------------------------- General Tests -----------------------------------//

--- a/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/ITReplicationQuery.java
+++ b/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/ITReplicationQuery.java
@@ -203,7 +203,7 @@ public class ITReplicationQuery {
 
   private static String makeUpdateSiteQuery(String id, String name, String url) {
     return String.format(
-        "{\"query\":\"mutation{ updateReplicationSite(id: \\\"%s\\\", name: \\\"%s\\\", address: { url: \\\"%s\\\"}, rootContext: \\\"services\\\"){ id name address{ host{ hostname port } url }}}\"}",
+        "{\"query\":\"mutation{ updateReplicationSite(id: \\\"%s\\\", name: \\\"%s\\\", address: { url: \\\"%s\\\"}, rootContext: \\\"services\\\")}\"}",
         id, name, url);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <snapshots.repository.url />
         <releases.repository.url />
 
-        <admin-query.version>1.2.7</admin-query.version>
+        <admin-query.version>1.2.8-SNAPSHOT</admin-query.version>
         <ddf.support.version>2.3.12</ddf.support.version>
         <ddf.version>2.13.9</ddf.version>
         <codice-maven.version>0.2</codice-maven.version>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -328,17 +328,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.56</minimum>
+                                            <minimum>0.57</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.48</minimum>
+                                            <minimum>0.50</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.53</minimum>
+                                            <minimum>0.54</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorRunner.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorRunner.java
@@ -22,12 +22,15 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.ws.rs.NotFoundException;
 import org.codice.ddf.security.common.Security;
+import org.codice.ditto.replication.api.ReplicationPersistenceException;
 import org.codice.ditto.replication.api.Replicator;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.impl.data.ReplicationStatusImpl;
 import org.codice.ditto.replication.api.impl.data.SyncRequestImpl;
 import org.codice.ditto.replication.api.persistence.ReplicatorConfigManager;
+import org.codice.ditto.replication.api.persistence.SiteManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +50,8 @@ public class ReplicatorRunner {
 
   private final ScheduledExecutorService scheduledExecutor;
 
+  private final SiteManager siteManager;
+
   private static final long STARTUP_DELAY = TimeUnit.MINUTES.toSeconds(1);
 
   private static final String DEFAULT_REPLICATION_PERIOD_STR =
@@ -55,8 +60,14 @@ public class ReplicatorRunner {
   public ReplicatorRunner(
       ScheduledExecutorService scheduledExecutor,
       Replicator replicator,
-      ReplicatorConfigManager replicatorConfigManager) {
-    this(scheduledExecutor, replicator, replicatorConfigManager, Security.getInstance());
+      ReplicatorConfigManager replicatorConfigManager,
+      SiteManager siteManager) {
+    this(
+        scheduledExecutor,
+        replicator,
+        replicatorConfigManager,
+        siteManager,
+        Security.getInstance());
   }
 
   /*Visible for testing only*/
@@ -64,10 +75,12 @@ public class ReplicatorRunner {
       ScheduledExecutorService scheduledExecutor,
       Replicator replicator,
       ReplicatorConfigManager replicatorConfigManager,
+      SiteManager siteManager,
       Security security) {
     this.scheduledExecutor = notNull(scheduledExecutor);
     this.replicator = notNull(replicator);
     this.replicatorConfigManager = notNull(replicatorConfigManager);
+    this.siteManager = notNull(siteManager);
     this.security = security;
   }
 
@@ -108,13 +121,32 @@ public class ReplicatorRunner {
             .objects()
             .filter(c -> !c.isSuspended())
             .collect(Collectors.toList());
+
     try {
       for (ReplicatorConfig config : configsToSchedule) {
+        if (sourceOrDestinationDisabledLocal(config)) {
+          LOGGER.trace(
+              "One of config {}'s sites are disabled locally, not running the config",
+              config.getName());
+          continue;
+        }
         replicator.submitSyncRequest(
             new SyncRequestImpl(config, new ReplicationStatusImpl(config.getName())));
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
+    }
+  }
+
+  private boolean sourceOrDestinationDisabledLocal(ReplicatorConfig replicatorConfig) {
+    try {
+      return siteManager.get(replicatorConfig.getSource()).isDisabledLocal()
+          || siteManager.get(replicatorConfig.getDestination()).isDisabledLocal();
+    } catch (NotFoundException | ReplicationPersistenceException e) {
+      LOGGER.debug(
+          "Unable to determine if replication {} should be run based on its sites. This replication will not be run.",
+          replicatorConfig.getName());
+      return true;
     }
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorRunner.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorRunner.java
@@ -124,9 +124,9 @@ public class ReplicatorRunner {
 
     try {
       for (ReplicatorConfig config : configsToSchedule) {
-        if (sourceOrDestinationDisabledLocal(config)) {
+        if (sourceOrDestinationIsRemotelyManaged(config)) {
           LOGGER.trace(
-              "One of config {}'s sites are disabled locally, not running the config",
+              "One of config {}'s sites are remotely managed, not running the config",
               config.getName());
           continue;
         }
@@ -138,10 +138,10 @@ public class ReplicatorRunner {
     }
   }
 
-  private boolean sourceOrDestinationDisabledLocal(ReplicatorConfig replicatorConfig) {
+  private boolean sourceOrDestinationIsRemotelyManaged(ReplicatorConfig replicatorConfig) {
     try {
-      return siteManager.get(replicatorConfig.getSource()).isDisabledLocal()
-          || siteManager.get(replicatorConfig.getDestination()).isDisabledLocal();
+      return siteManager.get(replicatorConfig.getSource()).isRemoteManaged()
+          || siteManager.get(replicatorConfig.getDestination()).isRemoteManaged();
     } catch (NotFoundException | ReplicationPersistenceException e) {
       LOGGER.debug(
           "Unable to determine if replication {} should be run based on its sites. This replication will not be run.",

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
@@ -29,8 +29,12 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
 
   private static final String URL_KEY = "url";
 
+  private static final String IS_DISABLED_LOCAL_KEY = "is-disabled-local";
+
   /** 1 - initial version. */
   public static final int CURRENT_VERSION = 1;
+
+  private boolean isDisabledLocal = false;
 
   private String name;
 
@@ -61,10 +65,21 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
   }
 
   @Override
+  public void setIsDisabledLocal(boolean isDisabledLocal) {
+    this.isDisabledLocal = isDisabledLocal;
+  }
+
+  @Override
+  public boolean isDisabledLocal() {
+    return isDisabledLocal;
+  }
+
+  @Override
   public Map<String, Object> toMap() {
     Map<String, Object> result = super.toMap();
     result.put(NAME_KEY, getName());
     result.put(URL_KEY, getUrl());
+    result.put(IS_DISABLED_LOCAL_KEY, isDisabledLocal());
     return result;
   }
 
@@ -73,5 +88,6 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
     super.fromMap(properties);
     setName((String) properties.get(NAME_KEY));
     setUrl((String) properties.get(URL_KEY));
+    setIsDisabledLocal((Boolean) properties.get(IS_DISABLED_LOCAL_KEY));
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
@@ -29,12 +29,22 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
 
   private static final String URL_KEY = "url";
 
-  private static final String IS_DISABLED_LOCAL_KEY = "is-disabled-local";
+  private static final String IS_REMOTE_MANAGED_KEY = "is-remote-managed";
 
-  /** 1 - initial version. */
-  public static final int CURRENT_VERSION = 1;
+  /**
+   * List of possible versions:
+   *
+   * <ul>
+   *   <li>1 - initial version.
+   *   <li>2 - Adds
+   *       <ul>
+   *         <li>is-remote-managed field of type boolean, defaults to false
+   *       </ul>
+   * </ul>
+   */
+  public static final int CURRENT_VERSION = 2;
 
-  private boolean isDisabledLocal = false;
+  private boolean isRemoteManaged = false;
 
   private String name;
 
@@ -65,13 +75,13 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
   }
 
   @Override
-  public void setIsDisabledLocal(boolean isDisabledLocal) {
-    this.isDisabledLocal = isDisabledLocal;
+  public void setIsRemoteManaged(boolean isRemoteManaged) {
+    this.isRemoteManaged = isRemoteManaged;
   }
 
   @Override
-  public boolean isDisabledLocal() {
-    return isDisabledLocal;
+  public boolean isRemoteManaged() {
+    return isRemoteManaged;
   }
 
   @Override
@@ -79,7 +89,7 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
     Map<String, Object> result = super.toMap();
     result.put(NAME_KEY, getName());
     result.put(URL_KEY, getUrl());
-    result.put(IS_DISABLED_LOCAL_KEY, isDisabledLocal());
+    result.put(IS_REMOTE_MANAGED_KEY, isRemoteManaged());
     return result;
   }
 
@@ -89,11 +99,11 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
     setName((String) properties.get(NAME_KEY));
     setUrl((String) properties.get(URL_KEY));
 
-    Object isDisableLocal = properties.get(IS_DISABLED_LOCAL_KEY);
-    if (isDisableLocal != null) {
-      setIsDisabledLocal(Boolean.parseBoolean((String) isDisableLocal));
+    if (super.getVersion() == 1) {
+      setIsRemoteManaged(false);
+      super.setVersion(CURRENT_VERSION);
     } else {
-      setIsDisabledLocal(false);
+      setIsRemoteManaged(Boolean.parseBoolean((String) properties.get(IS_REMOTE_MANAGED_KEY)));
     }
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
@@ -88,6 +88,12 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
     super.fromMap(properties);
     setName((String) properties.get(NAME_KEY));
     setUrl((String) properties.get(URL_KEY));
-    setIsDisabledLocal((Boolean) properties.get(IS_DISABLED_LOCAL_KEY));
+
+    Object isDisableLocal = properties.get(IS_DISABLED_LOCAL_KEY);
+    if (isDisableLocal != null) {
+      setIsDisabledLocal(Boolean.parseBoolean((String) isDisableLocal));
+    } else {
+      setIsDisabledLocal(false);
+    }
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
@@ -75,8 +75,8 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
   }
 
   @Override
-  public void setIsRemoteManaged(boolean isRemoteManaged) {
-    this.isRemoteManaged = isRemoteManaged;
+  public void setRemoteManaged(boolean remoteManaged) {
+    this.isRemoteManaged = remoteManaged;
   }
 
   @Override
@@ -100,10 +100,10 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
     setUrl((String) properties.get(URL_KEY));
 
     if (super.getVersion() == 1) {
-      setIsRemoteManaged(false);
+      setRemoteManaged(false);
       super.setVersion(CURRENT_VERSION);
     } else {
-      setIsRemoteManaged(Boolean.parseBoolean((String) properties.get(IS_REMOTE_MANAGED_KEY)));
+      setRemoteManaged(Boolean.parseBoolean((String) properties.get(IS_REMOTE_MANAGED_KEY)));
     }
   }
 }

--- a/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -161,6 +161,7 @@
         <argument ref="replicatorRunnerExecutor"/>
         <argument ref="replicator"/>
         <argument ref="configManager"/>
+        <argument ref="siteManager"/>
     </bean>
 
     <bean id="replicatorRunnerExecutor" class="java.util.concurrent.Executors"

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorRunnerTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorRunnerTest.java
@@ -162,7 +162,7 @@ public class ReplicatorRunnerTest {
   }
 
   @Test
-  public void testConfigNotRunWhenConfigSourceIsDisabledLocal() throws Exception {
+  public void testConfigNotRunWhenConfigSourceIsRemoteManaged() throws Exception {
     ReplicationSite source = mockSite(SOURCE_ID, true);
     ReplicationSite destination = mockSite(DESTINATION_ID, false);
     when(siteManager.get(SOURCE_ID)).thenReturn(source);
@@ -181,7 +181,7 @@ public class ReplicatorRunnerTest {
   }
 
   @Test
-  public void testConfigNotRunWhenConfigDestinationIsDisabledLocal() throws Exception {
+  public void testConfigNotRunWhenConfigDestinationIsRemoteManaged() throws Exception {
     ReplicationSite source = mockSite(SOURCE_ID, false);
     ReplicationSite destination = mockSite(DESTINATION_ID, true);
     when(siteManager.get(SOURCE_ID)).thenReturn(source);
@@ -207,10 +207,10 @@ public class ReplicatorRunnerTest {
     verify(security).runWithSubjectOrElevate(any(Callable.class));
   }
 
-  private ReplicationSite mockSite(String id, boolean isDisabledLocal) {
+  private ReplicationSite mockSite(String id, boolean isRemoteManaged) {
     ReplicationSite site = mock(ReplicationSite.class);
     when(site.getId()).thenReturn(id);
-    when(site.isDisabledLocal()).thenReturn(isDisabledLocal);
+    when(site.isRemoteManaged()).thenReturn(isRemoteManaged);
     return site;
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorRunnerTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorRunnerTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,8 +31,10 @@ import java.util.stream.Stream;
 import org.codice.ddf.security.common.Security;
 import org.codice.ditto.replication.api.Replicator;
 import org.codice.ditto.replication.api.SyncRequest;
+import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.persistence.ReplicatorConfigManager;
+import org.codice.ditto.replication.api.persistence.SiteManager;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +46,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ReplicatorRunnerTest {
 
-  ReplicatorRunner runner;
+  private static final String SOURCE_ID = "sourceId";
+
+  private static final String DESTINATION_ID = "destinationId";
+
+  private ReplicatorRunner runner;
 
   @Mock Security security;
 
@@ -53,9 +60,11 @@ public class ReplicatorRunnerTest {
 
   @Mock ScheduledExecutorService scheduledExecutor;
 
-  Stream<ReplicatorConfig> configStream;
+  private Stream<ReplicatorConfig> configStream;
 
   @Mock ReplicatorConfig config;
+
+  @Mock SiteManager siteManager;
 
   @Before
   public void setUp() throws Exception {
@@ -63,7 +72,8 @@ public class ReplicatorRunnerTest {
         .thenAnswer(invocation -> invocation.getArgumentAt(0, Callable.class).call());
     when(security.runAsAdmin(any(PrivilegedAction.class)))
         .thenAnswer(invocation -> invocation.getArgumentAt(0, PrivilegedAction.class).run());
-    runner = new ReplicatorRunner(scheduledExecutor, replicator, configManager, security);
+    runner =
+        new ReplicatorRunner(scheduledExecutor, replicator, configManager, siteManager, security);
     configStream = Stream.of(config);
   }
 
@@ -99,10 +109,22 @@ public class ReplicatorRunnerTest {
 
   @Test
   public void scheduleReplication() throws Exception {
-    ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
+    ReplicationSite source = mockSite(SOURCE_ID, false);
+    ReplicationSite destination = mockSite(DESTINATION_ID, false);
+    when(siteManager.get(SOURCE_ID)).thenReturn(source);
+    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+
     when(config.getName()).thenReturn("test");
+    when(config.getSource()).thenReturn(SOURCE_ID);
+    when(config.getDestination()).thenReturn(DESTINATION_ID);
     when(configManager.objects()).thenReturn(configStream);
+
+    ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
+
+    // when
     runner.scheduleReplication();
+
+    // then
     verify(replicator).submitSyncRequest(request.capture());
     assertThat(request.getValue().getConfig().getName(), is("test"));
   }
@@ -119,13 +141,62 @@ public class ReplicatorRunnerTest {
 
   @Test
   public void scheduleReplicationInterruptException() throws Exception {
-    ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
+    ReplicationSite source = mockSite(SOURCE_ID, false);
+    ReplicationSite destination = mockSite(DESTINATION_ID, false);
+    when(siteManager.get(SOURCE_ID)).thenReturn(source);
+    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+
     when(config.getName()).thenReturn("test");
+    when(config.getSource()).thenReturn(SOURCE_ID);
+    when(config.getDestination()).thenReturn(DESTINATION_ID);
     when(configManager.objects()).thenReturn(configStream);
     doThrow(new InterruptedException()).when(replicator).submitSyncRequest(any(SyncRequest.class));
+    ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
+
+    // when
     runner.scheduleReplication();
+
+    // then
     verify(replicator).submitSyncRequest(request.capture());
     assertThat(request.getValue().getConfig().getName(), is("test"));
+  }
+
+  @Test
+  public void testConfigNotRunWhenConfigSourceIsDisabledLocal() throws Exception {
+    ReplicationSite source = mockSite(SOURCE_ID, true);
+    ReplicationSite destination = mockSite(DESTINATION_ID, false);
+    when(siteManager.get(SOURCE_ID)).thenReturn(source);
+    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+
+    when(config.getName()).thenReturn("test");
+    when(config.getSource()).thenReturn(SOURCE_ID);
+    when(config.getDestination()).thenReturn(DESTINATION_ID);
+    when(configManager.objects()).thenReturn(configStream);
+
+    // when
+    runner.scheduleReplication();
+
+    // then
+    verify(replicator, never()).submitSyncRequest(any(SyncRequest.class));
+  }
+
+  @Test
+  public void testConfigNotRunWhenConfigDestinationIsDisabledLocal() throws Exception {
+    ReplicationSite source = mockSite(SOURCE_ID, false);
+    ReplicationSite destination = mockSite(DESTINATION_ID, true);
+    when(siteManager.get(SOURCE_ID)).thenReturn(source);
+    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+
+    when(config.getName()).thenReturn("test");
+    when(config.getSource()).thenReturn(SOURCE_ID);
+    when(config.getDestination()).thenReturn(DESTINATION_ID);
+    when(configManager.objects()).thenReturn(configStream);
+
+    // when
+    runner.scheduleReplication();
+
+    // then
+    verify(replicator, never()).submitSyncRequest(any(SyncRequest.class));
   }
 
   @Test
@@ -134,5 +205,12 @@ public class ReplicatorRunnerTest {
     runner.replicateAsSystemUser();
     verify(security).runAsAdmin(any(PrivilegedAction.class));
     verify(security).runWithSubjectOrElevate(any(Callable.class));
+  }
+
+  private ReplicationSite mockSite(String id, boolean isDisabledLocal) {
+    ReplicationSite site = mock(ReplicationSite.class);
+    when(site.getId()).thenReturn(id);
+    when(site.isDisabledLocal()).thenReturn(isDisabledLocal);
+    return site;
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImplTest.java
@@ -14,6 +14,7 @@
 package org.codice.ditto.replication.api.impl.data;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
@@ -79,7 +80,24 @@ public class ReplicationSiteImplTest {
     assertThat(site.getId(), equalTo(TEST_ID));
     assertThat(site.getName(), equalTo(TEST_NAME));
     assertThat(site.getUrl(), equalTo(TEST_URL));
-    assertThat(site.getVersion(), equalTo(1));
+    assertThat(site.getVersion(), equalTo(2));
+  }
+
+  @Test
+  public void testReadVersionOnePopulatesDefaultRemoteManagedField() {
+    Map<String, Object> map = new HashMap<>();
+    map.put(ID, TEST_ID);
+    map.put(NAME, TEST_NAME);
+    map.put(URL, TEST_URL);
+    map.put(VERSION, 1);
+
+    site.fromMap(map);
+
+    assertThat(site.getId(), is(TEST_ID));
+    assertThat(site.getName(), is(TEST_NAME));
+    assertThat(site.getUrl(), is(TEST_URL));
+    assertThat(site.isRemoteManaged(), is(false));
+    assertThat(site.getVersion(), is(2));
   }
 
   private ReplicationSiteImpl loadSite(ReplicationSiteImpl site) {

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/legacy/OldSiteTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/legacy/OldSiteTest.java
@@ -56,6 +56,6 @@ public class OldSiteTest {
     assertThat(site.getId(), equalTo(TEST_ID));
     assertThat(site.getName(), equalTo(TEST_NAME));
     assertThat(site.getUrl(), equalTo(TEST_URL));
-    assertThat(site.getVersion(), equalTo(1));
+    assertThat(site.getVersion(), equalTo(2));
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
@@ -82,7 +82,7 @@ public class ReplicationPersistentStoreTest {
 
   private static final String DELETE_DATA = "deleteData";
 
-  private static final String IS_DISABLED_LOCAL = "is-disabled-local";
+  private static final String IS_DISABLED_LOCAL = "is-remote-managed";
 
   private PersistentStore mockPersistentStore;
 

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
@@ -82,7 +82,7 @@ public class ReplicationPersistentStoreTest {
 
   private static final String DELETE_DATA = "deleteData";
 
-  private static final String IS_DISABLED_LOCAL = "is-remote-managed";
+  private static final String IS_REMOTE_MANAGED = "is-remote-managed";
 
   private PersistentStore mockPersistentStore;
 
@@ -139,7 +139,7 @@ public class ReplicationPersistentStoreTest {
     map.put(NAME, NAME + num);
     map.put(URL, URL + num);
     map.put(VERSION, ReplicationSiteImpl.CURRENT_VERSION);
-    map.put(IS_DISABLED_LOCAL, false);
+    map.put(IS_REMOTE_MANAGED, false);
     return map;
   }
 

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
@@ -82,6 +82,8 @@ public class ReplicationPersistentStoreTest {
 
   private static final String DELETE_DATA = "deleteData";
 
+  private static final String IS_DISABLED_LOCAL = "is-disabled-local";
+
   private PersistentStore mockPersistentStore;
 
   private ReplicationPersistentStore persistentStore;
@@ -137,6 +139,7 @@ public class ReplicationPersistentStoreTest {
     map.put(NAME, NAME + num);
     map.put(URL, URL + num);
     map.put(VERSION, ReplicationSiteImpl.CURRENT_VERSION);
+    map.put(IS_DISABLED_LOCAL, false);
     return map;
   }
 

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
@@ -47,10 +47,10 @@ public interface ReplicationSite extends Persistable {
   /**
    * See {@link #isRemoteManaged()}.
    *
-   * @param isRemoteManaged whether or not the local process is responsible for running replications
+   * @param remoteManaged whether or not the local process is responsible for running replications
    *     this site is associated with.
    */
-  void setIsRemoteManaged(boolean isRemoteManaged);
+  void setRemoteManaged(boolean remoteManaged);
 
   /**
    * When {@link false}, the local process is responsible for running {@link

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
@@ -43,4 +43,24 @@ public interface ReplicationSite extends Persistable {
    * @param url the URL to give this site
    */
   void setUrl(String url);
+
+  /**
+   * See {@link #isDisabledLocal()}.
+   *
+   * @param isDisabledLocal whether or not the local process is responsible for running replications
+   *     this site is associated with.
+   */
+  void setIsDisabledLocal(boolean isDisabledLocal);
+
+  /**
+   * When {@link false}, the local process is responsible for running {@link
+   * org.codice.ditto.replication.api.mcard.ReplicationConfig}s associated with this site.
+   *
+   * <p>When {@link true}, the local process is no longer responsible for performing replication for
+   * any {@link org.codice.ditto.replication.api.mcard.ReplicationConfig}s associated with this
+   * site. This effectively disables running replication locally.
+   *
+   * @return {@code true} if replication should not occur locally, otherwise {@link false}.
+   */
+  boolean isDisabledLocal();
 }

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
@@ -45,12 +45,12 @@ public interface ReplicationSite extends Persistable {
   void setUrl(String url);
 
   /**
-   * See {@link #isDisabledLocal()}.
+   * See {@link #isRemoteManaged()}.
    *
-   * @param isDisabledLocal whether or not the local process is responsible for running replications
+   * @param isRemoteManaged whether or not the local process is responsible for running replications
    *     this site is associated with.
    */
-  void setIsDisabledLocal(boolean isDisabledLocal);
+  void setIsRemoteManaged(boolean isRemoteManaged);
 
   /**
    * When {@link false}, the local process is responsible for running {@link
@@ -62,5 +62,5 @@ public interface ReplicationSite extends Persistable {
    *
    * @return {@code true} if replication should not run locally, otherwise {@link false}.
    */
-  boolean isDisabledLocal();
+  boolean isRemoteManaged();
 }

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
@@ -60,7 +60,7 @@ public interface ReplicationSite extends Persistable {
    * any {@link org.codice.ditto.replication.api.mcard.ReplicationConfig}s associated with this
    * site. This effectively disables running replication locally.
    *
-   * @return {@code true} if replication should not occur locally, otherwise {@link false}.
+   * @return {@code true} if replication should not run locally, otherwise {@link false}.
    */
   boolean isDisabledLocal();
 }


### PR DESCRIPTION
#### What does this PR do?
- Adds support for disabling local replication by site
- Addresses some tech-debt (unit tests, improvements to other graphql functions)

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @paouelle @kcover 

#### How should this be tested? (List steps with links to updated documentation)
Unit tests.

- Through a GraphiQL client, individually test updating a sites name, hostname, port and rootContext.

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
