### PR TITLE
[0.2.x] REP-87 Fix lastRun and lastSuccess not auto updating

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -35,6 +35,7 @@
     "react": "16.8.3",
     "react-apollo": "2.3.3",
     "react-dom": "16.8.3",
+    "react-interval": "2.0.2",
     "react-router-dom": "4.3.1",
     "unfetch": "4.1.0"
   },
@@ -74,7 +75,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 6,
+        "statements": 5,
         "branches": 6,
         "lines": 6,
         "functions": 1

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -6280,6 +6280,13 @@ react-hot-loader@4.6.3:
     shallowequal "^1.0.2"
     source-map "^0.7.3"
 
+react-interval@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-interval/-/react-interval-2.0.2.tgz#eb52690c79fde7125beaab6258e4d630d3f1f2ce"
+  integrity sha512-mdE3ZBcB0LQ5rMe/K1zstmIKJ4g23D3RCdRQjqxS2YVUMTMISNea9sIA5qy+7MOqwlYXF9bNGtoUfkrkrewwVw==
+  dependencies:
+    prop-types "^15.6.0"
+
 react-is@^16.3.2, react-is@^16.6.1, react-is@^16.6.3, react-is@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"


### PR DESCRIPTION
#### What does this PR do?
Adds a 1 minute interval that will update the relative time display of replication configurations even if their lastRun and lastSuccess dates don't change on polling.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @kcover @paouelle 

#### How should this be tested? (List steps with links to updated documentation)
- Setup 2 replications (to verify timers are independent)
- Make sure the date columns tick independently (can put one replication in inactive)

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #87 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
