### PR TITLE
UI support for displaying remote managed replications

### DIFF
--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
@@ -301,7 +301,7 @@ public class ReplicationUtils {
     address.port(url.getPort());
     field.address(address);
     field.rootContext(StringUtils.isEmpty(url.getPath()) ? DEFAULT_CONTEXT : url.getPath());
-    field.isDisableLocal(site.isRemoteManaged());
+    field.isRemoteManaged(site.isRemoteManaged());
     return field;
   }
 

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
@@ -94,8 +94,8 @@ public class ReplicationSiteField extends BaseObjectField {
     return this;
   }
 
-  public ReplicationSiteField isDisableLocal(boolean isDisableLocal) {
-    this.remoteManaged.setValue(isDisableLocal);
+  public ReplicationSiteField isRemoteManaged(boolean isRemoteManaged) {
+    this.remoteManaged.setValue(isRemoteManaged);
     return this;
   }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
     "@babel/polyfill": "7.2.5",
     "@material-ui/core": "3.9.2",
     "@material-ui/icons": "3.0.2",
+    "@material-ui/styles": "3.0.0-alpha.10",
     "apollo-cache-inmemory": "1.5.1",
     "apollo-client": "2.5.1",
     "apollo-link-http": "1.5.14",
@@ -77,7 +78,7 @@
       "global": {
         "statements": 5,
         "branches": 5,
-        "lines": 6,
+        "lines": 5,
         "functions": 1
       }
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -76,7 +76,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 5,
-        "branches": 6,
+        "branches": 5,
         "lines": 6,
         "functions": 1
       }

--- a/ui/src/main/webapp/components/replications/RemoteReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/RemoteReplicationsTable.js
@@ -26,6 +26,9 @@ const styles = {
   title: {
     flex: '0 0 auto',
   },
+  actions: {
+    float: 'right',
+  },
 }
 
 function RemoteReplicationsTable(props) {
@@ -41,7 +44,6 @@ function RemoteReplicationsTable(props) {
         <Typography variant='h6' id='tableTitle' className={classes.title}>
           {'Remote Managed Replications'}
           <Tooltip
-            className={classes.tooltip}
             title='Replications in this table are remotely managed by the Cloud because one of the source or destination Nodes has been identified as a Cloud ready Node. They will be run by the Cloud and statistics for these Replications will not be available locally.'
             placement='bottom'
           >
@@ -79,6 +81,7 @@ function RemoteReplicationsTable(props) {
                     }}
                     aria-label='More'
                     aria-owns={anchor !== null ? 'actions-menu' : undefined}
+                    className={classes.actions}
                   >
                     <MoreVert />
                   </IconButton>

--- a/ui/src/main/webapp/components/replications/RemoteReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/RemoteReplicationsTable.js
@@ -1,0 +1,101 @@
+import React from 'react'
+import {
+  Paper,
+  Table,
+  TableHead,
+  TableCell,
+  TableBody,
+  TableRow,
+  IconButton,
+  Typography,
+  Toolbar,
+  Tooltip,
+} from '@material-ui/core'
+import { MoreVert } from '@material-ui/icons'
+import HelpIcon from '@material-ui/icons/Help'
+import Immutable from 'immutable'
+import { withStyles } from '@material-ui/core/styles'
+import ActionsMenu from './ActionsMenu'
+import Replications from './replications'
+
+const styles = {
+  root: {
+    width: '100%',
+    overflowX: 'auto',
+  },
+  title: {
+    flex: '0 0 auto',
+  },
+}
+
+function RemoteReplicationsTable(props) {
+  const [anchor, setAnchor] = React.useState(null)
+  const [selectedReplication, setSelectedReplication] = React.useState({})
+
+  const { replications, classes } = props
+  const sorted = Immutable.List(replications.sort(Replications.repSort))
+
+  return (
+    <Paper className={classes.root}>
+      <Toolbar>
+        <Typography variant='h6' id='tableTitle' className={classes.title}>
+          {'Remote Managed Replications'}
+          <Tooltip
+            className={classes.tooltip}
+            title='Replications in this table are remotely managed by the Cloud because one of the source or destination Nodes has been identified as a Cloud ready Node. They will be run by the Cloud and statistics for these Replications will not be available locally.'
+            placement='bottom'
+          >
+            <HelpIcon fontSize='small' />
+          </Tooltip>
+        </Typography>
+      </Toolbar>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Source</TableCell>
+            <TableCell>Destination</TableCell>
+            <TableCell>Bidirectional</TableCell>
+            <TableCell>Suspended</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sorted &&
+            sorted.map(replication => (
+              <TableRow key={replication.id}>
+                <TableCell component='th'>{replication.name}</TableCell>
+                <TableCell>{replication.source.name}</TableCell>
+                <TableCell>{replication.destination.name}</TableCell>
+                <TableCell>
+                  {replication.biDirectional ? 'Yes' : 'No'}
+                </TableCell>
+                <TableCell>{replication.suspended ? 'Yes' : 'No'}</TableCell>
+                <TableCell>
+                  <IconButton
+                    onClick={e => {
+                      setSelectedReplication(replication)
+                      setAnchor(e.currentTarget)
+                    }}
+                    aria-label='More'
+                    aria-owns={anchor !== null ? 'actions-menu' : undefined}
+                  >
+                    <MoreVert />
+                  </IconButton>
+
+                  <ActionsMenu
+                    menuId='actions-menu'
+                    replication={selectedReplication}
+                    anchorEl={anchor}
+                    onClose={() => setAnchor(null)}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+        </TableBody>
+      </Table>
+    </Paper>
+  )
+}
+
+export default withStyles(styles)(RemoteReplicationsTable)

--- a/ui/src/main/webapp/components/replications/ReplicationsContainer.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsContainer.js
@@ -21,6 +21,7 @@ import { withStyles } from '@material-ui/core/styles'
 import Immutable from 'immutable'
 import ServerError from '../common/ServerError'
 import CenteredCircularProgress from '../common/CenteredCircularProgress'
+import RemoteReplicationsTable from './RemoteReplicationsTable'
 
 const styles = {
   expandingCard: {
@@ -51,6 +52,12 @@ const AddButton = props => {
     <Button color='primary' variant='outlined' onClick={props.onClick}>
       <Typography color='inherit'>Add Replication</Typography>
     </Button>
+  )
+}
+
+function sourceOrDestinationRemoteManaged(replication) {
+  return (
+    replication.source.remoteManaged || replication.destination.remoteManaged
   )
 }
 
@@ -86,10 +93,19 @@ function ReplicationsContainer(props) {
           data.replication.replications.length > 0
         ) {
           const activeReplications = Immutable.List(
-            data.replication.replications.filter(r => !r.suspended)
+            data.replication.replications.filter(
+              r => !r.suspended && !sourceOrDestinationRemoteManaged(r)
+            )
           )
           const inactiveReplications = Immutable.List(
-            data.replication.replications.filter(r => r.suspended)
+            data.replication.replications.filter(
+              r => r.suspended && !sourceOrDestinationRemoteManaged(r)
+            )
+          )
+          const remoteManagedReplications = Immutable.List(
+            data.replication.replications.filter(r =>
+              sourceOrDestinationRemoteManaged(r)
+            )
           )
 
           return (
@@ -110,6 +126,14 @@ function ReplicationsContainer(props) {
                   <ReplicationsTable
                     title='Inactive Replications'
                     replications={inactiveReplications}
+                  />
+                </div>
+              )}
+
+              {remoteManagedReplications.size > 0 && (
+                <div style={{ marginTop: 10 }}>
+                  <RemoteReplicationsTable
+                    replications={remoteManagedReplications}
                   />
                 </div>
               )}

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -40,6 +40,9 @@ const styles = {
   title: {
     flex: '0 0 auto',
   },
+  actions: {
+    float: 'right',
+  },
 }
 
 const format = utc => {
@@ -89,6 +92,7 @@ class ReplicationRow extends React.Component {
         <TableCell>{this.state.lastSuccess}</TableCell>
         <TableCell>
           <IconButton
+            className={classes.actions}
             onClick={this.handleClickOpen(replication)}
             aria-label='More'
             aria-owns={this.state.anchor !== null ? 'actions-menu' : undefined}

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -11,7 +11,7 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import {
   Paper,
@@ -27,12 +27,12 @@ import {
 import { MoreVert } from '@material-ui/icons'
 import moment from 'moment'
 import Immutable from 'immutable'
-import { withStyles } from '@material-ui/core/styles'
 import ActionsMenu from './ActionsMenu'
 import Replications from './replications'
 import ReactInterval from 'react-interval'
+import { makeStyles } from '@material-ui/styles'
 
-const styles = {
+const useStyles = makeStyles({
   root: {
     width: '100%',
     overflowX: 'auto',
@@ -43,120 +43,109 @@ const styles = {
   actions: {
     float: 'right',
   },
-}
+})
 
 const format = utc => {
   return utc ? moment.utc(utc).fromNow() : '-'
 }
 
-class ReplicationRow extends React.Component {
-  state = {
-    anchor: null,
-    lastRun: format(this.props.replication.lastRun),
-    lastSuccess: format(this.props.replication.lastSuccess),
-  }
+function ReplicationRow(props) {
+  const [anchor, setAnchor] = useState(null)
+  const [selectedReplication, setSelectedReplication] = useState({})
+  const [lastRun, setLastRun] = useState(format(props.replication.lastRun))
+  const [lastSuccess, setLastSuccess] = useState(
+    format(props.replication.lastSuccess)
+  )
+  const classes = useStyles()
 
-  handleClickOpen = replication => event => {
-    this.setState({ replication, anchor: event.currentTarget })
-  }
+  const { replication } = props
 
-  handleClose = () => {
-    this.setState({ anchor: null })
-  }
+  return (
+    <TableRow>
+      <ReactInterval
+        enabled={true}
+        timeout={60000}
+        callback={() => {
+          setLastRun(format(replication.lastRun))
+          setLastSuccess(format(replication.lastSuccess))
+        }}
+      />
 
-  render() {
-    const { replication } = this.props
-
-    return (
-      <TableRow>
-        <ReactInterval
-          enabled={true}
-          timeout={60000}
-          callback={() => {
-            this.setState({
-              lastRun: format(replication.lastRun),
-              lastSuccess: format(replication.lastSuccess),
-            })
+      <TableCell component='th'>{replication.name}</TableCell>
+      <TableCell>{Replications.statusDisplayName(replication)}</TableCell>
+      <TableCell>{replication.source.name}</TableCell>
+      <TableCell>{replication.destination.name}</TableCell>
+      <TableCell>{replication.biDirectional ? 'Yes' : 'No'}</TableCell>
+      <TableCell>{replication.filter}</TableCell>
+      <TableCell>{replication.itemsTransferred}</TableCell>
+      <TableCell>{replication.dataTransferred}</TableCell>
+      <TableCell>{lastRun}</TableCell>
+      <TableCell>{lastSuccess}</TableCell>
+      <TableCell>
+        <IconButton
+          className={classes.actions}
+          onClick={e => {
+            setSelectedReplication(replication)
+            setAnchor(e.currentTarget)
           }}
+          aria-label='More'
+          aria-owns={anchor !== null ? 'actions-menu' : undefined}
+        >
+          <MoreVert />
+        </IconButton>
+
+        <ActionsMenu
+          menuId='actions-menu'
+          replication={selectedReplication}
+          anchorEl={anchor}
+          onClose={() => setAnchor(null)}
         />
-
-        <TableCell component='th'>{replication.name}</TableCell>
-        <TableCell>{Replications.statusDisplayName(replication)}</TableCell>
-        <TableCell>{replication.source.name}</TableCell>
-        <TableCell>{replication.destination.name}</TableCell>
-        <TableCell>{replication.biDirectional ? 'Yes' : 'No'}</TableCell>
-        <TableCell>{replication.filter}</TableCell>
-        <TableCell>{replication.itemsTransferred}</TableCell>
-        <TableCell>{replication.dataTransferred}</TableCell>
-        <TableCell>{this.state.lastRun}</TableCell>
-        <TableCell>{this.state.lastSuccess}</TableCell>
-        <TableCell>
-          <IconButton
-            className={classes.actions}
-            onClick={this.handleClickOpen(replication)}
-            aria-label='More'
-            aria-owns={this.state.anchor !== null ? 'actions-menu' : undefined}
-          >
-            <MoreVert />
-          </IconButton>
-
-          <ActionsMenu
-            menuId='actions-menu'
-            replication={this.state.replication}
-            anchorEl={this.state.anchor}
-            onClose={this.handleClose}
-          />
-        </TableCell>
-      </TableRow>
-    )
-  }
+      </TableCell>
+    </TableRow>
+  )
 }
 
-class ReplicationsTable extends React.Component {
-  render() {
-    const { replications, title, classes } = this.props
-    const sorted = Immutable.List(replications.sort(Replications.repSort))
+function ReplicationsTable(props) {
+  const { replications, title } = props
+  const classes = useStyles()
+  const sorted = Immutable.List(replications.sort(Replications.repSort))
 
-    return (
-      <Paper className={classes.root}>
-        <Toolbar>
-          <Typography variant='h6' id='tableTitle' className={classes.title}>
-            {title}
-          </Typography>
-        </Toolbar>
-        <Table>
-          <TableHead>
-            <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Last Run Status</TableCell>
-              <TableCell>Source</TableCell>
-              <TableCell>Destination</TableCell>
-              <TableCell>Bidirectional</TableCell>
-              <TableCell>Filter</TableCell>
-              <TableCell>Items Transferred</TableCell>
-              <TableCell>MB Transferred</TableCell>
-              <TableCell>Last Run</TableCell>
-              <TableCell>Last Success</TableCell>
-              <TableCell />
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {sorted &&
-              sorted.map(replication => (
-                <ReplicationRow
-                  key={replication.id}
-                  replication={replication}
-                />
-              ))}
-          </TableBody>
-        </Table>
-      </Paper>
-    )
-  }
+  return (
+    <Paper className={classes.root}>
+      <Toolbar>
+        <Typography variant='h6' id='tableTitle' className={classes.title}>
+          {title}
+        </Typography>
+      </Toolbar>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Last Run Status</TableCell>
+            <TableCell>Source</TableCell>
+            <TableCell>Destination</TableCell>
+            <TableCell>Bidirectional</TableCell>
+            <TableCell>Filter</TableCell>
+            <TableCell>Items Transferred</TableCell>
+            <TableCell>MB Transferred</TableCell>
+            <TableCell>Last Run</TableCell>
+            <TableCell>Last Success</TableCell>
+            <TableCell />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sorted &&
+            sorted.map(replication => (
+              <ReplicationRow key={replication.id} replication={replication} />
+            ))}
+        </TableBody>
+      </Table>
+    </Paper>
+  )
 }
 
 ReplicationsTable.propTypes = {
   replications: PropTypes.object.isRequired,
 }
 
-export default withStyles(styles)(ReplicationsTable)
+export default ReplicationsTable

--- a/ui/src/main/webapp/components/replications/gql/fragments.js
+++ b/ui/src/main/webapp/components/replications/gql/fragments.js
@@ -1,0 +1,25 @@
+import gql from 'graphql-tag'
+import { sites } from '../../sites/gql/fragments'
+
+export const replications = gql`
+  fragment ReplicationConfig on ReplicationConfigPayload {
+    name
+    id
+    source {
+      ...ReplicationSite
+    }
+    destination {
+      ...ReplicationSite
+    }
+    lastRun
+    lastSuccess
+    firstRun
+    biDirectional
+    replicationStatus
+    filter
+    itemsTransferred
+    dataTransferred
+    suspended
+  }
+  ${sites}
+`

--- a/ui/src/main/webapp/components/replications/gql/mutations.js
+++ b/ui/src/main/webapp/components/replications/gql/mutations.js
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 import gql from 'graphql-tag'
+import { replications } from './fragments'
 
 export const addReplication = gql`
   mutation createReplication(
@@ -28,33 +29,10 @@ export const addReplication = gql`
       filter: $filter
       biDirectional: $biDirectional
     ) {
-      name
-      id
-      source {
-        id
-        name
-        address {
-          url
-        }
-      }
-      destination {
-        id
-        name
-        address {
-          url
-        }
-      }
-      lastRun
-      lastSuccess
-      firstRun
-      biDirectional
-      replicationStatus
-      filter
-      itemsTransferred
-      dataTransferred
-      suspended
+      ...ReplicationConfig
     }
   }
+  ${replications}
 `
 export const suspendReplication = gql`
   mutation suspendReplication($id: Pid!, $suspend: Boolean!) {

--- a/ui/src/main/webapp/components/replications/gql/queries.js
+++ b/ui/src/main/webapp/components/replications/gql/queries.js
@@ -12,37 +12,15 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 import gql from 'graphql-tag'
+import { replications } from './fragments'
 
 export const allReplications = gql`
   {
     replication {
       replications {
-        id
-        name
-        source {
-          id
-          name
-          address {
-            url
-          }
-        }
-        destination {
-          id
-          name
-          address {
-            url
-          }
-        }
-        lastRun
-        lastSuccess
-        firstRun
-        biDirectional
-        replicationStatus
-        itemsTransferred
-        dataTransferred
-        filter
-        suspended
+        ...ReplicationConfig
       }
     }
   }
+  ${replications}
 `

--- a/ui/src/main/webapp/components/sites/Site.js
+++ b/ui/src/main/webapp/components/sites/Site.js
@@ -22,6 +22,7 @@ import {
   Tooltip,
 } from '@material-ui/core'
 import DeleteForever from '@material-ui/icons/DeleteForever'
+import Cloud from '@material-ui/icons/Cloud'
 import CardActions from '@material-ui/core/CardActions'
 import { Mutation } from 'react-apollo'
 import { allSites } from './gql/queries'
@@ -58,7 +59,14 @@ const styles = {
 
 class Site extends React.Component {
   render() {
-    const { name, content, id, classes, enqueueSnackbar } = this.props
+    const {
+      name,
+      content,
+      remoteManaged,
+      id,
+      classes,
+      enqueueSnackbar,
+    } = this.props
 
     return (
       <Card className={classes.card}>
@@ -138,6 +146,11 @@ class Site extends React.Component {
               {content}
             </Typography>
           </Tooltip>
+          {remoteManaged ? (
+            <Tooltip title='This Node has been identified as Cloud ready and any Replication involving this Node will be remotely managed, and will no longer run locally.'>
+              <Cloud />
+            </Tooltip>
+          ) : null}
         </CardContent>
       </Card>
     )
@@ -148,6 +161,7 @@ Site.propTypes = {
   name: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  remoteManaged: PropTypes.bool.isRequired,
 }
 
 export default withStyles(styles)(withSnackbar(Site))

--- a/ui/src/main/webapp/components/sites/Sites.js
+++ b/ui/src/main/webapp/components/sites/Sites.js
@@ -27,6 +27,7 @@ export default function Sites(props) {
             name={site.name}
             content={site.address.url}
             id={site.id}
+            remoteManaged={site.remoteManaged}
           />
         ))}
     </Fragment>

--- a/ui/src/main/webapp/components/sites/gql/fragments.js
+++ b/ui/src/main/webapp/components/sites/gql/fragments.js
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag'
+
+export const sites = gql`
+  fragment ReplicationSite on ReplicationSitePayload {
+    id
+    name
+    remoteManaged
+    address {
+      url
+    }
+  }
+`

--- a/ui/src/main/webapp/components/sites/gql/mutations.js
+++ b/ui/src/main/webapp/components/sites/gql/mutations.js
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 import gql from 'graphql-tag'
+import { sites } from './fragments'
 
 export const deleteSite = gql`
   mutation deleteReplicationSite($id: Pid!) {
@@ -29,12 +30,9 @@ export const addSite = gql`
       address: $address
       rootContext: $rootContext
     ) {
-      id
-      name
-      address {
-        url
-      }
+      ...ReplicationSite
       rootContext
     }
   }
+  ${sites}
 `

--- a/ui/src/main/webapp/components/sites/gql/queries.js
+++ b/ui/src/main/webapp/components/sites/gql/queries.js
@@ -12,17 +12,15 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 import gql from 'graphql-tag'
+import { sites } from './fragments'
 
 export const allSites = gql`
   {
     replication {
       sites {
-        id
-        name
-        address {
-          url
-        }
+        ...ReplicationSite
       }
     }
   }
+  ${sites}
 `

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -690,6 +690,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.3.1":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
+  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -732,6 +739,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@emotion/hash@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
+  integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==
+
 "@material-ui/core@3.9.2":
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.9.2.tgz#41ed1a470e981d199829eb5d9317a671c66a6f7d"
@@ -772,6 +784,28 @@
   dependencies:
     "@babel/runtime" "^7.2.0"
     recompose "0.28.0 - 0.30.0"
+
+"@material-ui/styles@3.0.0-alpha.10":
+  version "3.0.0-alpha.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-3.0.0-alpha.10.tgz#4c28a6d6dacb1fb71aff4642f92b63232a3f298d"
+  integrity sha512-qJ5eiupBPRCNlMCDZ2G5h8auBtBtm8uT/oCUAJ/FqhO5oC7POLmmvDN1Cq1cgAmqQnaL6uN5mAM1Gc90GpKr9A==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    "@emotion/hash" "^0.7.1"
+    "@material-ui/utils" "^3.0.0-alpha.2"
+    classnames "^2.2.5"
+    deepmerge "^3.0.0"
+    hoist-non-react-statics "^3.2.1"
+    jss "^10.0.0-alpha.7"
+    jss-plugin-camel-case "^10.0.0-alpha.7"
+    jss-plugin-default-unit "^10.0.0-alpha.7"
+    jss-plugin-global "^10.0.0-alpha.7"
+    jss-plugin-nested "^10.0.0-alpha.7"
+    jss-plugin-props-sort "^10.0.0-alpha.7"
+    jss-plugin-rule-value-function "^10.0.0-alpha.7"
+    jss-plugin-vendor-prefixer "^10.0.0-alpha.7"
+    prop-types "^15.6.0"
+    warning "^4.0.1"
 
 "@material-ui/system@^3.0.0-alpha.0":
   version "3.0.0-alpha.1"
@@ -2176,6 +2210,14 @@ css-vendor@^0.3.8:
   resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
   integrity sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=
   dependencies:
+    is-in-browser "^1.0.2"
+
+css-vendor@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-1.2.1.tgz#21b914913d3a68bab2708090dab2e61db7c9eaec"
+  integrity sha512-ZpwiWxn5jWNJ7NF3DAb/Dc/+c2lRu+fnovej/adCv3VJsULJSjdXEpUwRcq4fnpAAh98Hi7b0GDnlyoNFcdv1g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
     is-in-browser "^1.0.2"
 
 css-what@2.1:
@@ -4746,6 +4788,58 @@ jss-nested@^6.0.1:
   dependencies:
     warning "^3.0.0"
 
+jss-plugin-camel-case@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.7.tgz#7dcbd9acb6682f3102cb2d3356b4fd9642d93f17"
+  integrity sha512-Bwrav1ZB0XywdJW6TaEuFhKe1ZpZvUlESh3jsFOvebA9aFTYNCkmHMEqjA5+u9VMxksl3u77nnZHtukpxkzrBA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    hyphenate-style-name "^1.0.2"
+
+jss-plugin-default-unit@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.7.tgz#f6dd0a03d545e7bf243c062bae3a832ac8c5ff6d"
+  integrity sha512-auuJUbQaWMxoHOVFPrfZNZpZm9ab8PZeDyvey8nMt2lbokkmZ53UyAnM/1kNsg5BdAXTItcLDxDB3I4gwNU84g==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+jss-plugin-global@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.7.tgz#38ca390802b62da490afbaafc581552a81977729"
+  integrity sha512-OWeoW4szLDgRUKviST+xfilqa8O5uXJCW+O3YonheCRTRJg6rRzlE/b5pfYPoU9UtwvY9n7JvwBX5r3c1lMsEQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+jss-plugin-nested@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.7.tgz#03a89c8f7c1d570a3d5f16dae3e61f7f2edb0316"
+  integrity sha512-wsRzuIZXAc6WMjc61mREW9cUrDxgSI7dK/fx5c7a06IDUfSn+83NJ30J/RB4oBnbQW9SijV/muujz7IJqpn9Gw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.7.tgz#46f1809fcae0acc048d0047aa54a4b9b6973597d"
+  integrity sha512-KXOCaHUk1+KXqE0z3q66/w1fDoy+VsZvI77gLxOqTsTrvIKFLX0jarwXogW3CDlaPQQFTZ6JykJJXtPRTBlstA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+jss-plugin-rule-value-function@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.7.tgz#63df1078ac361dda67996e25291d90f7226ae59a"
+  integrity sha512-ett83hvIM69/LknmrWndrrdiDlfLfP+rneU5qP7gTOWJ7g1P9GuEL1Tc4CWdZUWBX+T58tgIBP0V1pzWCkP0QA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
+jss-plugin-vendor-prefixer@^10.0.0-alpha.7:
+  version "10.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.7.tgz#caa34eb0bc39f0c98f425e174fc220d1f1a8760a"
+  integrity sha512-YbIVgqq+dLimOBOEYggho1Iuc0roz4PJSZYyaok9n8JnXVIqPnxYJbr8+bMbvzJ5CL3eeJij/e7L2IPCceRKrA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    css-vendor "^1.1.0"
+
 jss-props-sort@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
@@ -4757,6 +4851,15 @@ jss-vendor-prefixer@^7.0.0:
   integrity sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==
   dependencies:
     css-vendor "^0.3.8"
+
+jss@^10.0.0-alpha.7:
+  version "10.0.0-alpha.16"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.0.0-alpha.16.tgz#0555e8b667e08dbd2cc94f6125be5a8b8b022833"
+  integrity sha512-HmKNNnr82TR5jkWjBcbrx/uim2ief588pWp7zsf4GQpL125zRkEaWYL1SXv5bR6bBvAoTtvJsTAOxDIlLxUNZg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 jss@^9.8.7:
   version "9.8.7"
@@ -6468,6 +6571,11 @@ regenerator-runtime@^0.12.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
 regenerator-transform@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.3.tgz#264bd9ff38a8ce24b06e0636496b2c856b57bcbb"
@@ -7407,6 +7515,11 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-warning@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
+  integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
#### What does this PR do?
- Adds support for identifying cloud ready Nodes
- Adds support for displaying Replications with a source or destination cloud ready Node in a separate table.
- Add GraphQL Fragments which define sets of query fields that can be shared across multiple requests to help keep them in sync better.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@kcover @clockard @paouelle 

#### How should this be tested? (List steps with links to updated documentation)
- Create cloud node, put a debug point in the Node update method and before saving. Use GraphiQL client to send an update to that node and set its remoteManaged field to true.
- Verify the Node displays the cloud icon.
- Create a replication with that node and verify it is displayed in the new table.
- Try to run the replication and verify it does not run.

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)
![CloudNode](https://user-images.githubusercontent.com/17572782/57725636-76872c00-7642-11e9-8854-f574d4d8ee7d.PNG)
![CloudReplication](https://user-images.githubusercontent.com/17572782/57725642-7850ef80-7642-11e9-8fdf-ff9f356647e0.PNG)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
