### PR TITLE
REPL-95 Modified replication site to add verified url.

### DIFF
--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
@@ -356,7 +356,7 @@ public class ReplicationUtilsTest {
     ReplicationStatusImpl status = new ReplicationStatusImpl("test");
     status.setStatus(Status.PUSH_IN_PROGRESS);
     when(history.getReplicationEvents("test")).thenReturn(new ArrayList<>());
-    SyncRequestImpl syncRequest = new SyncRequestImpl(config, status);
+    SyncRequestImpl syncRequest = new SyncRequestImpl(config, src, dest, status);
     when(replicator.getActiveSyncRequests()).thenReturn(Collections.singleton(syncRequest));
     ReplicationField field = utils.updateReplication("id", "test", "srcId", "destId", "cql", true);
     assertThat(field.name(), is("test"));

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -328,17 +328,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.57</minimum>
+                                            <minimum>0.59</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.54</minimum>
+                                            <minimum>0.56</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/HeartbeaterAndVerifierImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/HeartbeaterAndVerifierImpl.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api.impl;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+import java.util.concurrent.ExecutorService;
+import org.codice.ddf.security.common.Security;
+import org.codice.ditto.replication.api.Heartbeater;
+import org.codice.ditto.replication.api.ReplicatorHistory;
+import org.codice.ditto.replication.api.Verifier;
+import org.codice.ditto.replication.api.data.ReplicationSite;
+import org.codice.ditto.replication.api.persistence.SiteManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides an implementation for both the {@link Verifier} and {@link Heartbeater} services capable
+ * of communicating with either Ion or DDF systems.
+ */
+public class HeartbeaterAndVerifierImpl implements Verifier, Heartbeater {
+  private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeaterAndVerifierImpl.class);
+
+  @SuppressWarnings("unused")
+  private final ReplicatorHistory history;
+
+  private final SiteManager siteManager;
+
+  private final ExecutorService executor;
+
+  private final Security security;
+
+  public HeartbeaterAndVerifierImpl(
+      ReplicatorHistory history, SiteManager siteManager, ExecutorService executor) {
+    this(history, siteManager, executor, Security.getInstance());
+  }
+
+  public HeartbeaterAndVerifierImpl(
+      ReplicatorHistory history,
+      SiteManager siteManager,
+      ExecutorService executor,
+      Security security) {
+    this.history = notNull(history);
+    this.executor = notNull(executor);
+    this.siteManager = notNull(siteManager);
+    this.security = security;
+  }
+
+  /** Initializes the heartbeat and verification service. */
+  public void init() {
+    LOGGER.trace("Initializing the heartbeater and verifier");
+  }
+
+  /** Cleanups the heartbeat and verification service. */
+  public void cleanUp() {
+    LOGGER.trace("Cleaning the heartbeater and verifier");
+    LOGGER.trace(
+        "Shutting down now the single-thread scheduler that executes sync requests from the queue");
+    executor.shutdownNow();
+    LOGGER.trace("Successfully shut down heartbeater thread pool and scheduler");
+  }
+
+  @Override
+  public void verify(ReplicationSite site) {
+    final String url = site.getUrl();
+
+    // For now, fake the verification until implemented
+    site.setVerifiedUrl(url);
+    siteManager.save(site);
+  }
+
+  @Override
+  public void heartbeat(ReplicationSite site) throws InterruptedException {
+    // do nothing for now
+    // schedule the heartbeat to occur on another thread
+    // if the heartbeat fails, get all configurations that involves that site
+    //   and mark their status to Status.CONNECTION_LOST if the current status was XXXX_IN_PROGRESS
+    //   and to Status.CONNECTION_UNAVAILABLE for any other status
+    // if the heartbeat succeeds, get all configurations that involves that site
+    //   and if their current status is Status.CONNECTION_LOST or Status.CONNECTION_UNAVAILABLE,
+    //   mark their status to Status.PENDING indicating the remote end should restart soon to
+    //   replicate. For all other status, leave untouched
+  }
+}

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
@@ -60,8 +60,14 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
 
   private String name;
 
+  /** This is the configured URL for the site. */
   private String url;
 
+  /**
+   * The verified url corresponds to the URL that should be used to replicate to/from or send a
+   * heartbeat to this site. It will typically be the same as the configured url above but you be
+   * changed if permanent redirects are received.
+   */
   @Nullable private String verifiedUrl = null;
 
   public ReplicationSiteImpl() {

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationStatusImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationStatusImpl.java
@@ -25,29 +25,29 @@ public class ReplicationStatusImpl implements ReplicationStatus {
 
   private final String replicatorName;
 
-  private Date startTime;
+  private volatile Date startTime;
 
-  @Nullable private Date lastSuccess;
+  @Nullable private volatile Date lastSuccess;
 
-  @Nullable private Date lastRun;
+  @Nullable private volatile Date lastRun;
 
-  @Nullable private Date lastMetadataModified;
+  @Nullable private volatile Date lastMetadataModified;
 
-  private long duration = -1;
+  private volatile long duration = -1;
 
-  private Status status = Status.PENDING;
+  private volatile Status status = Status.PENDING;
 
-  private long pushCount = 0;
+  private volatile long pushCount = 0;
 
-  private long pullCount = 0;
+  private volatile long pullCount = 0;
 
-  private long pushFailCount = 0;
+  private volatile long pushFailCount = 0;
 
-  private long pullFailCount = 0;
+  private volatile long pullFailCount = 0;
 
-  private long pushBytes = 0;
+  private volatile long pushBytes = 0;
 
-  private long pullBytes = 0;
+  private volatile long pullBytes = 0;
 
   public ReplicationStatusImpl(String replicatorName) {
     this.replicatorName = replicatorName;

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/SyncRequestImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/SyncRequestImpl.java
@@ -16,22 +16,44 @@ package org.codice.ditto.replication.api.impl.data;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.codice.ditto.replication.api.ReplicationStatus;
 import org.codice.ditto.replication.api.SyncRequest;
+import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 
+/** Provides a simple implementation for the {@link SyncRequest} interface. */
 public class SyncRequestImpl implements SyncRequest {
 
   private ReplicatorConfig config;
 
+  private ReplicationSite source;
+
+  private ReplicationSite destination;
+
   private ReplicationStatus status;
 
-  public SyncRequestImpl(ReplicatorConfig config, ReplicationStatus status) {
+  public SyncRequestImpl(
+      ReplicatorConfig config,
+      ReplicationSite source,
+      ReplicationSite destination,
+      ReplicationStatus status) {
     this.config = config;
+    this.source = source;
+    this.destination = destination;
     this.status = status;
   }
 
   @Override
   public ReplicatorConfig getConfig() {
     return config;
+  }
+
+  @Override
+  public ReplicationSite getSource() {
+    return source;
+  }
+
+  @Override
+  public ReplicationSite getDestination() {
+    return destination;
   }
 
   @Override
@@ -54,6 +76,8 @@ public class SyncRequestImpl implements SyncRequest {
 
   @Override
   public String toString() {
-    return String.format("SyncRequestImpl{config=%s, status=%s}", config, status);
+    return String.format(
+        "SyncRequestImpl{config=%s, source=%s, destination=%s, status=%s}",
+        config, source, destination, status);
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/legacy/OldSite.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/legacy/OldSite.java
@@ -22,5 +22,7 @@ public class OldSite extends ReplicationSiteImpl {
 
     setName((String) properties.get(NAME_KEY));
     setUrl((String) properties.get(URL_KEY));
+    setVerifiedUrl(getUrl()); // do this after setUrl()
+    setRemoteManaged(false);
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/SiteManagerImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/SiteManagerImpl.java
@@ -34,10 +34,13 @@ public class SiteManagerImpl implements SiteManager {
 
   private void createLocalSite() {
     if (!localSiteExistsAndIsCorrect()) {
-      ReplicationSite site = new ReplicationSiteImpl();
+      final ReplicationSite site = new ReplicationSiteImpl();
+      final String url = SystemBaseUrl.EXTERNAL.constructUrl(null, true);
+
       site.setId(LOCAL_SITE_ID);
       site.setName(SystemInfo.getSiteName());
-      site.setUrl(SystemBaseUrl.EXTERNAL.constructUrl(null, true));
+      site.setUrl(url);
+      site.setVerifiedUrl(url); // do this after setUrl()
       save(site);
     }
   }
@@ -50,9 +53,11 @@ public class SiteManagerImpl implements SiteManager {
     } catch (NotFoundException e) {
       return false;
     }
+    final String url = SystemBaseUrl.EXTERNAL.getBaseUrl();
 
     return site.getName().equals(SystemInfo.getSiteName())
-        && site.getUrl().equals(SystemBaseUrl.EXTERNAL.getBaseUrl());
+        && url.equals(site.getUrl())
+        && url.equals(site.getVerifiedUrl());
   }
 
   @Override

--- a/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -135,12 +135,33 @@
 
     <service ref="historyService" interface="org.codice.ditto.replication.api.ReplicatorHistory"/>
 
+    <bean id="heartbeater_verifier" class="org.codice.ditto.replication.api.impl.HeartbeaterAndVerifierImpl"
+          init-method="init"
+          destroy-method="cleanUp">
+        <argument ref="historyService"/>
+        <argument ref="siteManager"/>
+        <argument ref="heartbeaterImplExecutor"/>
+    </bean>
+
+    <bean id="heartbeaterImplExecutor" class="java.util.concurrent.Executors"
+          factory-method="newSingleThreadScheduledExecutor">
+        <argument ref="heartbeaterImplThreadFactory"/>
+    </bean>
+
+    <bean id="heartbeaterImplThreadFactory" class="org.codice.ddf.platform.util.StandardThreadFactoryBuilder"
+          factory-method="newThreadFactory">
+        <argument value="heartbeaterImplProcessorThread"/>
+    </bean>
+
+    <service ref="heartbeater_verifier" interface="org.codice.ditto.replication.api.Heartbeater"/>
+    <service ref="heartbeater_verifier" interface="org.codice.ditto.replication.api.Verifier"/>
+
     <bean id="replicator" class="org.codice.ditto.replication.api.impl.ReplicatorImpl" init-method="init"
           destroy-method="cleanUp">
         <argument ref="catalogResourceStoreFactory"/>
         <argument ref="historyService"/>
         <argument ref="replicationItemManager"/>
-        <argument ref="siteManager"/>
+        <argument ref="heartbeater_verifier"/>
         <argument ref="replicatorImplExecutor"/>
         <argument ref="filterBuilder"/>
     </bean>
@@ -160,12 +181,14 @@
           destroy-method="destroy">
         <argument ref="replicatorRunnerExecutor"/>
         <argument ref="replicator"/>
+        <argument ref="heartbeater_verifier"/>
         <argument ref="configManager"/>
         <argument ref="siteManager"/>
     </bean>
 
     <bean id="replicatorRunnerExecutor" class="java.util.concurrent.Executors"
-          factory-method="newSingleThreadScheduledExecutor">
+          factory-method="newScheduledThreadPool">
+        <argument value="2"/>
         <argument ref="replicatorRunnerFactory"/>
     </bean>
 

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
@@ -16,6 +16,7 @@ package org.codice.ditto.replication.api.impl;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -35,12 +36,15 @@ import org.codice.ditto.replication.api.ReplicatorHistory;
 import org.codice.ditto.replication.api.ReplicatorStoreFactory;
 import org.codice.ditto.replication.api.Status;
 import org.codice.ditto.replication.api.SyncRequest;
+import org.codice.ditto.replication.api.Verifier;
 import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
+import org.codice.ditto.replication.api.impl.data.ReplicationSiteImpl;
 import org.codice.ditto.replication.api.impl.data.ReplicationStatusImpl;
 import org.codice.ditto.replication.api.impl.data.ReplicatorConfigImpl;
 import org.codice.ditto.replication.api.impl.data.SyncRequestImpl;
-import org.codice.ditto.replication.api.persistence.SiteManager;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,12 +56,20 @@ import org.mockito.stubbing.Answer;
 @RunWith(MockitoJUnitRunner.class)
 public class ReplicatorImplTest {
 
+  private static final String URL1 = "https://site1:1234";
+  private static final String URL2 = "https://site2:1234";
+  private static final String VERIFIED_SUFFIX = "/verified";
+  private static final String VERIFIED_URL1 =
+      ReplicatorImplTest.URL1 + ReplicatorImplTest.VERIFIED_SUFFIX;
+  private static final String VERIFIED_URL2 =
+      ReplicatorImplTest.URL2 + ReplicatorImplTest.VERIFIED_SUFFIX;
+
   ReplicatorImpl replicator;
 
   @Mock ReplicatorStoreFactory replicatorStoreFactory;
   @Mock ReplicatorHistory history;
   @Mock ReplicationItemManager persistentStore;
-  @Mock SiteManager siteManager;
+  @Mock Verifier verifier;
   @Mock ExecutorService executor;
   @Mock Security security;
 
@@ -65,6 +77,8 @@ public class ReplicatorImplTest {
   @Mock ReplicationStore store2;
   @Mock SyncHelper helper;
 
+  ReplicationSite site1;
+  ReplicationSite site2;
   ReplicatorConfigImpl config;
 
   @Before
@@ -75,10 +89,11 @@ public class ReplicatorImplTest {
             replicatorStoreFactory,
             history,
             persistentStore,
-            siteManager,
+            verifier,
             executor,
             builder,
             security) {
+          @Override
           SyncHelper createSyncHelper(
               ReplicationStore source,
               ReplicationStore destination,
@@ -89,19 +104,26 @@ public class ReplicatorImplTest {
         };
     Subject subject = mock(Subject.class);
     Answer answer =
-        new Answer() {
-          @Override
-          public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-            ((Runnable) invocationOnMock.getArguments()[0]).run();
-            return null;
-          }
+        i -> {
+          i.getArgumentAt(0, Runnable.class).run();
+          return null;
         };
     doAnswer(answer).when(subject).execute(any(Runnable.class));
     when(security.runAsAdmin(any(PrivilegedAction.class))).thenReturn(subject);
+    site1 = new ReplicationSiteImpl();
+    site1.setId("srcId");
+    site1.setName("source");
+    site1.setUrl(ReplicatorImplTest.URL1);
+    site1.setVerifiedUrl(ReplicatorImplTest.VERIFIED_URL1);
+    site2 = new ReplicationSiteImpl();
+    site2.setId("srcId");
+    site2.setName("destination");
+    site2.setUrl(ReplicatorImplTest.URL2);
+    site2.setVerifiedUrl(ReplicatorImplTest.VERIFIED_URL2);
     config = new ReplicatorConfigImpl();
     config.setName("test");
-    config.setSource("srcId");
-    config.setDestination("destId");
+    config.setSource(site1.getId());
+    config.setDestination(site2.getId());
     config.setId("id");
     config.setBidirectional(true);
     config.setFilter("cql");
@@ -110,27 +132,305 @@ public class ReplicatorImplTest {
 
   @Test
   public void executeSyncRequest() throws Exception {
-    ReplicationSite site1 = mock(ReplicationSite.class);
-    ReplicationSite site2 = mock(ReplicationSite.class);
-    when(site1.getUrl()).thenReturn("https://site1:1234");
-    when(site2.getUrl()).thenReturn("https://site2:1234");
-    when(siteManager.get("srcId")).thenReturn(site1);
-    when(siteManager.get("destId")).thenReturn(site2);
-    when(replicatorStoreFactory.createReplicatorStore(new URL("https://site1:1234")))
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
         .thenReturn(store1);
-    when(replicatorStoreFactory.createReplicatorStore(new URL("https://site2:1234")))
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
+        .thenReturn(store2);
+    when(store1.isAvailable()).thenReturn(true);
+    when(store2.isAvailable()).thenReturn(true);
+    SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.SUCCESS);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    when(helper.sync()).thenAnswer(i -> updateStatusAndReturnResponse(status, response));
+
+    replicator.executeSyncRequest(request);
+
+    verify(history).addReplicationEvent(status);
+    verify(helper, times(2)).sync();
+    verify(replicatorStoreFactory, times(2)).createReplicatorStore(any());
+    verify(store1).isAvailable();
+    verify(store2).isAvailable();
+    verify(verifier, never()).verify(any());
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.SUCCESS));
+  }
+
+  @Test
+  public void executeSyncRequestSourceSiteIsRemoteManaged() throws Exception {
+    site1.setRemoteManaged(true);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history, never()).addReplicationEvent(any());
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, never()).createReplicatorStore(any());
+    verify(store1, never()).isAvailable();
+    verify(store2, never()).isAvailable();
+    verify(verifier, never()).verify(any());
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.PENDING));
+  }
+
+  @Test
+  public void executeSyncRequestDestinationSiteIsRemoteManaged() throws Exception {
+    site2.setRemoteManaged(true);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history, never()).addReplicationEvent(any());
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, never()).createReplicatorStore(any());
+    verify(store1, never()).isAvailable();
+    verify(store2, never()).isAvailable();
+    verify(verifier, never()).verify(any());
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.PENDING));
+  }
+
+  @Test
+  public void executeSyncRequestSourceSiteNotVerifiedAndWontVerify() throws Exception {
+    site1.setVerifiedUrl(null);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history).addReplicationEvent(status);
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, never()).createReplicatorStore(any());
+    verify(store1, never()).isAvailable();
+    verify(store2, never()).isAvailable();
+    verify(verifier).verify(site1);
+    verify(verifier, never()).verify(site2);
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.CONNECTION_UNAVAILABLE));
+  }
+
+  @Test
+  public void executeSyncRequestDestinationSiteNotVerifiedAndWontVerify() throws Exception {
+    site2.setVerifiedUrl(null);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
+        .thenReturn(store1);
+    when(store1.isAvailable()).thenReturn(true);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history).addReplicationEvent(status);
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, never()).createReplicatorStore(any());
+    verify(store1, never()).isAvailable();
+    verify(store2, never()).isAvailable();
+    verify(verifier, never()).verify(site1);
+    verify(verifier).verify(site2);
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.CONNECTION_UNAVAILABLE));
+  }
+
+  @Test
+  public void executeSyncRequestSourceSiteNotVerifiedThenVerifiesAsLocal() throws Exception {
+    site1.setVerifiedUrl(null);
+    doAnswer(this::setVerifiedUrl).when(verifier).verify(site1);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
+        .thenReturn(store1);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
+        .thenReturn(store2);
+    when(store1.isAvailable()).thenReturn(true);
+    when(store2.isAvailable()).thenReturn(true);
+    SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.SUCCESS);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    when(helper.sync()).thenAnswer(i -> updateStatusAndReturnResponse(status, response));
+
+    replicator.executeSyncRequest(request);
+
+    verify(history).addReplicationEvent(status);
+    verify(helper, times(2)).sync();
+    verify(replicatorStoreFactory, times(2)).createReplicatorStore(any());
+    verify(store1).isAvailable();
+    verify(store2).isAvailable();
+    verify(verifier).verify(site1);
+    verify(verifier, never()).verify(site2);
+
+    Assert.assertThat(site1.getVerifiedUrl(), Matchers.equalTo(ReplicatorImplTest.VERIFIED_URL1));
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.SUCCESS));
+  }
+
+  @Test
+  public void executeSyncRequestDestinationSiteNotVerifiedThenVerifiesAsLocal() throws Exception {
+    site2.setVerifiedUrl(null);
+    doAnswer(this::setVerifiedUrl).when(verifier).verify(site2);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
+        .thenReturn(store1);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
+        .thenReturn(store2);
+    when(store1.isAvailable()).thenReturn(true);
+    when(store2.isAvailable()).thenReturn(true);
+    SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.SUCCESS);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    when(helper.sync()).thenAnswer(i -> updateStatusAndReturnResponse(status, response));
+
+    replicator.executeSyncRequest(request);
+
+    verify(history).addReplicationEvent(status);
+    verify(helper, times(2)).sync();
+    verify(replicatorStoreFactory, times(2)).createReplicatorStore(any());
+    verify(store1).isAvailable();
+    verify(store2).isAvailable();
+    verify(verifier, never()).verify(site1);
+    verify(verifier).verify(site2);
+
+    Assert.assertThat(site2.getVerifiedUrl(), Matchers.equalTo(ReplicatorImplTest.VERIFIED_URL2));
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.SUCCESS));
+  }
+
+  @Test
+  public void executeSyncRequestSourceSiteNotVerifiedThenVerifiesAsRemote() throws Exception {
+    site1.setVerifiedUrl(null);
+    doAnswer(this::setVerifiedUrlAndSetAsRemote).when(verifier).verify(site1);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history, never()).addReplicationEvent(any());
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, never()).createReplicatorStore(any());
+    verify(verifier).verify(site1);
+    verify(verifier, never()).verify(site2);
+
+    Assert.assertThat(site1.getVerifiedUrl(), Matchers.equalTo(ReplicatorImplTest.VERIFIED_URL1));
+    Assert.assertThat(site1.isRemoteManaged(), Matchers.equalTo(true));
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.PENDING));
+  }
+
+  @Test
+  public void executeSyncRequestDestinationSiteNotVerifiedThenVerifiesAsRemote() throws Exception {
+    site2.setVerifiedUrl(null);
+    doAnswer(this::setVerifiedUrlAndSetAsRemote).when(verifier).verify(site2);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history, never()).addReplicationEvent(any());
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, never()).createReplicatorStore(any());
+    verify(verifier, never()).verify(site1);
+    verify(verifier).verify(site2);
+
+    Assert.assertThat(site2.getVerifiedUrl(), Matchers.equalTo(ReplicatorImplTest.VERIFIED_URL2));
+    Assert.assertThat(site2.isRemoteManaged(), Matchers.equalTo(true));
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.PENDING));
+  }
+
+  @Test
+  public void executeSyncRequestFailToCreateSourceStore() throws Exception {
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
+        .thenThrow(new RuntimeException("testing"));
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
         .thenReturn(store2);
     when(store1.isAvailable()).thenReturn(true);
     when(store2.isAvailable()).thenReturn(true);
     SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.SUCCESS);
     when(helper.sync()).thenReturn(response);
     ReplicationStatusImpl status = new ReplicationStatusImpl("test");
-    SyncRequest request = new SyncRequestImpl(config, status);
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
     replicator.executeSyncRequest(request);
+
     verify(history).addReplicationEvent(status);
-    verify(siteManager).get("srcId");
-    verify(siteManager).get("destId");
-    verify(helper, times(2)).sync();
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, times(1)).createReplicatorStore(any());
+    verify(store1, never()).isAvailable();
+    verify(store2, never()).isAvailable();
+    verify(verifier, never()).verify(any());
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.CONNECTION_UNAVAILABLE));
+  }
+
+  @Test
+  public void executeSyncRequestFailToCreateDestinationStore() throws Exception {
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
+        .thenReturn(store1);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
+        .thenThrow(new RuntimeException("testing"));
+    when(store1.isAvailable()).thenReturn(true);
+    when(store2.isAvailable()).thenReturn(true);
+    SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.SUCCESS);
+    when(helper.sync()).thenReturn(response);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history).addReplicationEvent(status);
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, times(2)).createReplicatorStore(any());
+    verify(store1).isAvailable();
+    verify(store2, never()).isAvailable();
+    verify(verifier, never()).verify(any());
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.CONNECTION_UNAVAILABLE));
+  }
+
+  @Test
+  public void executeSyncRequestSourceStoreIsNotAvailable() throws Exception {
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
+        .thenReturn(store1);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
+        .thenReturn(store2);
+    when(store1.isAvailable()).thenReturn(false);
+    when(store2.isAvailable()).thenReturn(true);
+    SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.SUCCESS);
+    when(helper.sync()).thenReturn(response);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history).addReplicationEvent(status);
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, times(1)).createReplicatorStore(any());
+    verify(store1).isAvailable();
+    verify(store2, never()).isAvailable();
+    verify(verifier, never()).verify(any());
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.CONNECTION_UNAVAILABLE));
+  }
+
+  @Test
+  public void executeSyncRequestDestinationStoreIsNotAvailable() throws Exception {
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
+        .thenReturn(store1);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
+        .thenReturn(store2);
+    when(store1.isAvailable()).thenReturn(true);
+    when(store2.isAvailable()).thenReturn(false);
+    SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.SUCCESS);
+    when(helper.sync()).thenReturn(response);
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
+    replicator.executeSyncRequest(request);
+
+    verify(history).addReplicationEvent(status);
+    verify(helper, never()).sync();
+    verify(replicatorStoreFactory, times(2)).createReplicatorStore(any());
+    verify(store1).isAvailable();
+    verify(store2).isAvailable();
+    verify(verifier, never()).verify(any());
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.CONNECTION_UNAVAILABLE));
   }
 
   @Test
@@ -138,41 +438,90 @@ public class ReplicatorImplTest {
     BlockingQueue<SyncRequest> queue = mock(BlockingQueue.class);
     replicator.setPendingSyncRequestsQueue(queue);
     ReplicationStatusImpl status = new ReplicationStatusImpl("test");
-    SyncRequest request = new SyncRequestImpl(config, status);
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+
     replicator.submitSyncRequest(request);
     verify(queue, times(1)).put(request);
+
     replicator.cancelSyncRequest(request);
     verify(queue, times(1)).remove(request);
   }
 
   @Test
   public void cancelActiveSyncRequest() throws Exception {
-    ReplicationSite site1 = mock(ReplicationSite.class);
-    ReplicationSite site2 = mock(ReplicationSite.class);
-    when(site1.getUrl()).thenReturn("https://site1:1234");
-    when(site2.getUrl()).thenReturn("https://site2:1234");
-    when(siteManager.get("srcId")).thenReturn(site1);
-    when(siteManager.get("destId")).thenReturn(site2);
-    when(replicatorStoreFactory.createReplicatorStore(new URL("https://site1:1234")))
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
         .thenReturn(store1);
-    when(replicatorStoreFactory.createReplicatorStore(new URL("https://site2:1234")))
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
         .thenReturn(store2);
     when(store1.isAvailable()).thenReturn(true);
     when(store2.isAvailable()).thenReturn(true);
     SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.CANCELED);
 
     ReplicationStatusImpl status = new ReplicationStatusImpl("test");
-    SyncRequest request = new SyncRequestImpl(config, status);
-    Answer answer =
-        new Answer() {
-          @Override
-          public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-            replicator.cancelSyncRequest(request);
-            return response;
-          }
-        };
-    when(helper.sync()).thenAnswer(answer);
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+    when(helper.sync()).thenAnswer(i -> cancelSyncRequest(status, response, request));
+
     replicator.executeSyncRequest(request);
+
     verify(helper).cancel();
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.CANCELED));
+  }
+
+  @Test
+  public void cancelActiveSyncRequestByConfigId() throws Exception {
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL1)))
+        .thenReturn(store1);
+    when(replicatorStoreFactory.createReplicatorStore(new URL(ReplicatorImplTest.VERIFIED_URL2)))
+        .thenReturn(store2);
+    when(store1.isAvailable()).thenReturn(true);
+    when(store2.isAvailable()).thenReturn(true);
+    SyncResponse response = new SyncResponse(1L, 0L, 10L, Status.CANCELED);
+
+    ReplicationStatusImpl status = new ReplicationStatusImpl("test");
+    SyncRequest request = new SyncRequestImpl(config, site1, site2, status);
+    when(helper.sync()).thenAnswer(i -> cancelSyncRequest(status, response, config));
+
+    replicator.submitSyncRequest(request);
+    replicator.executeSyncRequest(request);
+
+    verify(helper).cancel();
+
+    Assert.assertThat(status.getStatus(), Matchers.equalTo(Status.CANCELED));
+  }
+
+  private Void setVerifiedUrl(InvocationOnMock invocation) {
+    final ReplicationSite site = invocation.getArgumentAt(0, ReplicationSite.class);
+
+    site.setVerifiedUrl(site.getUrl() + ReplicatorImplTest.VERIFIED_SUFFIX);
+    return null;
+  }
+
+  private Void setVerifiedUrlAndSetAsRemote(InvocationOnMock invocation) {
+    final ReplicationSite site = invocation.getArgumentAt(0, ReplicationSite.class);
+
+    site.setVerifiedUrl(site.getUrl() + ReplicatorImplTest.VERIFIED_SUFFIX);
+    site.setRemoteManaged(true);
+    return null;
+  }
+
+  private SyncResponse updateStatusAndReturnResponse(
+      ReplicationStatusImpl status, SyncResponse response) {
+    status.setStatus(response.getStatus());
+    return response;
+  }
+
+  private SyncResponse cancelSyncRequest(
+      ReplicationStatusImpl status, SyncResponse response, SyncRequest request) {
+    replicator.cancelSyncRequest(request);
+    status.setStatus(response.getStatus());
+    return response;
+  }
+
+  private SyncResponse cancelSyncRequest(
+      ReplicationStatusImpl status, SyncResponse response, ReplicatorConfig config) {
+    replicator.cancelSyncRequest(config.getId());
+    status.setStatus(response.getStatus());
+    return response;
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorRunnerTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorRunnerTest.java
@@ -15,11 +15,13 @@ package org.codice.ditto.replication.api.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,15 +30,20 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.codice.ddf.security.common.Security;
+import org.codice.ditto.replication.api.Heartbeater;
 import org.codice.ditto.replication.api.Replicator;
 import org.codice.ditto.replication.api.SyncRequest;
 import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.persistence.ReplicatorConfigManager;
 import org.codice.ditto.replication.api.persistence.SiteManager;
-import org.junit.After;
+import org.codice.junit.ClearInterruptions;
+import org.codice.junit.RestoreSystemProperties;
+import org.codice.junit.rules.MethodRuleAnnotationProcessor;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -50,6 +57,16 @@ public class ReplicatorRunnerTest {
 
   private static final String DESTINATION_ID = "destinationId";
 
+  private static final String URL1 = "url1";
+  private static final String URL2 = "url2";
+  private static final String VERIFIED_PREFIX = "verified_";
+  private static final String VERIFIED_URL1 =
+      ReplicatorRunnerTest.VERIFIED_PREFIX + ReplicatorRunnerTest.URL1;
+  private static final String VERIFIED_URL2 =
+      ReplicatorRunnerTest.VERIFIED_PREFIX + ReplicatorRunnerTest.URL2;
+
+  @Rule public final MethodRuleAnnotationProcessor processor = new MethodRuleAnnotationProcessor();
+
   private ReplicatorRunner runner;
 
   @Mock Security security;
@@ -60,11 +77,11 @@ public class ReplicatorRunnerTest {
 
   @Mock ScheduledExecutorService scheduledExecutor;
 
-  private Stream<ReplicatorConfig> configStream;
-
   @Mock ReplicatorConfig config;
 
   @Mock SiteManager siteManager;
+
+  @Mock Heartbeater heartbeater;
 
   @Before
   public void setUp() throws Exception {
@@ -73,32 +90,38 @@ public class ReplicatorRunnerTest {
     when(security.runAsAdmin(any(PrivilegedAction.class)))
         .thenAnswer(invocation -> invocation.getArgumentAt(0, PrivilegedAction.class).run());
     runner =
-        new ReplicatorRunner(scheduledExecutor, replicator, configManager, siteManager, security);
-    configStream = Stream.of(config);
-  }
-
-  @After
-  public void after() {
-    System.clearProperty("org.codice.replication.period");
+        new ReplicatorRunner(
+            scheduledExecutor, replicator, heartbeater, configManager, siteManager, security);
   }
 
   @Test
   public void init() {
     ArgumentCaptor<Long> period = ArgumentCaptor.forClass(Long.class);
+
     runner.init();
-    verify(scheduledExecutor)
+
+    verify(scheduledExecutor, times(2))
         .scheduleAtFixedRate(any(Runnable.class), anyLong(), period.capture(), any(TimeUnit.class));
-    assertThat(period.getValue(), is(TimeUnit.MINUTES.toSeconds(5)));
+
+    assertThat(
+        period.getAllValues(),
+        contains(TimeUnit.MINUTES.toSeconds(5), TimeUnit.MINUTES.toSeconds(1)));
   }
 
+  @RestoreSystemProperties
   @Test
   public void initNonDefaultPeriod() {
     ArgumentCaptor<Long> period = ArgumentCaptor.forClass(Long.class);
+
     System.setProperty("org.codice.replication.period", "1");
+    System.setProperty("org.codice.replication.heartbeat.period", "2");
+
     runner.init();
-    verify(scheduledExecutor)
+
+    verify(scheduledExecutor, times(2))
         .scheduleAtFixedRate(any(Runnable.class), anyLong(), period.capture(), any(TimeUnit.class));
-    assertThat(period.getValue(), is(1L));
+
+    assertThat(period.getAllValues(), contains(1L, 2L));
   }
 
   @Test
@@ -109,15 +132,16 @@ public class ReplicatorRunnerTest {
 
   @Test
   public void scheduleReplication() throws Exception {
-    ReplicationSite source = mockSite(SOURCE_ID, false);
-    ReplicationSite destination = mockSite(DESTINATION_ID, false);
+    ReplicationSite source = mockSite(SOURCE_ID, false, URL1, VERIFIED_URL1);
+    ReplicationSite destination = mockSite(DESTINATION_ID, false, URL2, VERIFIED_URL2);
+    when(siteManager.objects()).thenReturn(Stream.of(source, destination));
     when(siteManager.get(SOURCE_ID)).thenReturn(source);
     when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
 
     when(config.getName()).thenReturn("test");
     when(config.getSource()).thenReturn(SOURCE_ID);
     when(config.getDestination()).thenReturn(DESTINATION_ID);
-    when(configManager.objects()).thenReturn(configStream);
+    when(configManager.objects()).thenReturn(Stream.of(config));
 
     ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
 
@@ -125,32 +149,41 @@ public class ReplicatorRunnerTest {
     runner.scheduleReplication();
 
     // then
+    verify(source, never()).setVerifiedUrl(any());
+    verify(destination, never()).setVerifiedUrl(any());
     verify(replicator).submitSyncRequest(request.capture());
     assertThat(request.getValue().getConfig().getName(), is("test"));
   }
 
   @Test
   public void scheduleReplicationWithSuspend() throws Exception {
-    ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
+    when(siteManager.objects()).thenReturn(Stream.empty());
     when(config.getName()).thenReturn("test");
     when(config.isSuspended()).thenReturn(true);
-    when(configManager.objects()).thenReturn(configStream);
+    when(configManager.objects()).thenReturn(Stream.of(config));
+
+    ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
+
     runner.scheduleReplication();
+
     verify(replicator, never()).submitSyncRequest(request.capture());
   }
 
+  @ClearInterruptions
   @Test
   public void scheduleReplicationInterruptException() throws Exception {
-    ReplicationSite source = mockSite(SOURCE_ID, false);
-    ReplicationSite destination = mockSite(DESTINATION_ID, false);
+    ReplicationSite source = mockSite(SOURCE_ID, false, URL1, VERIFIED_URL1);
+    ReplicationSite destination = mockSite(DESTINATION_ID, false, URL2, VERIFIED_URL2);
+
+    when(siteManager.objects()).thenReturn(Stream.of(source, destination));
     when(siteManager.get(SOURCE_ID)).thenReturn(source);
     when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
-
     when(config.getName()).thenReturn("test");
     when(config.getSource()).thenReturn(SOURCE_ID);
     when(config.getDestination()).thenReturn(DESTINATION_ID);
-    when(configManager.objects()).thenReturn(configStream);
+    when(configManager.objects()).thenReturn(Stream.of(config));
     doThrow(new InterruptedException()).when(replicator).submitSyncRequest(any(SyncRequest.class));
+
     ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
 
     // when
@@ -159,58 +192,184 @@ public class ReplicatorRunnerTest {
     // then
     verify(replicator).submitSyncRequest(request.capture());
     assertThat(request.getValue().getConfig().getName(), is("test"));
+    assertThat(Thread.currentThread().isInterrupted(), is(true));
   }
 
   @Test
-  public void testConfigNotRunWhenConfigSourceIsRemoteManaged() throws Exception {
-    ReplicationSite source = mockSite(SOURCE_ID, true);
-    ReplicationSite destination = mockSite(DESTINATION_ID, false);
-    when(siteManager.get(SOURCE_ID)).thenReturn(source);
-    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+  public void scheduleReplicationWhereConfigNotRunWhenSourceIsNotFound() throws Exception {
+    ReplicationSite source = mockSite(SOURCE_ID, false, URL1, VERIFIED_URL1);
+    ReplicationSite destination = mockSite(DESTINATION_ID, false, URL2, VERIFIED_URL2);
 
+    when(siteManager.objects()).thenReturn(Stream.of(destination));
     when(config.getName()).thenReturn("test");
     when(config.getSource()).thenReturn(SOURCE_ID);
     when(config.getDestination()).thenReturn(DESTINATION_ID);
-    when(configManager.objects()).thenReturn(configStream);
+    when(configManager.objects()).thenReturn(Stream.of(config));
 
     // when
     runner.scheduleReplication();
 
     // then
-    verify(replicator, never()).submitSyncRequest(any(SyncRequest.class));
+    verify(replicator, never()).submitSyncRequest(any());
   }
 
   @Test
-  public void testConfigNotRunWhenConfigDestinationIsRemoteManaged() throws Exception {
-    ReplicationSite source = mockSite(SOURCE_ID, false);
-    ReplicationSite destination = mockSite(DESTINATION_ID, true);
-    when(siteManager.get(SOURCE_ID)).thenReturn(source);
-    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+  public void scheduleReplicationWhereConfigNotRunWhenDestinationIsNotFound() throws Exception {
+    ReplicationSite source = mockSite(SOURCE_ID, false, URL1, VERIFIED_URL1);
+    ReplicationSite destination = mockSite(DESTINATION_ID, false, URL2, VERIFIED_URL2);
 
+    when(siteManager.objects()).thenReturn(Stream.of(source));
     when(config.getName()).thenReturn("test");
     when(config.getSource()).thenReturn(SOURCE_ID);
     when(config.getDestination()).thenReturn(DESTINATION_ID);
-    when(configManager.objects()).thenReturn(configStream);
+    when(configManager.objects()).thenReturn(Stream.of(config));
 
     // when
     runner.scheduleReplication();
 
     // then
-    verify(replicator, never()).submitSyncRequest(any(SyncRequest.class));
+    verify(replicator, never()).submitSyncRequest(any());
+  }
+
+  @Test
+  public void scheduleReplicationWhereConfigNotRunWhenConfigSourceIsRemoteManaged()
+      throws Exception {
+    ReplicationSite source = mockSite(SOURCE_ID, true, URL1, VERIFIED_URL1);
+    ReplicationSite destination = mockSite(DESTINATION_ID, false, URL2, VERIFIED_URL2);
+
+    when(siteManager.objects()).thenReturn(Stream.of(source, destination));
+    when(siteManager.get(SOURCE_ID)).thenReturn(source);
+    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+    when(config.getName()).thenReturn("test");
+    when(config.getSource()).thenReturn(SOURCE_ID);
+    when(config.getDestination()).thenReturn(DESTINATION_ID);
+    when(configManager.objects()).thenReturn(Stream.of(config));
+
+    // when
+    runner.scheduleReplication();
+
+    // then
+    verify(replicator, never()).submitSyncRequest(any());
+  }
+
+  @Test
+  public void scheduleReplicationWhereConfigNotRunWhenConfigDestinationIsRemoteManaged()
+      throws Exception {
+    ReplicationSite source = mockSite(SOURCE_ID, false, URL1, VERIFIED_URL1);
+    ReplicationSite destination = mockSite(DESTINATION_ID, true, URL2, VERIFIED_URL2);
+
+    when(siteManager.objects()).thenReturn(Stream.of(source, destination));
+    when(siteManager.get(SOURCE_ID)).thenReturn(source);
+    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+    when(config.getName()).thenReturn("test");
+    when(config.getSource()).thenReturn(SOURCE_ID);
+    when(config.getDestination()).thenReturn(DESTINATION_ID);
+    when(configManager.objects()).thenReturn(Stream.of(config));
+
+    // when
+    runner.scheduleReplication();
+
+    // then
+    verify(replicator, never()).submitSyncRequest(any());
   }
 
   @Test
   public void scheduleReplicationAsSystemUser() throws Exception {
-    when(configManager.objects()).thenReturn(Stream.empty());
+    final ReplicationSite source = mockSite(SOURCE_ID, false, URL1, VERIFIED_URL1);
+    final ReplicationSite destination = mockSite(DESTINATION_ID, false, URL2, VERIFIED_URL2);
+
+    when(siteManager.objects()).thenReturn(Stream.of(source, destination));
+    when(siteManager.get(SOURCE_ID)).thenReturn(source);
+    when(siteManager.get(DESTINATION_ID)).thenReturn(destination);
+
+    when(config.getName()).thenReturn("test");
+    when(config.getSource()).thenReturn(SOURCE_ID);
+    when(config.getDestination()).thenReturn(DESTINATION_ID);
+    when(configManager.objects()).thenReturn(Stream.of(config));
+
+    ArgumentCaptor<SyncRequest> request = ArgumentCaptor.forClass(SyncRequest.class);
+
+    // when
     runner.replicateAsSystemUser();
+
+    // then
     verify(security).runAsAdmin(any(PrivilegedAction.class));
     verify(security).runWithSubjectOrElevate(any(Callable.class));
+    verify(source, never()).setVerifiedUrl(any());
+    verify(destination, never()).setVerifiedUrl(any());
+    verify(replicator).submitSyncRequest(request.capture());
+    assertThat(request.getValue().getConfig().getName(), is("test"));
   }
 
-  private ReplicationSite mockSite(String id, boolean isRemoteManaged) {
+  @Test
+  public void scheduleHeartbeat() throws Exception {
+    final ReplicationSite site1 = mockSite(SOURCE_ID, true, URL1, VERIFIED_URL1);
+    final ReplicationSite site2 = mockSite(DESTINATION_ID, true, URL2, VERIFIED_URL2);
+    final ReplicationSite site3 =
+        mockSite("id3", false, "url3", ReplicatorRunnerTest.VERIFIED_PREFIX + "url3");
+
+    when(siteManager.objects()).thenReturn(Stream.of(site1, site2, site3));
+
+    runner.scheduleHeartbeat();
+
+    verify(heartbeater).heartbeat(site1);
+    verify(heartbeater).heartbeat(site2);
+    verify(heartbeater, never()).heartbeat(site3);
+  }
+
+  @Test
+  public void scheduleHeartbeatWhenNotVerified() throws Exception {
+    final ReplicationSite site1 = mockSite(SOURCE_ID, true, URL1, VERIFIED_URL1);
+    final ReplicationSite site2 = mockSite(DESTINATION_ID, true, URL2, VERIFIED_URL2);
+    final ReplicationSite site3 = mockSite("id3", false, "url3", null);
+
+    when(siteManager.objects()).thenReturn(Stream.of(site1, site2, site3));
+
+    runner.scheduleHeartbeat();
+
+    verify(heartbeater).heartbeat(site1);
+    verify(heartbeater).heartbeat(site2);
+    verify(heartbeater).heartbeat(site3);
+  }
+
+  @ClearInterruptions
+  @Test
+  public void scheduleHeartbeatWhenInterrupted() throws Exception {
+    final ReplicationSite site1 = mockSite(SOURCE_ID, true, URL1, VERIFIED_URL1);
+    final ReplicationSite site2 = mockSite(DESTINATION_ID, true, URL2, VERIFIED_URL2);
+
+    when(siteManager.objects()).thenReturn(Stream.of(site1, site2));
+    doThrow(new InterruptedException("testing")).when(heartbeater).heartbeat(any());
+
+    runner.scheduleHeartbeat();
+
+    verify(heartbeater).heartbeat(site1);
+    verify(heartbeater).heartbeat(site2);
+    assertThat(Thread.currentThread().isInterrupted(), is(true));
+  }
+
+  @Test
+  public void scheduleHeartbeatAsSystemUser() throws Exception {
+    final ReplicationSite site1 = mockSite(SOURCE_ID, true, URL1, VERIFIED_URL1);
+    final ReplicationSite site2 = mockSite(DESTINATION_ID, true, URL2, VERIFIED_URL2);
+
+    when(siteManager.objects()).thenReturn(Stream.of(site1, site2));
+
+    runner.heartbeatAsSystemUser();
+
+    verify(security).runAsAdmin(any(PrivilegedAction.class));
+    verify(security).runWithSubjectOrElevate(any(Callable.class));
+    verify(heartbeater).heartbeat(site1);
+    verify(heartbeater).heartbeat(site2);
+  }
+
+  private ReplicationSite mockSite(
+      String id, boolean isRemoteManaged, String url, @Nullable String verifiedUrl) {
     ReplicationSite site = mock(ReplicationSite.class);
     when(site.getId()).thenReturn(id);
     when(site.isRemoteManaged()).thenReturn(isRemoteManaged);
+    when(site.getUrl()).thenReturn(url);
+    when(site.getVerifiedUrl()).thenReturn(verifiedUrl);
     return site;
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImplTest.java
@@ -14,6 +14,7 @@
 package org.codice.ditto.replication.api.impl.data;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -29,6 +30,10 @@ public class ReplicationSiteImplTest {
 
   private static final String URL = "url";
 
+  private static final String VERIFIED_URL = "verified-url";
+
+  private static final String IS_REMOTE_MANAGED_KEY = "is-remote-managed";
+
   private static final String VERSION = "version";
 
   private static final String TEST_ID = "testId";
@@ -36,6 +41,8 @@ public class ReplicationSiteImplTest {
   private static final String TEST_NAME = "testName";
 
   private static final String TEST_URL = "https://host:44";
+
+  private static final String TEST_VERIFIED_URL = "https://host2:44";
 
   private ReplicationSiteImpl site;
 
@@ -52,8 +59,16 @@ public class ReplicationSiteImplTest {
 
   @Test
   public void testSetGetUrl() {
+    site.setVerifiedUrl(TEST_VERIFIED_URL);
     site.setUrl(TEST_URL);
     assertThat(site.getUrl(), equalTo(TEST_URL));
+    assertThat(site.getVerifiedUrl(), nullValue());
+  }
+
+  @Test
+  public void testSetGetVerifiedUrl() {
+    site.setVerifiedUrl(TEST_VERIFIED_URL);
+    assertThat(site.getVerifiedUrl(), equalTo(TEST_VERIFIED_URL));
   }
 
   @Test
@@ -64,11 +79,61 @@ public class ReplicationSiteImplTest {
     assertThat(map.get(ID), equalTo(TEST_ID));
     assertThat(map.get(NAME), equalTo(TEST_NAME));
     assertThat(map.get(URL), equalTo(TEST_URL));
+    assertThat(map.get(VERIFIED_URL), equalTo(TEST_VERIFIED_URL));
+    assertThat(map.get(VERSION), equalTo(ReplicationSiteImpl.CURRENT_VERSION));
+  }
+
+  @Test
+  public void testWriteToMapNoVerifiedUrl() {
+    loadSite(site);
+    site.setVerifiedUrl(null);
+    Map<String, Object> map = site.toMap();
+
+    assertThat(map.get(ID), equalTo(TEST_ID));
+    assertThat(map.get(NAME), equalTo(TEST_NAME));
+    assertThat(map.get(URL), equalTo(TEST_URL));
+    assertThat(map.get(VERIFIED_URL), nullValue());
     assertThat(map.get(VERSION), equalTo(ReplicationSiteImpl.CURRENT_VERSION));
   }
 
   @Test
   public void testReadFromMap() {
+    Map<String, Object> map = new HashMap<>();
+    map.put(ID, TEST_ID);
+    map.put(NAME, TEST_NAME);
+    map.put(URL, TEST_URL);
+    map.put(VERIFIED_URL, TEST_VERIFIED_URL);
+    map.put(VERSION, ReplicationSiteImpl.CURRENT_VERSION);
+
+    site.fromMap(map);
+
+    assertThat(site.getId(), equalTo(TEST_ID));
+    assertThat(site.getName(), equalTo(TEST_NAME));
+    assertThat(site.getUrl(), equalTo(TEST_URL));
+    assertThat(site.getVerifiedUrl(), equalTo(TEST_VERIFIED_URL));
+    assertThat(site.getVersion(), equalTo(ReplicationSiteImpl.CURRENT_VERSION));
+  }
+
+  @Test
+  public void testReadFromMapWhenNotVerified() {
+    Map<String, Object> map = new HashMap<>();
+    map.put(ID, TEST_ID);
+    map.put(NAME, TEST_NAME);
+    map.put(URL, TEST_URL);
+    map.put(VERIFIED_URL, null);
+    map.put(VERSION, ReplicationSiteImpl.CURRENT_VERSION);
+
+    site.fromMap(map);
+
+    assertThat(site.getId(), equalTo(TEST_ID));
+    assertThat(site.getName(), equalTo(TEST_NAME));
+    assertThat(site.getUrl(), equalTo(TEST_URL));
+    assertThat(site.getVerifiedUrl(), nullValue());
+    assertThat(site.getVersion(), equalTo(ReplicationSiteImpl.CURRENT_VERSION));
+  }
+
+  @Test
+  public void testReadFromMapWhenNotVerifiedAndMapDoesNotHaveVerifiedUrl() {
     Map<String, Object> map = new HashMap<>();
     map.put(ID, TEST_ID);
     map.put(NAME, TEST_NAME);
@@ -80,11 +145,12 @@ public class ReplicationSiteImplTest {
     assertThat(site.getId(), equalTo(TEST_ID));
     assertThat(site.getName(), equalTo(TEST_NAME));
     assertThat(site.getUrl(), equalTo(TEST_URL));
-    assertThat(site.getVersion(), equalTo(2));
+    assertThat(site.getVerifiedUrl(), nullValue());
+    assertThat(site.getVersion(), equalTo(ReplicationSiteImpl.CURRENT_VERSION));
   }
 
   @Test
-  public void testReadVersionOnePopulatesDefaultRemoteManagedField() {
+  public void testReadVersionOne() {
     Map<String, Object> map = new HashMap<>();
     map.put(ID, TEST_ID);
     map.put(NAME, TEST_NAME);
@@ -96,14 +162,43 @@ public class ReplicationSiteImplTest {
     assertThat(site.getId(), is(TEST_ID));
     assertThat(site.getName(), is(TEST_NAME));
     assertThat(site.getUrl(), is(TEST_URL));
+    assertThat(site.getVerifiedUrl(), is(TEST_URL));
     assertThat(site.isRemoteManaged(), is(false));
-    assertThat(site.getVersion(), is(2));
+    assertThat(site.getVersion(), equalTo(ReplicationSiteImpl.CURRENT_VERSION));
+  }
+
+  @Test
+  public void testReadVersionTwo() {
+    Map<String, Object> map = new HashMap<>();
+    map.put(ID, TEST_ID);
+    map.put(NAME, TEST_NAME);
+    map.put(URL, TEST_URL);
+    map.put(IS_REMOTE_MANAGED_KEY, "true");
+    map.put(VERSION, 2);
+
+    site.fromMap(map);
+
+    assertThat(site.getId(), is(TEST_ID));
+    assertThat(site.getName(), is(TEST_NAME));
+    assertThat(site.getUrl(), is(TEST_URL));
+    assertThat(site.getVerifiedUrl(), is(TEST_URL));
+    assertThat(site.isRemoteManaged(), is(true));
+    assertThat(site.getVersion(), equalTo(ReplicationSiteImpl.CURRENT_VERSION));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testReadUnknownVersion() {
+    Map<String, Object> map = new HashMap<>();
+    map.put(VERSION, -1);
+
+    site.fromMap(map);
   }
 
   private ReplicationSiteImpl loadSite(ReplicationSiteImpl site) {
     site.setId(TEST_ID);
     site.setName(TEST_NAME);
     site.setUrl(TEST_URL);
+    site.setVerifiedUrl(TEST_VERIFIED_URL);
     return site;
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/legacy/OldSiteTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/legacy/OldSiteTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.codice.ditto.replication.api.impl.data.ReplicationSiteImpl;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,13 +50,15 @@ public class OldSiteTest {
     map.put(ID, TEST_ID);
     map.put(NAME, TEST_NAME);
     map.put(URL, TEST_URL);
-    map.put(VERSION, OldSite.CURRENT_VERSION);
+    map.put(VERSION, -9999);
 
     site.fromMap(map);
 
     assertThat(site.getId(), equalTo(TEST_ID));
     assertThat(site.getName(), equalTo(TEST_NAME));
     assertThat(site.getUrl(), equalTo(TEST_URL));
-    assertThat(site.getVersion(), equalTo(2));
+    assertThat(site.isRemoteManaged(), equalTo(false));
+    assertThat(site.getVerifiedUrl(), equalTo(TEST_URL));
+    assertThat(site.getVersion(), equalTo(ReplicationSiteImpl.CURRENT_VERSION));
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/ReplicationPersistentStoreTest.java
@@ -13,9 +13,9 @@
  */
 package org.codice.ditto.replication.api.impl.persistence;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -73,6 +73,8 @@ public class ReplicationPersistentStoreTest {
   private static final String SUSPENDED = "suspended";
 
   private static final String URL = "url";
+
+  private static final String VERIFIED_URL = "verified-url";
 
   private static final String VERSION = "version";
 
@@ -138,6 +140,7 @@ public class ReplicationPersistentStoreTest {
     map.put(ID, ID + num);
     map.put(NAME, NAME + num);
     map.put(URL, URL + num);
+    map.put(VERIFIED_URL, URL + "/verified/" + num);
     map.put(VERSION, ReplicationSiteImpl.CURRENT_VERSION);
     map.put(IS_REMOTE_MANAGED, false);
     return map;

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/SiteManagerImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/persistence/SiteManagerImplTest.java
@@ -14,6 +14,7 @@
 package org.codice.ditto.replication.api.impl.persistence;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -61,6 +62,7 @@ public class SiteManagerImplTest {
     ReplicationSite site = captor.getValue();
     assertThat(site.getName(), is(SystemInfo.getSiteName()));
     assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
+    assertThat(site.getVerifiedUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
   }
 
   @Test
@@ -76,6 +78,7 @@ public class SiteManagerImplTest {
     ReplicationSiteImpl site = captor.getValue();
     assertThat(site.getName(), is(SystemInfo.getSiteName()));
     assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
+    assertThat(site.getVerifiedUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
   }
 
   @Test
@@ -91,6 +94,7 @@ public class SiteManagerImplTest {
     ReplicationSiteImpl site = captor.getValue();
     assertThat(site.getName(), is(SystemInfo.getSiteName()));
     assertThat(site.getUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
+    assertThat(site.getVerifiedUrl(), is(SystemBaseUrl.EXTERNAL.constructUrl(null, true)));
   }
 
   @Test
@@ -99,6 +103,7 @@ public class SiteManagerImplTest {
     orig.setId(LOCAL_SITE_ID);
     orig.setName(SystemInfo.getSiteName());
     orig.setUrl(SystemBaseUrl.EXTERNAL.getBaseUrl());
+    orig.setVerifiedUrl(SystemBaseUrl.EXTERNAL.getBaseUrl());
     when(persistentStore.get(eq(ReplicationSiteImpl.class), anyString())).thenReturn(orig);
     siteManager.init();
     verify(persistentStore, never()).save(any(ReplicationSiteImpl.class));
@@ -118,6 +123,7 @@ public class SiteManagerImplTest {
     ReplicationSite site = siteManager.createSite("name", "url");
     assertThat(site.getName(), is("name"));
     assertThat(site.getUrl(), is("url"));
+    assertThat(site.getVerifiedUrl(), nullValue());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/Heartbeater.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/Heartbeater.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api;
+
+import org.codice.ditto.replication.api.data.ReplicationSite;
+
+/**
+ * This interface is design to provide various implementations capable of generating a heartbeat to
+ * sites.
+ */
+public interface Heartbeater {
+  /**
+   * Submit a request to generate a heartbeat to the specified site.
+   *
+   * @param site the site to send a heartbeat to and be updated if needed
+   * @throws InterruptedException if interrupted while submitting the request
+   */
+  void heartbeat(ReplicationSite site) throws InterruptedException;
+}

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/SyncRequest.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/SyncRequest.java
@@ -13,8 +13,14 @@
  */
 package org.codice.ditto.replication.api;
 
+import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 
+/**
+ * The {@link SyncRequest} interface gathers together information that is required to synchronize
+ * two sites together. It also provides access to a status that can be updated as part of the
+ * processing of this synchronization request.
+ */
 public interface SyncRequest {
 
   /**
@@ -23,6 +29,20 @@ public interface SyncRequest {
    * @return The configuration of this request
    */
   ReplicatorConfig getConfig();
+
+  /**
+   * Gets the source replication site associated with the configuration for this request.
+   *
+   * @return the source replication site
+   */
+  ReplicationSite getSource();
+
+  /**
+   * Gets the destination replication site associated with the configuration for this request.
+   *
+   * @return the destination replication site
+   */
+  ReplicationSite getDestination();
 
   /**
    * Get the status of this request. Status will be updated during processing.

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/Verifier.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/Verifier.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.api;
+
+import org.codice.ditto.replication.api.data.ReplicationSite;
+
+/**
+ * This interface is design to provide various implementations capable of verifying if a site is a
+ * remote one. The verification process is used to identify if sites should be managed locally or
+ * remotely. Remotely managed sites will not be replicated to or from here; the replication
+ * responsibility will be left to those sites.
+ */
+public interface Verifier {
+  /**
+   * Verifies the specified site.
+   *
+   * @param site the site to be verified and updated if needed
+   */
+  void verify(ReplicationSite site);
+}

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ditto.replication.api.data;
 
+import javax.annotation.Nullable;
+
 /** A ReplicationSite holds information about a system to be replicated to/from */
 public interface ReplicationSite extends Persistable {
 
@@ -38,11 +40,32 @@ public interface ReplicationSite extends Persistable {
   String getUrl();
 
   /**
-   * Set the URL of this site
+   * Set the URL of this site while clearing the verified URL.
    *
    * @param url the URL to give this site
    */
   void setUrl(String url);
+
+  /**
+   * Get the verified URL of this site. This should be the url to use to communicate with the site
+   * when replicating. This URL will be <code>null</code> until the URL reported by {@link
+   * #getUrl()} has been verified at which point the verified URL should be updated. It is also
+   * possible that this URL be changed later in cases where the site permanently redirected us to a
+   * new location at which point this new location should be saved as the new verified URL until
+   * such time when the URL is changed via {@link #setUrl(String)} which will automatically clear
+   * the verified URL.
+   *
+   * @return the verified site URL
+   */
+  @Nullable
+  String getVerifiedUrl();
+
+  /**
+   * Set the verified URL of this site.
+   *
+   * @param url the verified URL to give this site or <code>null</code> to clear the URL
+   */
+  void setVerifiedUrl(@Nullable String url);
 
   /**
    * See {@link #isRemoteManaged()}.


### PR DESCRIPTION
#### What does this PR do?
Modifies the replication site config to add verified-url.
Introduces heartbeater and verifier.
Provided place holder for heartbeat and verification which right now, simply auto-verify the sites by copying the url to the verified one.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard 
@peterhuffer 
@kcover 

#### How should this be tested? (List steps with links to updated documentation)
Configure replication and make sure it connects normally to start replication.

#### Any background context you want to provide?
The replicator was changed to use the verified url when replicating. If this one is null, it will attempt to verify the site first. The current implementation will automatically copy the url to the verified one. A follow up ticket will properly implement the verification and hearbeat process.

#### What are the relevant tickets?
Fixes #

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
