### PR TITLE
Support updating replication stats

### DIFF
--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -95,17 +95,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.80</minimum>
+                                            <minimum>0.83</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.79</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.67</minimum>
+                                            <minimum>0.71</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationFieldProvider.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationFieldProvider.java
@@ -27,6 +27,7 @@ import org.codice.ditto.replication.admin.query.sites.discover.GetReplicationSit
 import org.codice.ditto.replication.admin.query.sites.persist.CreateReplicationSite;
 import org.codice.ditto.replication.admin.query.sites.persist.DeleteReplicationSite;
 import org.codice.ditto.replication.admin.query.sites.persist.UpdateReplicationSite;
+import org.codice.ditto.replication.admin.query.status.persist.UpdateReplicationStats;
 import org.codice.ditto.replication.admin.query.ui.GetUiConfig;
 
 public class ReplicationFieldProvider extends BaseFieldProvider {
@@ -60,6 +61,8 @@ public class ReplicationFieldProvider extends BaseFieldProvider {
 
   private GetUiConfig getUiConfig;
 
+  private UpdateReplicationStats updateReplicationStats;
+
   public ReplicationFieldProvider(
       GetReplications getReplications,
       GetReplicationSites getReplicationSites,
@@ -71,7 +74,8 @@ public class ReplicationFieldProvider extends BaseFieldProvider {
       CreateReplicationSite createReplicationSite,
       UpdateReplicationSite updateReplicationSite,
       DeleteReplicationSite deleteReplicationSite,
-      GetUiConfig getUiConfig) {
+      GetUiConfig getUiConfig,
+      UpdateReplicationStats updateReplicationStats) {
     super(DEFAULT_FIELD_NAME, TYPE_NAME, DESCRIPTION);
     this.getReplications = getReplications;
     this.getReplicationSites = getReplicationSites;
@@ -84,6 +88,7 @@ public class ReplicationFieldProvider extends BaseFieldProvider {
     this.updateReplicationSite = updateReplicationSite;
     this.deleteReplicationSite = deleteReplicationSite;
     this.getUiConfig = getUiConfig;
+    this.updateReplicationStats = updateReplicationStats;
   }
 
   @Override
@@ -101,6 +106,7 @@ public class ReplicationFieldProvider extends BaseFieldProvider {
         updateReplicationSite,
         deleteReplicationSite,
         cancelReplication,
-        suspendReplication);
+        suspendReplication,
+        updateReplicationStats);
   }
 }

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationMessages.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationMessages.java
@@ -13,6 +13,7 @@
  */
 package org.codice.ditto.replication.admin.query;
 
+import java.util.List;
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.report.message.ErrorMessageImpl;
 
@@ -37,6 +38,8 @@ public class ReplicationMessages {
   public static final String DESTINATION_DOES_NOT_EXIST = "DESTINATION_DOES_NOT_EXIST";
 
   public static final String CONFIG_DOES_NOT_EXIST = "CONFIG_DOES_NOT_EXIST";
+
+  public static final String INVALID_ISO8601 = "INVALID_ISO8601";
 
   private ReplicationMessages() {}
 
@@ -70,5 +73,9 @@ public class ReplicationMessages {
 
   public static ErrorMessage destinationDoesNotExist() {
     return new ErrorMessageImpl(DESTINATION_DOES_NOT_EXIST);
+  }
+
+  public static ErrorMessage invalidIso8601(List<Object> path) {
+    return new ErrorMessageImpl(INVALID_ISO8601, path);
   }
 }

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/ReplicationUtils.java
@@ -50,8 +50,6 @@ public class ReplicationUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicationUtils.class);
 
-  private static final long BYTES_PER_MB = 1024L * 1024L;
-
   private static final String DEFAULT_CONTEXT = "services";
 
   private static final String NOT_RUN = "NOT_RUN";
@@ -286,8 +284,8 @@ public class ReplicationUtils {
       ReplicationStatus status = statusList.get(0);
       stats.setPid(status.getId());
       stats.setStatus(status.getStatus().name());
-      stats.setPullBytes(status.getPullBytes() / BYTES_PER_MB);
-      stats.setPushBytes(status.getPushBytes() / BYTES_PER_MB);
+      stats.setPullBytes(status.getPullBytes());
+      stats.setPushBytes(status.getPushBytes());
       stats.setPullCount(status.getPullCount());
       stats.setPushCount(status.getPushCount());
       stats.setPullFailCount(status.getPullFailCount());

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/fields/ReplicationField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/fields/ReplicationField.java
@@ -26,6 +26,7 @@ import org.codice.ddf.admin.common.fields.base.scalar.IntegerField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ditto.replication.admin.query.sites.fields.ReplicationSiteField;
+import org.codice.ditto.replication.admin.query.status.fields.ReplicationStats;
 
 public class ReplicationField extends BaseObjectField {
 
@@ -42,23 +43,13 @@ public class ReplicationField extends BaseObjectField {
 
   private CqlExpressionField filter;
 
-  private IntegerField itemsTransferred;
-
-  private StringField dataTransferred;
-
   private BooleanField biDirectional;
-
-  private ReplicationStatus status;
 
   private BooleanField suspended;
 
-  private DateField lastRun;
+  private ReplicationStats stats;
 
-  private DateField firstRun;
-
-  private DateField lastSuccess;
-
-  private DateField modified;
+  private Iso8601Field modified;
 
   private IntegerField version;
 
@@ -69,16 +60,11 @@ public class ReplicationField extends BaseObjectField {
     source = new ReplicationSiteField("source");
     destination = new ReplicationSiteField("destination");
     filter = new CqlExpressionField("filter");
-    itemsTransferred = new IntegerField("itemsTransferred");
-    dataTransferred = new StringField("dataTransferred");
     biDirectional = new BooleanField("biDirectional");
-    status = new ReplicationStatus();
     suspended = new BooleanField("suspended");
-    lastRun = new DateField("lastRun");
-    firstRun = new DateField("firstRun");
-    lastSuccess = new DateField("lastSuccess");
-    modified = new DateField("modified");
+    modified = new Iso8601Field("modified");
     version = new IntegerField("version");
+    stats = new ReplicationStats();
   }
 
   // setters
@@ -112,53 +98,17 @@ public class ReplicationField extends BaseObjectField {
     return this;
   }
 
-  public ReplicationField itemsTransferred(int itemsTransferred) {
-    this.itemsTransferred.setValue(itemsTransferred);
+  public ReplicationField stats(ReplicationStats stats) {
+    this.stats = stats;
     return this;
   }
 
-  public ReplicationField dataTransferred(String dataTransferred) {
-    this.dataTransferred.setValue(dataTransferred);
-    return this;
-  }
-
-  public ReplicationField status(String status) {
-    this.status.setValue(status);
-    return this;
+  public ReplicationStats getStats() {
+    return this.stats;
   }
 
   public ReplicationField suspended(Boolean suspended) {
     this.suspended.setValue(suspended);
-    return this;
-  }
-
-  public ReplicationField lastRun(String last) {
-    this.lastRun.setValue(last);
-    return this;
-  }
-
-  public ReplicationField lastRun(Date last) {
-    this.lastRun.setValue(getInstantOrNull(last));
-    return this;
-  }
-
-  public ReplicationField firstRun(String first) {
-    this.firstRun.setValue(first);
-    return this;
-  }
-
-  public ReplicationField firstRun(Date first) {
-    this.firstRun.setValue(getInstantOrNull(first));
-    return this;
-  }
-
-  public ReplicationField lastSuccess(String success) {
-    this.lastSuccess.setValue(success);
-    return this;
-  }
-
-  public ReplicationField lastSuccess(Date success) {
-    this.lastSuccess.setValue(getInstantOrNull(success));
     return this;
   }
 
@@ -221,43 +171,11 @@ public class ReplicationField extends BaseObjectField {
     return biDirectional.getValue();
   }
 
-  public int itemsTransferred() {
-    return itemsTransferred.getValue();
-  }
-
-  public IntegerField itemsTransferredField() {
-    return itemsTransferred;
-  }
-
-  public String dataTransferred() {
-    return dataTransferred.getValue();
-  }
-
-  public StringField dataTransferredField() {
-    return dataTransferred;
-  }
-
-  public ReplicationStatus status() {
-    return status;
-  }
-
   public Boolean suspended() {
     return suspended.getValue();
   }
 
-  public DateField lastRun() {
-    return lastRun;
-  }
-
-  public DateField lastSuccess() {
-    return lastSuccess;
-  }
-
-  public DateField firstRun() {
-    return firstRun;
-  }
-
-  public DateField modified() {
+  public Iso8601Field modified() {
     return modified;
   }
 
@@ -268,21 +186,7 @@ public class ReplicationField extends BaseObjectField {
   @Override
   public List<Field> getFields() {
     return ImmutableList.of(
-        id,
-        name,
-        source,
-        destination,
-        filter,
-        itemsTransferred,
-        dataTransferred,
-        biDirectional,
-        status,
-        suspended,
-        lastRun,
-        lastSuccess,
-        firstRun,
-        modified,
-        version);
+        id, name, source, destination, filter, biDirectional, suspended, modified, version, stats);
   }
 
   public static class ListImpl extends BaseListField<ReplicationField> {

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/fields/ReplicationStatus.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/fields/ReplicationStatus.java
@@ -59,9 +59,9 @@ public class ReplicationStatus extends BaseEnumField<String> {
     private String value;
     private String description;
 
-    public ReplicationStatusEnum(String value, String desscription) {
+    public ReplicationStatusEnum(String value, String description) {
       this.value = value;
-      this.description = desscription;
+      this.description = description;
     }
 
     @Override

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
@@ -25,7 +25,7 @@ import org.codice.ddf.admin.common.fields.base.scalar.IntegerField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ddf.admin.common.fields.common.PidField;
-import org.codice.ditto.replication.admin.query.replications.fields.DateField;
+import org.codice.ditto.replication.admin.query.replications.fields.Iso8601Field;
 
 public class ReplicationSiteField extends BaseObjectField {
 
@@ -43,7 +43,7 @@ public class ReplicationSiteField extends BaseObjectField {
 
   private StringField rootContext;
 
-  private DateField modified;
+  private Iso8601Field modified;
 
   private IntegerField version;
 
@@ -59,7 +59,7 @@ public class ReplicationSiteField extends BaseObjectField {
     this.name = new StringField("name");
     this.address = new AddressField();
     this.rootContext = new StringField("rootContext");
-    this.modified = new DateField("modified");
+    this.modified = new Iso8601Field("modified");
     this.version = new IntegerField("version");
     this.remoteManaged = new RemoteManagedField();
   }
@@ -130,7 +130,7 @@ public class ReplicationSiteField extends BaseObjectField {
     return rootContext;
   }
 
-  public DateField modified() {
+  public Iso8601Field modified() {
     return modified;
   }
 

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/status/fields/ReplicationStats.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/status/fields/ReplicationStats.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.status.fields;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Date;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.codice.ddf.admin.api.Field;
+import org.codice.ddf.admin.common.fields.base.BaseObjectField;
+import org.codice.ddf.admin.common.fields.base.scalar.LongField;
+import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ditto.replication.admin.query.replications.fields.Iso8601Field;
+import org.codice.ditto.replication.admin.query.replications.fields.ReplicationStatus;
+
+public class ReplicationStats extends BaseObjectField {
+
+  private static final String FIELD_NAME = "stats";
+
+  private static final String FIELD_TYPE_NAME = "ReplicationStats";
+
+  private static final String DESCRIPTION = "Contains various statistics of a replication's run.";
+
+  private PidField pid;
+
+  private Iso8601Field startTime;
+
+  private Iso8601Field lastRun;
+
+  private Iso8601Field lastSuccess;
+
+  private LongField duration;
+
+  private ReplicationStatus status;
+
+  private LongField pushCount;
+
+  private LongField pullCount;
+
+  private LongField pushFailCount;
+
+  private LongField pullFailCount;
+
+  private LongField pushBytes;
+
+  private LongField pullBytes;
+
+  public ReplicationStats() {
+    super(FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
+    pid = new PidField();
+    startTime = new Iso8601Field("startTime");
+    lastRun = new Iso8601Field("lastRun");
+    lastSuccess = new Iso8601Field("lastSuccess");
+    duration = new LongField("duration");
+    status = new ReplicationStatus();
+    pushCount = new LongField("pushCount");
+    pullCount = new LongField("pullCount");
+    pushFailCount = new LongField("pushFailCount");
+    pullFailCount = new LongField("pullFailCount");
+    pushBytes = new LongField("pushBytes");
+    pullBytes = new LongField("pullBytes");
+
+    pid.isRequired(true);
+    startTime.isRequired(true);
+    lastRun.isRequired(true);
+    duration.isRequired(true);
+    status.isRequired(true);
+    pushCount.isRequired(true);
+    pullCount.isRequired(true);
+    pushFailCount.isRequired(true);
+    pullFailCount.isRequired(true);
+    pushBytes.isRequired(true);
+    pullBytes.isRequired(true);
+  }
+
+  @Override
+  public List<Field> getFields() {
+    return ImmutableList.of(
+        pid,
+        startTime,
+        lastRun,
+        lastSuccess,
+        duration,
+        status,
+        pushCount,
+        pullCount,
+        pushFailCount,
+        pullFailCount,
+        pushBytes,
+        pullBytes);
+  }
+
+  public void setPid(String pid) {
+    this.pid.setValue(pid);
+  }
+
+  public String getPid() {
+    return this.pid.getValue();
+  }
+
+  public void setStartTime(Date date) {
+    this.startTime.setValue(date.toInstant());
+  }
+
+  public String getStartTime() {
+    return this.startTime.getValue();
+  }
+
+  public void setLastRun(Date date) {
+    this.lastRun.setValue(date.toInstant());
+  }
+
+  public String getLastRun() {
+    return this.lastRun.getValue();
+  }
+
+  public void setLastSuccess(@Nullable Date date) {
+    if (date != null) {
+      this.lastSuccess.setValue(date.toInstant());
+    }
+  }
+
+  public String getLastSuccess() {
+    return this.lastSuccess.getValue();
+  }
+
+  public void setDuration(long duration) {
+    this.duration.setValue(duration);
+  }
+
+  public long getDuration() {
+    if (this.duration != null) {
+      return this.duration.getValue();
+    }
+    return 0L;
+  }
+
+  public void setStatus(String replicationStatus) {
+    this.status.setValue(replicationStatus);
+  }
+
+  public String getStatus() {
+    return this.status.getValue();
+  }
+
+  public void setPushCount(long pushCount) {
+    this.pushCount.setValue(pushCount);
+  }
+
+  public long getPushCount() {
+    return this.pushCount.getValue();
+  }
+
+  public void setPullCount(long pullCount) {
+    this.pullCount.setValue(pullCount);
+  }
+
+  public long getPullCount() {
+    return this.pullCount.getValue();
+  }
+
+  public void setPushFailCount(long pushFailCount) {
+    this.pushFailCount.setValue(pushFailCount);
+  }
+
+  public long getPushFailCount() {
+    return this.pushFailCount.getValue();
+  }
+
+  public void setPullFailCount(long pullFailCount) {
+    this.pullFailCount.setValue(pullFailCount);
+  }
+
+  public long getPullFailCount() {
+    return this.pullFailCount.getValue();
+  }
+
+  public void setPushBytes(long pushBytes) {
+    this.pushBytes.setValue(pushBytes);
+  }
+
+  public long getPushBytes() {
+    return this.pushBytes.getValue();
+  }
+
+  public void setPullBytes(long pullBytes) {
+    this.pullBytes.setValue(pullBytes);
+  }
+
+  public long getPullBytes() {
+    return this.pullBytes.getValue();
+  }
+}

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/status/persist/UpdateReplicationStats.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/status/persist/UpdateReplicationStats.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.status.persist;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Set;
+import org.codice.ddf.admin.api.Field;
+import org.codice.ddf.admin.api.fields.FunctionField;
+import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
+import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
+import org.codice.ditto.replication.admin.query.ReplicationUtils;
+import org.codice.ditto.replication.admin.query.status.fields.ReplicationStats;
+
+public class UpdateReplicationStats extends BaseFunctionField<BooleanField> {
+
+  private static final String FUNCTION_NAME = "updateReplicationStats";
+
+  private static final String DESCRIPTION =
+      "Updates an existing replication's stats based on the provided replication name.";
+
+  private static final BooleanField RETURN_TYPE = new BooleanField();
+
+  private final ReplicationUtils replicationUtils;
+
+  private ReplicationStats stats;
+
+  private StringField replicationName;
+
+  public UpdateReplicationStats(ReplicationUtils replicationUtils) {
+    super(FUNCTION_NAME, DESCRIPTION);
+    this.replicationUtils = replicationUtils;
+
+    stats = new ReplicationStats();
+    replicationName = new StringField("replicationName");
+    stats.isRequired(true);
+    replicationName.isRequired(true);
+  }
+
+  @Override
+  public BooleanField performFunction() {
+    return new BooleanField(replicationUtils.updateReplicationStats(replicationName, stats));
+  }
+
+  @Override
+  public Set<String> getFunctionErrorCodes() {
+    return ImmutableSet.of(DefaultMessages.NO_EXISTING_CONFIG);
+  }
+
+  @Override
+  public List<Field> getArguments() {
+    return ImmutableList.of(replicationName, stats);
+  }
+
+  @Override
+  public BooleanField getReturnType() {
+    return RETURN_TYPE;
+  }
+
+  @Override
+  public FunctionField<BooleanField> newInstance() {
+    return new UpdateReplicationStats(replicationUtils);
+  }
+
+  @Override
+  public void validate() {
+    super.validate();
+    if (containsErrorMsgs()) {
+      return;
+    }
+
+    if (!replicationUtils.replicationConfigExists(replicationName.getValue())) {
+      addErrorMessage(DefaultMessages.noExistingConfigError());
+    }
+  }
+}

--- a/admin/query/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/admin/query/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -60,6 +60,9 @@
     <bean id="getUiConfig" class="org.codice.ditto.replication.admin.query.ui.GetUiConfig">
         <argument ref="uiConfigurationFactory"/>
     </bean>
+    <bean id="updateReplicationStats" class="org.codice.ditto.replication.admin.query.status.persist.UpdateReplicationStats">
+        <argument ref="replicationUtils"/>
+    </bean>
 
     <service id="replicationFieldProvider" interface="org.codice.ddf.admin.api.FieldProvider">
         <bean class="org.codice.ditto.replication.admin.query.ReplicationFieldProvider">
@@ -74,6 +77,7 @@
             <argument ref="updateReplicationSite"/>
             <argument ref="deleteReplicationSite"/>
             <argument ref="getUiConfig"/>
+            <argument ref="updateReplicationStats"/>
         </bean>
     </service>
 </blueprint>

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
@@ -24,16 +24,20 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.crypto.tink.subtle.Random;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.stream.Stream;
 import javax.ws.rs.NotFoundException;
 import org.codice.ddf.admin.api.fields.ListField;
+import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ddf.admin.common.fields.common.HostField;
 import org.codice.ditto.replication.admin.query.replications.fields.ReplicationField;
 import org.codice.ditto.replication.admin.query.sites.fields.ReplicationSiteField;
+import org.codice.ditto.replication.admin.query.status.fields.ReplicationStats;
 import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.ReplicationPersistenceException;
 import org.codice.ditto.replication.api.ReplicationStatus;
@@ -62,6 +66,14 @@ public class ReplicationUtilsTest {
 
   private static final String SITE_ID = "siteId";
 
+  private static final String REP_ID = "repId";
+
+  private static final Date LAST_SUCCESS = new Date(Random.randInt(100));
+
+  private static final Date START_TIME = new Date(Random.randInt(100));
+
+  private static final Date LAST_RUN = new Date(Random.randInt(100));
+
   private ReplicationUtils utils;
 
   @Mock SiteManager siteManager;
@@ -82,7 +94,7 @@ public class ReplicationUtilsTest {
   @Test
   public void createSite() throws Exception {
     ReplicationSiteImpl site = new ReplicationSiteImpl();
-    site.setId("id");
+    site.setId(SITE_ID);
     site.setName("site");
     site.setUrl("https://localhost:1234");
 
@@ -94,7 +106,7 @@ public class ReplicationUtilsTest {
             });
     ReplicationSiteField field =
         utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), null, false);
-    assertThat(field.id(), is("id"));
+    assertThat(field.id(), is(SITE_ID));
     assertThat(field.name(), is("site"));
     assertThat(field.address().url(), is("https://localhost:1234/services"));
     verify(siteManager).save(any(ReplicationSiteImpl.class));
@@ -103,7 +115,7 @@ public class ReplicationUtilsTest {
   @Test
   public void createSiteWithContext() throws Exception {
     ReplicationSiteImpl site = new ReplicationSiteImpl();
-    site.setId("id");
+    site.setId(SITE_ID);
     site.setName("site");
     site.setUrl("https://localhost:1234/");
 
@@ -115,7 +127,7 @@ public class ReplicationUtilsTest {
             });
     ReplicationSiteField field =
         utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), "context", false);
-    assertThat(field.id(), is("id"));
+    assertThat(field.id(), is(SITE_ID));
     assertThat(field.name(), is("site"));
     assertThat(field.address().url(), is("https://localhost:1234/context"));
     verify(siteManager).save(any(ReplicationSiteImpl.class));
@@ -124,7 +136,7 @@ public class ReplicationUtilsTest {
   @Test
   public void createSiteWithContextWithSlashes() throws Exception {
     ReplicationSiteImpl site = new ReplicationSiteImpl();
-    site.setId("id");
+    site.setId(SITE_ID);
     site.setName("site");
     site.setUrl("https://localhost:1234/");
 
@@ -136,7 +148,7 @@ public class ReplicationUtilsTest {
             });
     ReplicationSiteField field =
         utils.createSite(site.getName(), getAddress(new URL(site.getUrl())), " // context ", false);
-    assertThat(field.id(), is("id"));
+    assertThat(field.id(), is(SITE_ID));
     assertThat(field.name(), is("site"));
     assertThat(field.address().url(), is("https://localhost:1234/context"));
     verify(siteManager).save(any(ReplicationSiteImpl.class));
@@ -145,7 +157,7 @@ public class ReplicationUtilsTest {
   @Test(expected = ReplicationException.class)
   public void getSiteFieldForSiteBadUrl() throws Exception {
     ReplicationSiteImpl site = new ReplicationSiteImpl();
-    site.setId("id");
+    site.setId(SITE_ID);
     site.setName("site");
     site.setUrl("NotSoGood.URL");
 
@@ -157,6 +169,7 @@ public class ReplicationUtilsTest {
 
   @Test
   public void createReplication() throws Exception {
+    // setup
     ReplicationSiteImpl src = new ReplicationSiteImpl();
     src.setId("srcId");
     src.setName("source");
@@ -175,21 +188,43 @@ public class ReplicationUtilsTest {
     status.setPushBytes(1024 * 1024 * 5L);
     status.setPullCount(2L);
     status.setPullBytes(1024 * 1024 * 10L);
+    status.setLastRun(LAST_RUN);
+    status.setLastSuccess(LAST_SUCCESS);
+    status.setStartTime(START_TIME);
+    status.setDuration(9L);
+    status.setPullFailCount(99L);
+    status.setPushFailCount(100L);
+    status.setStatus(Status.SUCCESS);
     when(history.getReplicationEvents("test")).thenReturn(Collections.singletonList(status));
     when(replicator.getActiveSyncRequests()).thenReturn(Collections.emptySet());
+
+    // when
     ReplicationField field = utils.createReplication("test", "srcId", "destId", "cql", true);
+
+    // then
     assertThat(field.name(), is("test"));
     assertThat(field.source().id(), is("srcId"));
     assertThat(field.destination().id(), is("destId"));
     assertThat(field.filter(), is("cql"));
     assertThat(field.biDirectional(), is(true));
-    assertThat(field.itemsTransferred(), is(3));
-    assertThat(field.dataTransferred(), is("15 MB"));
+    assertThat(field.getStats().getStatus(), is(Status.SUCCESS.toString()));
+    assertThat(field.getStats().getPushCount(), is(1L));
+    assertThat(field.getStats().getPullCount(), is(2L));
+    assertThat(field.getStats().getPushBytes(), is(5L));
+    assertThat(field.getStats().getPullBytes(), is(10L));
+    assertThat(field.getStats().getDuration(), is(9L));
+    assertThat(field.getStats().getPullFailCount(), is(99L));
+    assertThat(field.getStats().getPushFailCount(), is(100L));
+    assertThat(field.getStats().getLastRun(), is(LAST_RUN.toInstant().toString()));
+    assertThat(field.getStats().getLastSuccess(), is(LAST_SUCCESS.toInstant().toString()));
+    assertThat(field.getStats().getStartTime(), is(START_TIME.toInstant().toString()));
+
     verify(configManager).save(any(ReplicatorConfig.class));
   }
 
   @Test
   public void createReplicationNoHistory() throws Exception {
+    // setup
     ReplicationSiteImpl src = new ReplicationSiteImpl();
     src.setId("srcId");
     src.setName("source");
@@ -205,19 +240,33 @@ public class ReplicationUtilsTest {
 
     when(history.getReplicationEvents("test")).thenReturn(Collections.emptyList());
     when(replicator.getActiveSyncRequests()).thenReturn(Collections.emptySet());
+
+    // when
     ReplicationField field = utils.createReplication("test", "srcId", "destId", "cql", true);
+
+    // then
     assertThat(field.name(), is("test"));
     assertThat(field.source().id(), is("srcId"));
     assertThat(field.destination().id(), is("destId"));
     assertThat(field.filter(), is("cql"));
     assertThat(field.biDirectional(), is(true));
-    assertThat(field.itemsTransferred(), is(0));
-    assertThat(field.dataTransferred(), is("0 MB"));
+    assertThat(field.getStats().getStatus(), is("NOT_RUN"));
+    assertThat(field.getStats().getPushCount(), is(0L));
+    assertThat(field.getStats().getPullCount(), is(0L));
+    assertThat(field.getStats().getPushBytes(), is(0L));
+    assertThat(field.getStats().getPullBytes(), is(0L));
+    assertThat(field.getStats().getDuration(), is(0L));
+    assertThat(field.getStats().getPullFailCount(), is(0L));
+    assertThat(field.getStats().getPushFailCount(), is(0L));
+    assertThat(field.getStats().getLastRun(), is(nullValue()));
+    assertThat(field.getStats().getLastSuccess(), is(nullValue()));
+    assertThat(field.getStats().getStartTime(), is(nullValue()));
     verify(configManager).save(any(ReplicatorConfig.class));
   }
 
   @Test
   public void updateReplication() throws Exception {
+    // setup
     ReplicationSiteImpl src = new ReplicationSiteImpl();
     src.setId("srcId");
     src.setName("source");
@@ -231,26 +280,48 @@ public class ReplicationUtilsTest {
     when(siteManager.get("srcId")).thenReturn(src);
     when(siteManager.get("destId")).thenReturn(dest);
     ReplicatorConfigImpl config = new ReplicatorConfigImpl();
-    config.setId("id");
+    config.setId(REP_ID);
     config.setName("oldName");
     config.setFilter("oldCql");
     config.setFailureRetryCount(7);
-    when(configManager.get(anyString())).thenReturn(config);
+    when(configManager.get(REP_ID)).thenReturn(config);
     ReplicationStatus status = new ReplicationStatusImpl("test");
     status.setPushCount(1L);
-    status.setPushBytes(1024 * 1024 * 5L);
+    status.setPushBytes(5L);
     status.setPullCount(2L);
-    status.setPullBytes(1024 * 1024 * 10L);
+    status.setPullBytes(10L);
+    status.setLastRun(LAST_RUN);
+    status.setLastSuccess(LAST_SUCCESS);
+    status.setStartTime(START_TIME);
+    status.setDuration(9L);
+    status.setPullFailCount(99L);
+    status.setPushFailCount(100L);
+    status.setStatus(Status.SUCCESS);
     when(history.getReplicationEvents("test")).thenReturn(Collections.singletonList(status));
     when(replicator.getActiveSyncRequests()).thenReturn(Collections.emptySet());
-    ReplicationField field = utils.updateReplication("id", "test", "srcId", "destId", "cql", true);
+
+    // when
+    ReplicationField field =
+        utils.updateReplication(REP_ID, "test", "srcId", "destId", "cql", true);
+
+    // then
     assertThat(field.name(), is("test"));
     assertThat(field.source().id(), is("srcId"));
     assertThat(field.destination().id(), is("destId"));
     assertThat(field.filter(), is("cql"));
     assertThat(field.biDirectional(), is(true));
-    assertThat(field.itemsTransferred(), is(3));
-    assertThat(field.dataTransferred(), is("15 MB"));
+    assertThat(field.getStats().getStatus(), is(Status.SUCCESS.toString()));
+    assertThat(field.getStats().getPushCount(), is(1L));
+    assertThat(field.getStats().getPullCount(), is(2L));
+    assertThat(field.getStats().getPushBytes(), is(5L));
+    assertThat(field.getStats().getPullBytes(), is(10L));
+    assertThat(field.getStats().getDuration(), is(9L));
+    assertThat(field.getStats().getPullFailCount(), is(99L));
+    assertThat(field.getStats().getPushFailCount(), is(100L));
+    assertThat(field.getStats().getLastRun(), is(LAST_RUN.toInstant().toString()));
+    assertThat(field.getStats().getLastSuccess(), is(LAST_SUCCESS.toInstant().toString()));
+    assertThat(field.getStats().getStartTime(), is(START_TIME.toInstant().toString()));
+
     verify(configManager).save(any(ReplicatorConfig.class));
   }
 
@@ -294,6 +365,7 @@ public class ReplicationUtilsTest {
 
   @Test
   public void updateReplicationNullValues() {
+    // setup
     ReplicationSiteImpl src = new ReplicationSiteImpl();
     src.setId("srcId");
     src.setName("source");
@@ -307,34 +379,55 @@ public class ReplicationUtilsTest {
     when(siteManager.get("srcId")).thenReturn(src);
     when(siteManager.get("destId")).thenReturn(dest);
     ReplicatorConfigImpl config = new ReplicatorConfigImpl();
-    config.setId("id");
+    config.setId(REP_ID);
     config.setName("test");
     config.setSource("srcId");
     config.setDestination("destId");
     config.setFilter("cql");
     config.setBidirectional(true);
     config.setFailureRetryCount(7);
-    when(configManager.get(anyString())).thenReturn(config);
+    when(configManager.get(REP_ID)).thenReturn(config);
     ReplicationStatus status = new ReplicationStatusImpl("test");
     status.setPushCount(1L);
-    status.setPushBytes(1024 * 1024 * 5L);
+    status.setPushBytes(5L);
     status.setPullCount(2L);
     status.setPullBytes(1024 * 1024 * 10L);
+    status.setLastRun(LAST_RUN);
+    status.setLastSuccess(LAST_SUCCESS);
+    status.setStartTime(START_TIME);
+    status.setDuration(9L);
+    status.setPullFailCount(99L);
+    status.setPushFailCount(100L);
+    status.setStatus(Status.SUCCESS);
     when(history.getReplicationEvents("test")).thenReturn(Collections.singletonList(status));
     when(replicator.getActiveSyncRequests()).thenReturn(Collections.emptySet());
-    ReplicationField field = utils.updateReplication("id", null, null, null, null, null);
+
+    // when
+    ReplicationField field = utils.updateReplication(REP_ID, null, null, null, null, null);
+
+    // then
     assertThat(field.name(), is("test"));
     assertThat(field.source().id(), is("srcId"));
     assertThat(field.destination().id(), is("destId"));
     assertThat(field.filter(), is("cql"));
     assertThat(field.biDirectional(), is(true));
-    assertThat(field.itemsTransferred(), is(3));
-    assertThat(field.dataTransferred(), is("15 MB"));
+    assertThat(field.getStats().getStatus(), is(Status.SUCCESS.toString()));
+    assertThat(field.getStats().getPushCount(), is(1L));
+    assertThat(field.getStats().getPullCount(), is(2L));
+    assertThat(field.getStats().getPushBytes(), is(5L));
+    assertThat(field.getStats().getPullBytes(), is(10L));
+    assertThat(field.getStats().getDuration(), is(9L));
+    assertThat(field.getStats().getPullFailCount(), is(99L));
+    assertThat(field.getStats().getPushFailCount(), is(100L));
+    assertThat(field.getStats().getLastRun(), is(LAST_RUN.toInstant().toString()));
+    assertThat(field.getStats().getLastSuccess(), is(LAST_SUCCESS.toInstant().toString()));
+    assertThat(field.getStats().getStartTime(), is(START_TIME.toInstant().toString()));
     verify(configManager).save(any(ReplicatorConfig.class));
   }
 
   @Test
   public void updateReplicationActiveSyncRequest() {
+    // setup
     ReplicationSiteImpl src = new ReplicationSiteImpl();
     src.setId("srcId");
     src.setName("source");
@@ -348,25 +441,38 @@ public class ReplicationUtilsTest {
     when(siteManager.get("srcId")).thenReturn(src);
     when(siteManager.get("destId")).thenReturn(dest);
     ReplicatorConfigImpl config = new ReplicatorConfigImpl();
-    config.setId("id");
+    config.setId(REP_ID);
     config.setName("oldName");
     config.setFilter("oldCql");
     config.setFailureRetryCount(7);
-    when(configManager.get(anyString())).thenReturn(config);
+    when(configManager.get(REP_ID)).thenReturn(config);
     ReplicationStatusImpl status = new ReplicationStatusImpl("test");
     status.setStatus(Status.PUSH_IN_PROGRESS);
     when(history.getReplicationEvents("test")).thenReturn(new ArrayList<>());
     SyncRequestImpl syncRequest = new SyncRequestImpl(config, status);
     when(replicator.getActiveSyncRequests()).thenReturn(Collections.singleton(syncRequest));
-    ReplicationField field = utils.updateReplication("id", "test", "srcId", "destId", "cql", true);
+
+    // when
+    ReplicationField field =
+        utils.updateReplication(REP_ID, "test", "srcId", "destId", "cql", true);
+
+    // then
     assertThat(field.name(), is("test"));
     assertThat(field.source().id(), is("srcId"));
     assertThat(field.destination().id(), is("destId"));
     assertThat(field.filter(), is("cql"));
     assertThat(field.biDirectional(), is(true));
-    assertThat(field.itemsTransferred(), is(0));
-    assertThat(field.dataTransferred(), is("0 MB"));
-    assertThat(field.status().getValue(), is("PUSH_IN_PROGRESS"));
+    assertThat(field.getStats().getStatus(), is(Status.PUSH_IN_PROGRESS.toString()));
+    assertThat(field.getStats().getPushCount(), is(0L));
+    assertThat(field.getStats().getPullCount(), is(0L));
+    assertThat(field.getStats().getPushBytes(), is(0L));
+    assertThat(field.getStats().getPullBytes(), is(0L));
+    assertThat(field.getStats().getDuration(), is(-1L));
+    assertThat(field.getStats().getPullFailCount(), is(0L));
+    assertThat(field.getStats().getPushFailCount(), is(0L));
+    assertThat(field.getStats().getLastRun(), is(nullValue()));
+    assertThat(field.getStats().getLastSuccess(), is(nullValue()));
+    assertThat(field.getStats().getStartTime(), is(nullValue()));
     verify(configManager).save(any(ReplicatorConfig.class));
   }
 
@@ -400,6 +506,7 @@ public class ReplicationUtilsTest {
 
   @Test
   public void getReplications() throws Exception {
+    // setup
     ReplicationSiteImpl src = new ReplicationSiteImpl();
     src.setId("srcId");
     src.setName("source");
@@ -418,24 +525,44 @@ public class ReplicationUtilsTest {
     status.setPushBytes(1024 * 1024 * 5L);
     status.setPullCount(2L);
     status.setPullBytes(1024 * 1024 * 10L);
+    status.setLastRun(LAST_RUN);
+    status.setLastSuccess(LAST_SUCCESS);
+    status.setStartTime(START_TIME);
+    status.setDuration(9L);
+    status.setPullFailCount(99L);
+    status.setPushFailCount(100L);
+    status.setStatus(Status.SUCCESS);
     when(history.getReplicationEvents("test")).thenReturn(Collections.singletonList(status));
     when(replicator.getActiveSyncRequests()).thenReturn(Collections.emptySet());
     ReplicatorConfigImpl config = new ReplicatorConfigImpl();
-    config.setId("id");
+    config.setId(REP_ID);
     config.setName("test");
     config.setFilter("cql");
     config.setSource("srcId");
     config.setDestination("destId");
     config.setBidirectional(false);
     when(configManager.objects()).thenReturn(Stream.of(config));
+
+    // when
     ReplicationField field = utils.getReplications(false).getList().get(0);
+
+    // then
     assertThat(field.name(), is("test"));
     assertThat(field.source().id(), is("srcId"));
     assertThat(field.destination().id(), is("destId"));
     assertThat(field.filter(), is("cql"));
     assertThat(field.biDirectional(), is(false));
-    assertThat(field.itemsTransferred(), is(3));
-    assertThat(field.dataTransferred(), is("15 MB"));
+    assertThat(field.getStats().getStatus(), is(Status.SUCCESS.toString()));
+    assertThat(field.getStats().getPushCount(), is(1L));
+    assertThat(field.getStats().getPullCount(), is(2L));
+    assertThat(field.getStats().getPushBytes(), is(5L));
+    assertThat(field.getStats().getPullBytes(), is(10L));
+    assertThat(field.getStats().getDuration(), is(9L));
+    assertThat(field.getStats().getPullFailCount(), is(99L));
+    assertThat(field.getStats().getPushFailCount(), is(100L));
+    assertThat(field.getStats().getLastRun(), is(LAST_RUN.toInstant().toString()));
+    assertThat(field.getStats().getLastSuccess(), is(LAST_SUCCESS.toInstant().toString()));
+    assertThat(field.getStats().getStartTime(), is(START_TIME.toInstant().toString()));
   }
 
   @Test
@@ -641,6 +768,132 @@ public class ReplicationUtilsTest {
 
     when(siteManager.objects()).thenReturn(Stream.empty());
     assertThat(utils.isDuplicateSiteName("site"), is(false));
+  }
+
+  @Test
+  public void testUpdateReplicationStats() {
+    // setup
+    final String repName = "repName";
+    StringField repNameField = new StringField();
+    repNameField.setValue(repName);
+
+    ReplicationStats stats = new ReplicationStats();
+    stats.setPid("pid");
+    stats.setStartTime(START_TIME);
+    stats.setLastRun(LAST_RUN);
+    stats.setLastSuccess(LAST_SUCCESS);
+    stats.setDuration(10L);
+    stats.setStatus(Status.SUCCESS.name());
+    stats.setPushCount(1L);
+    stats.setPullCount(2L);
+    stats.setPushFailCount(3L);
+    stats.setPullFailCount(4L);
+    stats.setPushBytes(5L);
+    stats.setPullBytes(6L);
+
+    final String statusId = "statusId";
+    ReplicationStatus status = mock(ReplicationStatus.class);
+    when(status.getId()).thenReturn(statusId);
+
+    when(history.getReplicationEvents(repName)).thenReturn(Collections.singletonList(status));
+
+    ArgumentCaptor<ReplicationStatus> repStatus = ArgumentCaptor.forClass(ReplicationStatus.class);
+
+    // when
+    boolean updated = utils.updateReplicationStats(repNameField, stats);
+
+    // then
+    assertThat(updated, is(true));
+    verify(history).addReplicationEvent(repStatus.capture());
+
+    ReplicationStatus savedStatus = repStatus.getValue();
+    assertThat(savedStatus.getId(), is("pid"));
+    assertThat(savedStatus.getStartTime(), is(START_TIME));
+    assertThat(savedStatus.getLastRun(), is(LAST_RUN));
+    assertThat(savedStatus.getLastSuccess(), is(LAST_SUCCESS));
+    assertThat(savedStatus.getDuration(), is(10L));
+    assertThat(savedStatus.getStatus(), is(Status.SUCCESS));
+    assertThat(savedStatus.getPushCount(), is(1L));
+    assertThat(savedStatus.getPullCount(), is(2L));
+    assertThat(savedStatus.getPushFailCount(), is(3L));
+    assertThat(savedStatus.getPullFailCount(), is(4L));
+    assertThat(savedStatus.getPushBytes(), is(5L));
+    assertThat(savedStatus.getPullBytes(), is(6L));
+  }
+
+  @Test
+  public void testUpdateReplicationFailToDeleteExistingStats() {
+    // setup
+    final String repName = "repName";
+    StringField repNameField = new StringField();
+    repNameField.setValue(repName);
+
+    ReplicationStats stats = new ReplicationStats();
+    stats.setPid("pid");
+    stats.setStartTime(START_TIME);
+    stats.setLastRun(LAST_RUN);
+    stats.setLastSuccess(LAST_SUCCESS);
+    stats.setDuration(10L);
+    stats.setStatus(Status.SUCCESS.name());
+    stats.setPushCount(1L);
+    stats.setPullCount(2L);
+    stats.setPushFailCount(3L);
+    stats.setPullFailCount(4L);
+    stats.setPushBytes(5L);
+    stats.setPullBytes(6L);
+
+    final String statusId = "statusId";
+    ReplicationStatus status = mock(ReplicationStatus.class);
+    when(status.getId()).thenReturn(statusId);
+
+    when(history.getReplicationEvents(repName)).thenReturn(Collections.singletonList(status));
+    doThrow(ReplicationPersistenceException.class)
+        .when(history)
+        .removeReplicationEvents(Collections.singleton(statusId));
+
+    // when
+    boolean updated = utils.updateReplicationStats(repNameField, stats);
+
+    // then
+    assertThat(updated, is(false));
+  }
+
+  @Test
+  public void testUpdateReplicationStatsFailToSave() {
+    // setup
+    final String repName = "repName";
+    StringField repNameField = new StringField();
+    repNameField.setValue(repName);
+
+    ReplicationStats stats = new ReplicationStats();
+    stats.setPid("pid");
+    stats.setStartTime(START_TIME);
+    stats.setLastRun(LAST_RUN);
+    stats.setLastSuccess(LAST_SUCCESS);
+    stats.setDuration(10L);
+    stats.setStatus(Status.SUCCESS.name());
+    stats.setPushCount(1L);
+    stats.setPullCount(2L);
+    stats.setPushFailCount(3L);
+    stats.setPullFailCount(4L);
+    stats.setPushBytes(5L);
+    stats.setPullBytes(6L);
+
+    final String statusId = "statusId";
+    ReplicationStatus status = mock(ReplicationStatus.class);
+    when(status.getId()).thenReturn(statusId);
+
+    when(history.getReplicationEvents(repName)).thenReturn(Collections.singletonList(status));
+
+    doThrow(ReplicationPersistenceException.class)
+        .when(history)
+        .addReplicationEvent(any(ReplicationStatus.class));
+
+    // when
+    boolean updated = utils.updateReplicationStats(repNameField, stats);
+
+    // then
+    assertThat(updated, is(false));
   }
 
   private AddressField getAddress(URL url) {

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/ReplicationUtilsTest.java
@@ -185,9 +185,9 @@ public class ReplicationUtilsTest {
 
     ReplicationStatus status = new ReplicationStatusImpl("test");
     status.setPushCount(1L);
-    status.setPushBytes(1024 * 1024 * 5L);
+    status.setPushBytes(5L);
     status.setPullCount(2L);
-    status.setPullBytes(1024 * 1024 * 10L);
+    status.setPullBytes(10L);
     status.setLastRun(LAST_RUN);
     status.setLastSuccess(LAST_SUCCESS);
     status.setStartTime(START_TIME);
@@ -391,7 +391,7 @@ public class ReplicationUtilsTest {
     status.setPushCount(1L);
     status.setPushBytes(5L);
     status.setPullCount(2L);
-    status.setPullBytes(1024 * 1024 * 10L);
+    status.setPullBytes(10L);
     status.setLastRun(LAST_RUN);
     status.setLastSuccess(LAST_SUCCESS);
     status.setStartTime(START_TIME);
@@ -522,9 +522,9 @@ public class ReplicationUtilsTest {
 
     ReplicationStatus status = new ReplicationStatusImpl("test");
     status.setPushCount(1L);
-    status.setPushBytes(1024 * 1024 * 5L);
+    status.setPushBytes(5L);
     status.setPullCount(2L);
-    status.setPullBytes(1024 * 1024 * 10L);
+    status.setPullBytes(10L);
     status.setLastRun(LAST_RUN);
     status.setLastSuccess(LAST_SUCCESS);
     status.setStartTime(START_TIME);

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/status/persist/UpdateReplicationStatsTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/status/persist/UpdateReplicationStatsTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.status.persist;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import java.sql.Date;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.codice.ddf.admin.api.report.ErrorMessage;
+import org.codice.ddf.admin.api.report.FunctionReport;
+import org.codice.ditto.replication.admin.query.ReplicationUtils;
+import org.codice.ditto.replication.admin.query.status.fields.ReplicationStats;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UpdateReplicationStatsTest {
+
+  private static final String FUNCTION_PATH = "functionPath";
+
+  private static final String STATS_PATH = "stats";
+
+  private static final String PID = "pid";
+
+  private static final String START_TIME = "2017-04-20T15:25:46.327Z";
+
+  private static final String LAST_RUN = "2016-04-20T15:25:46.327Z";
+
+  private static final String LAST_SUCCESS = "2015-04-20T15:25:46.327Z";
+
+  private static final long DURATION = 5;
+
+  private static final String STATUS = "SUCCESS";
+
+  private static final long PUSH_COUNT = 1;
+
+  private static final long PULL_COUNT = 2;
+
+  private static final long PUSH_FAIL_COUNT = 3;
+
+  private static final long PULL_FAIL_COUNT = 4;
+
+  private static final long PUSH_BYTES = 5;
+
+  private static final long PULL_BYTES = 6;
+
+  private static final String REPLICATION_NAME = "repName";
+
+  private UpdateReplicationStats updateReplicationStats;
+
+  @Mock ReplicationUtils replicationUtils;
+
+  private Map<String, Object> args;
+
+  private ReplicationStats replicationStats;
+
+  @Before
+  public void setup() {
+    updateReplicationStats = new UpdateReplicationStats(replicationUtils);
+
+    replicationStats = new ReplicationStats();
+    replicationStats.setPid(PID);
+    replicationStats.setStartTime(Date.from(Instant.parse(START_TIME)));
+    replicationStats.setLastRun(Date.from(Instant.parse(LAST_RUN)));
+    replicationStats.setLastSuccess(Date.from(Instant.parse(LAST_SUCCESS)));
+    replicationStats.setDuration(DURATION);
+    replicationStats.setStatus(STATUS);
+    replicationStats.setPushCount(PUSH_COUNT);
+    replicationStats.setPullCount(PULL_COUNT);
+    replicationStats.setPushFailCount(PUSH_FAIL_COUNT);
+    replicationStats.setPullFailCount(PULL_FAIL_COUNT);
+    replicationStats.setPushBytes(PUSH_BYTES);
+    replicationStats.setPullBytes(PULL_BYTES);
+
+    args = new HashMap<>();
+    args.put("stats", replicationStats.getValue());
+    args.put("replicationName", REPLICATION_NAME);
+  }
+
+  @Test
+  public void testUpdateReplicationStats() {
+    // setup
+    when(replicationUtils.replicationConfigExists(REPLICATION_NAME)).thenReturn(true);
+    when(replicationUtils.updateReplicationStats(any(), any())).thenReturn(true);
+
+    // when
+    boolean result = updateReplicationStats.execute(args, null).getResult().getValue();
+
+    // then
+    assertThat(result, is(true));
+  }
+
+  @Test
+  public void testReplicationNameDoesNotExist() {
+    // setup
+    when(replicationUtils.replicationConfigExists(REPLICATION_NAME)).thenReturn(false);
+
+    // when
+    FunctionReport report = updateReplicationStats.execute(args, ImmutableList.of(FUNCTION_PATH));
+    List<ErrorMessage> errors = report.getErrorMessages();
+
+    // then
+    assertThat(report.getResult(), is(nullValue()));
+    assertThat(errors.size(), is(1));
+    assertThat(errors.get(0).getCode(), is("NO_EXISTING_CONFIG"));
+    assertThat(errors.get(0).getPath(), is(ImmutableList.of(FUNCTION_PATH)));
+  }
+
+  @Test
+  public void testMissingRequiredArgs() {
+    // when
+    FunctionReport report = updateReplicationStats.execute(null, ImmutableList.of(FUNCTION_PATH));
+    List<ErrorMessage> errors = report.getErrorMessages();
+
+    // then
+    assertThat(report.getResult(), is(nullValue()));
+    assertThat(errors.size(), is(12));
+    assertRequiredArg(
+        errors.get(0).getCode(),
+        errors.get(0).getPath(),
+        ImmutableList.of(FUNCTION_PATH, "replicationName"));
+    assertRequiredArg(
+        errors.get(1).getCode(),
+        errors.get(1).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "pid"));
+    assertRequiredArg(
+        errors.get(2).getCode(),
+        errors.get(2).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "startTime"));
+    assertRequiredArg(
+        errors.get(3).getCode(),
+        errors.get(3).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "lastRun"));
+    assertRequiredArg(
+        errors.get(4).getCode(),
+        errors.get(4).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "duration"));
+    assertRequiredArg(
+        errors.get(5).getCode(),
+        errors.get(5).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "replicationStatus"));
+    assertRequiredArg(
+        errors.get(6).getCode(),
+        errors.get(6).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "pushCount"));
+    assertRequiredArg(
+        errors.get(7).getCode(),
+        errors.get(7).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "pullCount"));
+    assertRequiredArg(
+        errors.get(8).getCode(),
+        errors.get(8).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "pushFailCount"));
+    assertRequiredArg(
+        errors.get(9).getCode(),
+        errors.get(9).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "pullFailCount"));
+    assertRequiredArg(
+        errors.get(10).getCode(),
+        errors.get(10).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "pushBytes"));
+    assertRequiredArg(
+        errors.get(11).getCode(),
+        errors.get(11).getPath(),
+        ImmutableList.of(FUNCTION_PATH, STATS_PATH, "pullBytes"));
+  }
+
+  private void assertRequiredArg(String code, List<Object> path, List<Object> expectedPath) {
+    assertThat(code, is("MISSING_REQUIRED_FIELD"));
+    assertThat(path, is(expectedPath));
+  }
+}

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -87,7 +87,9 @@ class ReplicationRow extends React.Component {
           {replication.stats.pullCount + replication.stats.pushCount}
         </TableCell>
         <TableCell>
-          {replication.stats.pushBytes + replication.stats.pullBytes}
+          {Replications.formatBytes(
+            replication.stats.pushBytes + replication.stats.pullBytes
+          )}
         </TableCell>
         <TableCell>{this.state.lastRun}</TableCell>
         <TableCell>{this.state.lastSuccess}</TableCell>
@@ -134,7 +136,7 @@ class ReplicationsTable extends React.Component {
               <TableCell>Bidirectional</TableCell>
               <TableCell>Filter</TableCell>
               <TableCell>Items Transferred</TableCell>
-              <TableCell>MB Transferred</TableCell>
+              <TableCell>Data Transferred</TableCell>
               <TableCell>Last Run</TableCell>
               <TableCell>Last Success</TableCell>
               <TableCell />

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -49,8 +49,8 @@ const format = utc => {
 class ReplicationRow extends React.Component {
   state = {
     anchor: null,
-    lastRun: format(this.props.replication.lastRun),
-    lastSuccess: format(this.props.replication.lastSuccess),
+    lastRun: format(this.props.replication.stats.lastRun),
+    lastSuccess: format(this.props.replication.stats.lastSuccess),
   }
 
   handleClickOpen = replication => event => {
@@ -71,8 +71,8 @@ class ReplicationRow extends React.Component {
           timeout={60000}
           callback={() => {
             this.setState({
-              lastRun: format(replication.lastRun),
-              lastSuccess: format(replication.lastSuccess),
+              lastRun: format(replication.stats.lastRun),
+              lastSuccess: format(replication.stats.lastSuccess),
             })
           }}
         />
@@ -83,8 +83,12 @@ class ReplicationRow extends React.Component {
         <TableCell>{replication.destination.name}</TableCell>
         <TableCell>{replication.biDirectional ? 'Yes' : 'No'}</TableCell>
         <TableCell>{replication.filter}</TableCell>
-        <TableCell>{replication.itemsTransferred}</TableCell>
-        <TableCell>{replication.dataTransferred}</TableCell>
+        <TableCell>
+          {replication.stats.pullCount + replication.stats.pushCount}
+        </TableCell>
+        <TableCell>
+          {replication.stats.pushBytes + replication.stats.pullBytes}
+        </TableCell>
         <TableCell>{this.state.lastRun}</TableCell>
         <TableCell>{this.state.lastSuccess}</TableCell>
         <TableCell>

--- a/ui/src/main/webapp/components/replications/__tests__/actionsMenu.spec.js
+++ b/ui/src/main/webapp/components/replications/__tests__/actionsMenu.spec.js
@@ -34,8 +34,10 @@ test('push in progress status renders cancel action', () => {
     <ActionsMenu
       replication={{
         id: '1234',
-        replicationStatus: Replications.Status.PUSH_IN_PROGRESS,
         suspended: false,
+        stats: {
+          replicationStatus: Replications.Status.PUSH_IN_PROGRESS,
+        },
       }}
       menuId='1234'
       anchorEl={null}
@@ -50,8 +52,10 @@ test('pull in progress status renders cancel action', () => {
     <ActionsMenu
       replication={{
         id: '1234',
-        replicationStatus: Replications.Status.PULL_IN_PROGRESS,
         suspended: false,
+        stats: {
+          replicationStatus: Replications.Status.PULL_IN_PROGRESS,
+        },
       }}
       menuId='1234'
       anchorEl={null}
@@ -66,8 +70,10 @@ test('pending status renders cancel action', () => {
     <ActionsMenu
       replication={{
         id: '1234',
-        replicationStatus: Replications.Status.PENDING,
         suspended: false,
+        stats: {
+          replicationStatus: Replications.Status.PENDING,
+        },
       }}
       menuId='1234'
       anchorEl={null}
@@ -82,8 +88,10 @@ test('suspended config renders enable action', () => {
     <ActionsMenu
       replication={{
         id: '1234',
-        replicationStatus: Replications.Status.PENDING,
         suspended: true,
+        stats: {
+          replicationStatus: Replications.Status.PENDING,
+        },
       }}
       menuId='1234'
       anchorEl={null}
@@ -98,8 +106,10 @@ test('enabled config renders suspend action', () => {
     <ActionsMenu
       replication={{
         id: '1234',
-        replicationStatus: Replications.Status.PENDING,
         suspended: false,
+        stats: {
+          replicationStatus: Replications.Status.PENDING,
+        },
       }}
       menuId='1234'
       anchorEl={null}

--- a/ui/src/main/webapp/components/replications/gql/mutations.js
+++ b/ui/src/main/webapp/components/replications/gql/mutations.js
@@ -44,15 +44,19 @@ export const addReplication = gql`
           url
         }
       }
-      lastRun
-      lastSuccess
-      firstRun
       biDirectional
-      replicationStatus
       filter
-      itemsTransferred
-      dataTransferred
       suspended
+      stats {
+        replicationStatus
+        pushCount
+        pullCount
+        pushBytes
+        pullBytes
+        lastRun
+        lastSuccess
+        startTime
+      }
     }
   }
 `

--- a/ui/src/main/webapp/components/replications/gql/queries.js
+++ b/ui/src/main/webapp/components/replications/gql/queries.js
@@ -33,15 +33,19 @@ export const allReplications = gql`
             url
           }
         }
-        lastRun
-        lastSuccess
-        firstRun
         biDirectional
-        replicationStatus
-        itemsTransferred
-        dataTransferred
         filter
         suspended
+        stats {
+          replicationStatus
+          pushCount
+          pullCount
+          pushBytes
+          pullBytes
+          lastRun
+          lastSuccess
+          startTime
+        }
       }
     }
   }

--- a/ui/src/main/webapp/components/replications/replications.js
+++ b/ui/src/main/webapp/components/replications/replications.js
@@ -71,10 +71,26 @@ function repSort(a, b) {
   return 0
 }
 
+function formatBytes(bytes, disableBytes = true) {
+  if (bytes === 0) return '0 MB'
+
+  const k = 1024
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+  let i = Math.floor(Math.log(bytes) / Math.log(k))
+  if (disableBytes && i === 0) {
+    // don't allow Bytes display if less than KB, force to KB
+    i = 1
+  }
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
 export default {
   Status,
   isInProgress,
   statusDisplayName,
   cancelable,
   repSort,
+  formatBytes,
 }

--- a/ui/src/main/webapp/components/replications/replications.js
+++ b/ui/src/main/webapp/components/replications/replications.js
@@ -38,18 +38,18 @@ const statusDisplayNameMapping = {
 }
 
 function isInProgress(replication) {
-  const status = replication.replicationStatus
+  const status = replication.stats.replicationStatus
   return (
     status === Status.PULL_IN_PROGRESS || status === Status.PUSH_IN_PROGRESS
   )
 }
 
 function statusDisplayName(replication) {
-  return statusDisplayNameMapping[replication.replicationStatus]
+  return statusDisplayNameMapping[replication.stats.replicationStatus]
 }
 
 function cancelable(replication) {
-  const status = replication.replicationStatus
+  const status = replication.stats.replicationStatus
   return (
     status === Status.PUSH_IN_PROGRESS ||
     status === Status.PULL_IN_PROGRESS ||


### PR DESCRIPTION
#### What does this PR do?
- Supports updating a configurations stats by configuration name
- Make back end pass bytes pulled/pushed to front end, and format on front end.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard @kcover 

#### How should this be tested? (List steps with links to updated documentation)
- Create a replication config that will run normally and verify it still displays correct information
- Create another replication config, disable it, then through a GraphiQL interface, update its stats and verify that it displays correct information in the UI.

#### Any background context you want to provide?
This will allow cloud instances to push stats to a fielded node when the cloud owns those replications.

#### What are the relevant tickets?
Fixes #95 

#### Screenshots (if appropriate)
![Transferred_KB](https://user-images.githubusercontent.com/17572782/58199533-88418280-7c85-11e9-8b8f-01844f65924b.PNG)
![Transferred_MB](https://user-images.githubusercontent.com/17572782/58199532-87a8ec00-7c85-11e9-8182-47dc9a921db0.PNG)
![Transferred_GB](https://user-images.githubusercontent.com/17572782/58199536-8972af80-7c85-11e9-9bf6-a00b510caa4f.PNG)
![Transferred_TB](https://user-images.githubusercontent.com/17572782/58199539-8aa3dc80-7c85-11e9-9f3c-4cccf859c9b5.PNG)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
