### PR TITLE
REP-102 Add ION NodeAdapter

### DIFF
--- a/adapters/ion-adapter/pom.xml
+++ b/adapters/ion-adapter/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>adapters</artifactId>
+    <groupId>replication</groupId>
+    <version>0.3.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>ion-adapter</artifactId>
+  <name>Replication :: Adapters :: ION</name>
+  <groupId>replication-adapters</groupId>
+
+  <dependencies>
+    <dependency>
+      <groupId>replication</groupId>
+      <artifactId>replication-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.reactivestreams</groupId>
+      <artifactId>reactive-streams</artifactId>
+      <version>${reactive-streams.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-base</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>org.springframework.test</artifactId>
+      <version>${spring-test.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+      <version>${spring.version}</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <haltOnFailure>true</haltOnFailure>
+              <rules>
+                <rule>
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>INSTRUCTION</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.91</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>BRANCH</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.91</minimum>
+                    </limit>
+                    <limit implementation="org.codice.jacoco.LenientLimit">
+                      <counter>COMPLEXITY</counter>
+                      <value>COVEREDRATIO</value>
+                      <minimum>0.82</minimum>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/IonNodeAdapter.java
+++ b/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/IonNodeAdapter.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.adapters.ion;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import org.codice.ditto.replication.api.NodeAdapter;
+import org.codice.ditto.replication.api.data.CreateRequest;
+import org.codice.ditto.replication.api.data.CreateStorageRequest;
+import org.codice.ditto.replication.api.data.DeleteRequest;
+import org.codice.ditto.replication.api.data.Metadata;
+import org.codice.ditto.replication.api.data.QueryRequest;
+import org.codice.ditto.replication.api.data.QueryResponse;
+import org.codice.ditto.replication.api.data.Resource;
+import org.codice.ditto.replication.api.data.ResourceRequest;
+import org.codice.ditto.replication.api.data.ResourceResponse;
+import org.codice.ditto.replication.api.data.UpdateRequest;
+import org.codice.ditto.replication.api.data.UpdateStorageRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestOperations;
+
+public class IonNodeAdapter implements NodeAdapter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(IonNodeAdapter.class);
+
+  private final URL ionUrl;
+
+  private final RestOperations restOps;
+
+  public IonNodeAdapter(URL ionUrl, RestOperations restOps) {
+    this.ionUrl = ionUrl;
+    this.restOps = restOps;
+  }
+
+  @Override
+  public boolean isAvailable() {
+    try {
+      return restOps.optionsForAllow(this.ionUrl.toString() + "/ingest").contains(HttpMethod.POST);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  @Override
+  public String getSystemName() {
+    return "ION";
+  }
+
+  @Override
+  public QueryResponse query(QueryRequest queryRequest) {
+    // Ion doesn't support query at this time
+    LOGGER.debug("Ion Adapter ignoring query request");
+    return ArrayList::new;
+  }
+
+  @Override
+  public boolean exists(Metadata metadata) {
+    LOGGER.debug("Ion Adapter exist returning false as always.");
+    return false;
+  }
+
+  @Override
+  public boolean createRequest(CreateRequest createRequest) {
+    LOGGER.debug("Ion doesn't support metadata only creation at this time");
+    return true;
+  }
+
+  @Override
+  public boolean updateRequest(UpdateRequest updateRequest) {
+    LOGGER.debug("Ion doesn't support metadata updates at this time");
+    return true;
+  }
+
+  @Override
+  public boolean deleteRequest(DeleteRequest deleteRequest) {
+    LOGGER.debug("Ion doesn't delete data");
+    return true;
+  }
+
+  @Override
+  public ResourceResponse readResource(ResourceRequest resourceRequest) {
+    LOGGER.debug("Ion Adapter doesn't support resource retrieval at this time");
+    return null;
+  }
+
+  @Override
+  public boolean createResource(CreateStorageRequest createStorageRequest) {
+    boolean success = true;
+    for (Resource resource : createStorageRequest.getResources()) {
+
+      MultipartBodyBuilder builder = new MultipartBodyBuilder();
+      builder.part("title", resource.getId());
+
+      builder.part("fileSize", resource.getSize());
+
+      builder.part("fileName", resource.getName());
+
+      builder.part("mimeType", resource.getMimeType());
+
+      builder.part("file", new MultipartInputStreamResource(resource));
+
+      MultiValueMap<String, HttpEntity<?>> multipartBody = builder.build();
+
+      HttpHeaders headers = new HttpHeaders();
+      headers.set("Accept-Version", "0.1.0");
+      headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+      HttpEntity<MultiValueMap<String, Object>> requestEntity =
+          new HttpEntity(multipartBody, headers);
+      LOGGER.debug("Sending create request to ION at {}", ionUrl);
+      try {
+        ResponseEntity<String> response =
+            restOps.exchange(
+                this.ionUrl.toString() + "/ingest", HttpMethod.POST, requestEntity, String.class);
+        if (response.getStatusCodeValue() != 202) {
+          LOGGER.debug(
+              "Failed to replicate {}. Message: {}", resource.getName(), response.getBody());
+          success = false;
+        }
+      } catch (Exception e) {
+        LOGGER.debug("Error sending create request to ION.", e);
+        success = false;
+      }
+    }
+    return success;
+  }
+
+  @Override
+  public boolean updateResource(UpdateStorageRequest updateStorageRequest) {
+    LOGGER.debug("Ion doesn't support product updates at this time");
+    return true;
+  }
+
+  @Override
+  public void close() throws IOException {
+    // nothing to close
+  }
+
+  private class MultipartInputStreamResource extends InputStreamResource {
+
+    private final String filename;
+
+    private final long length;
+
+    public MultipartInputStreamResource(Resource resource) {
+      super(resource.getInputStream());
+      this.filename = resource.getName();
+      this.length = resource.getSize();
+    }
+
+    @Override
+    public String getFilename() {
+      return this.filename;
+    }
+
+    @Override
+    public long contentLength() {
+      return this.length;
+    }
+  }
+}

--- a/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/IonNodeAdapterFactory.java
+++ b/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/IonNodeAdapterFactory.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.adapters.ion;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.codice.ditto.replication.api.AdapterException;
+import org.codice.ditto.replication.api.NodeAdapter;
+import org.codice.ditto.replication.api.NodeAdapterFactory;
+import org.codice.ditto.replication.api.NodeAdapterType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+public class IonNodeAdapterFactory implements NodeAdapterFactory {
+
+  @Override
+  public NodeAdapter create(URL url) {
+    // TODO change this when ingest enpoint supports https
+    String baseUrl = "http://" + url.getHost() + ":" + url.getPort();
+    try {
+      RestTemplate template = new RestTemplate();
+      SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+      requestFactory.setBufferRequestBody(false);
+      template.setRequestFactory(requestFactory);
+      return new IonNodeAdapter(new URL(baseUrl), template);
+    } catch (MalformedURLException e) {
+      throw new AdapterException("Failed to create adapter", e);
+    }
+  }
+
+  @Override
+  public NodeAdapterType getType() {
+    return NodeAdapterType.ION;
+  }
+}

--- a/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/spring/ServiceConfig.java
+++ b/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/spring/ServiceConfig.java
@@ -11,9 +11,17 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package org.codice.ditto.replication.api;
+package com.connexta.replication.adapters.ion.spring;
 
-public enum NodeAdapterType {
-  DDF,
-  ION
+import com.connexta.replication.adapters.ion.IonNodeAdapterFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration("ion-adapter")
+public class ServiceConfig {
+
+  @Bean
+  public IonNodeAdapterFactory ionNodeAdapterFactory() {
+    return new IonNodeAdapterFactory();
+  }
 }

--- a/adapters/ion-adapter/src/test/java/com/connexta/replication/adapters/ion/IonNodeAdapterFactoryTest.java
+++ b/adapters/ion-adapter/src/test/java/com/connexta/replication/adapters/ion/IonNodeAdapterFactoryTest.java
@@ -1,0 +1,23 @@
+package com.connexta.replication.adapters.ion;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.net.URL;
+import org.codice.ditto.replication.api.NodeAdapter;
+import org.codice.ditto.replication.api.NodeAdapterType;
+import org.junit.Test;
+
+public class IonNodeAdapterFactoryTest {
+
+  @Test
+  public void create() throws Exception {
+    NodeAdapter adapter = new IonNodeAdapterFactory().create(new URL("https://localhost:1234"));
+    assertThat(adapter.getClass().isAssignableFrom(IonNodeAdapter.class), is(true));
+  }
+
+  @Test
+  public void getType() {
+    assertThat(new IonNodeAdapterFactory().getType(), is(NodeAdapterType.ION));
+  }
+}

--- a/adapters/ion-adapter/src/test/java/com/connexta/replication/adapters/ion/IonNodeAdapterTest.java
+++ b/adapters/ion-adapter/src/test/java/com/connexta/replication/adapters/ion/IonNodeAdapterTest.java
@@ -1,0 +1,165 @@
+package com.connexta.replication.adapters.ion;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+
+import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import org.codice.ditto.replication.api.data.CreateStorageRequest;
+import org.codice.ditto.replication.api.data.Metadata;
+import org.codice.ditto.replication.api.data.Resource;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.lang.Nullable;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.test.web.client.response.DefaultResponseCreator;
+import org.springframework.test.web.client.response.MockRestResponseCreators;
+import org.springframework.web.client.RestTemplate;
+
+public class IonNodeAdapterTest {
+
+  RestTemplate restTemplate;
+
+  MockRestServiceServer mockServer;
+
+  IonNodeAdapter adapter;
+
+  @Before
+  public void setup() throws Exception {
+    restTemplate = new RestTemplate();
+    mockServer = MockRestServiceServer.createServer(restTemplate);
+    adapter = new IonNodeAdapter(new URL("http://localhost:1234"), restTemplate);
+  }
+
+  @Test
+  public void isAvailable() {
+    DefaultResponseCreator response = MockRestResponseCreators.withSuccess();
+    HttpHeaders headers = new HttpHeaders();
+    headers.addAll("Allow", ImmutableList.of("POST", "OPTIONS"));
+    response.headers(headers);
+    mockServer
+        .expect(requestTo("http://localhost:1234/ingest"))
+        .andExpect(method(HttpMethod.OPTIONS))
+        .andRespond(response);
+    assertThat(adapter.isAvailable(), is(true));
+    mockServer.verify();
+  }
+
+  @Test
+  public void isNotAvailable() throws Exception {
+    restTemplate = new RestTemplate();
+    adapter = new IonNodeAdapter(new URL("http://localhost:1234321"), restTemplate);
+    assertThat(adapter.isAvailable(), is(false));
+  }
+
+  @Test
+  public void getSystemName() {
+    assertThat(adapter.getSystemName(), is("ION"));
+  }
+
+  @Test
+  public void createResource() {
+    mockServer
+        .expect(requestTo("http://localhost:1234/ingest"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(MockRestResponseCreators.withStatus(HttpStatus.ACCEPTED));
+
+    assertThat(adapter.createResource(getCreateStorageRequest()), is(true));
+    mockServer.verify();
+  }
+
+  @Test
+  public void createResourceFailed401() {
+    mockServer
+        .expect(requestTo("http://localhost:1234/ingest"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(MockRestResponseCreators.withStatus(HttpStatus.UNAUTHORIZED));
+
+    assertThat(adapter.createResource(getCreateStorageRequest()), is(false));
+    mockServer.verify();
+  }
+
+  @Test
+  public void createResourceFailed200() {
+    mockServer
+        .expect(requestTo("http://localhost:1234/ingest"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(MockRestResponseCreators.withStatus(HttpStatus.OK));
+
+    assertThat(adapter.createResource(getCreateStorageRequest()), is(false));
+    mockServer.verify();
+  }
+
+  @Test
+  public void unimplementedMethods() {
+    // many of the unimplemented methods return true since we don't want to wast time retrying them
+    // later
+    // when we know they will never succeed. We will just let replication think it was successful.
+    assertThat(adapter.createRequest(null), is(true));
+    assertThat(adapter.updateRequest(null), is(true));
+    assertThat(adapter.deleteRequest(null), is(true));
+    assertThat(adapter.readResource(null), is(nullValue()));
+    assertThat(adapter.updateResource(null), is(true));
+    assertThat(adapter.query(null).getMetadata().iterator().hasNext(), is(false));
+  }
+
+  private CreateStorageRequest getCreateStorageRequest() {
+    CreateStorageRequest request =
+        () ->
+            Collections.singletonList(
+                new Resource() {
+                  @Override
+                  public String getId() {
+                    return "1234";
+                  }
+
+                  @Override
+                  public String getName() {
+                    return "test";
+                  }
+
+                  @Override
+                  public URI getResourceUri() {
+                    return URI.create("https://host:1234/path/to/resource");
+                  }
+
+                  @Nullable
+                  @Override
+                  public String getQualifier() {
+                    return null;
+                  }
+
+                  @Override
+                  public InputStream getInputStream() {
+                    return new ByteArrayInputStream("This is a test".getBytes());
+                  }
+
+                  @Override
+                  public String getMimeType() {
+                    return MediaType.TEXT_PLAIN.toString();
+                  }
+
+                  @Override
+                  public long getSize() {
+                    return 14;
+                  }
+
+                  @Override
+                  public Metadata getMetadata() {
+                    return null;
+                  }
+                });
+    return request;
+  }
+}

--- a/adapters/pom.xml
+++ b/adapters/pom.xml
@@ -16,5 +16,6 @@
 
   <modules>
     <module>ddf-adapter</module>
+    <module>ion-adapter</module>
   </modules>
 </project>

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -23,6 +23,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>replication-adapters</groupId>
+            <artifactId>ion-adapter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>replication</groupId>
             <artifactId>replication-api</artifactId>
             <version>${project.version}</version>

--- a/application/src/main/java/com/connexta/replication/application/Main.java
+++ b/application/src/main/java/com/connexta/replication/application/Main.java
@@ -17,6 +17,7 @@ import org.codice.ditto.replication.api.persistence.ReplicatorConfigManager;
 import org.codice.ditto.replication.api.persistence.ReplicatorHistoryManager;
 import org.codice.ditto.replication.api.persistence.SiteManager;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -30,7 +31,9 @@ import org.springframework.data.solr.repository.config.EnableSolrRepositories;
 public class Main {
 
   public static void main(String[] args) throws Exception {
-    SpringApplication.run(Main.class, args);
+    SpringApplication application = new SpringApplication(Main.class);
+    application.setWebApplicationType(WebApplicationType.NONE);
+    application.run(args);
     while (true) {
       Thread.sleep(1000);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
         <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
         <jbake.maven.plugin.version>0.3.1</jbake.maven.plugin.version>
         <javax.xml.soap.version>1.4.0</javax.xml.soap.version>
+        <jackson.version>2.9.9</jackson.version>
+        <spring.version>5.1.7.RELEASE</spring.version>
+        <spring-test.version>3.2.2.RELEASE</spring-test.version>
+        <annotation.version>1.3.1</annotation.version>
+        <reactive-streams.version>1.0.2</reactive-streams.version>
+
         <project.report.output.directory>project-info</project.report.output.directory>
 
         <!-- documentation replacements -->

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
@@ -280,11 +280,18 @@ public class ReplicatorImpl implements Replicator {
     return Collections.unmodifiableSet(new HashSet<>(activeSyncRequests));
   }
 
-  private NodeAdapter getStoreForId(String siteId) {
+  @VisibleForTesting
+  NodeAdapter getStoreForId(String siteId) {
     NodeAdapter store;
     ReplicationSite site = siteManager.get(siteId);
+    if (site.getType() == null) {
+      determineType(site);
+    }
     try {
-      store = nodeAdapters.factoryFor(NodeAdapterType.DDF).create(new URL(site.getUrl()));
+      store =
+          nodeAdapters
+              .factoryFor(NodeAdapterType.valueOf(site.getType()))
+              .create(new URL(site.getUrl()));
     } catch (Exception e) {
       throw new ReplicationException("Error connecting to node at " + site.getUrl(), e);
     }
@@ -292,6 +299,23 @@ public class ReplicatorImpl implements Replicator {
       throw new ReplicationException("System at " + site.getUrl() + " is currently unavailable");
     }
     return store;
+  }
+
+  private void determineType(ReplicationSite site) {
+    for (NodeAdapterType type : NodeAdapterType.values()) {
+      LOGGER.debug("Checking if site {} is of type {}", site.getName(), type.name());
+      try (NodeAdapter adapter = nodeAdapters.factoryFor(type).create(new URL(site.getUrl()))) {
+        if (adapter.isAvailable()) {
+          LOGGER.debug("Site {} is type {}", site.getName(), type.name());
+          site.setType(type.name());
+          siteManager.save(site);
+          return;
+        }
+      } catch (Exception e) {
+        LOGGER.debug(
+            "Checking node type failed for type {}. Reason: {}", type.name(), e.getMessage());
+      }
+    }
   }
 
   @VisibleForTesting

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationSiteImpl.java
@@ -37,6 +37,7 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
    */
   public static final int CURRENT_VERSION = 2;
 
+  @Indexed(name = "remote-managed_b")
   private boolean isRemoteManaged = false;
 
   @Indexed(name = "name_txt")
@@ -44,6 +45,9 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
 
   @Indexed(name = "url_txt")
   private String url;
+
+  @Indexed(name = "type_txt")
+  private String type;
 
   public ReplicationSiteImpl() {
     super.setVersion(CURRENT_VERSION);
@@ -77,5 +81,15 @@ public class ReplicationSiteImpl extends AbstractPersistable implements Replicat
   @Override
   public boolean isRemoteManaged() {
     return isRemoteManaged;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public void setType(String type) {
+    this.type = type;
   }
 }

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
@@ -13,6 +13,9 @@
  */
 package org.codice.ditto.replication.api.impl;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -30,6 +33,7 @@ import org.codice.ditto.replication.api.SyncRequest;
 import org.codice.ditto.replication.api.data.ReplicationSite;
 import org.codice.ditto.replication.api.data.ReplicationStatus;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
+import org.codice.ditto.replication.api.impl.data.ReplicationSiteImpl;
 import org.codice.ditto.replication.api.persistence.ReplicatorHistoryManager;
 import org.codice.ditto.replication.api.persistence.SiteManager;
 import org.junit.Before;
@@ -84,8 +88,10 @@ public class ReplicatorImplTest {
 
     ReplicationSite sourceSite = mock(ReplicationSite.class);
     when(sourceSite.getUrl()).thenReturn(SOURCE_URL);
+    when(sourceSite.getType()).thenReturn(NodeAdapterType.DDF.name());
     ReplicationSite destinationSite = mock(ReplicationSite.class);
     when(destinationSite.getUrl()).thenReturn(DESTINATION_URL);
+    when(destinationSite.getType()).thenReturn(NodeAdapterType.DDF.name());
 
     when(siteManager.get(SOURCE_ID)).thenReturn(sourceSite);
     when(siteManager.get(DESTINATION_ID)).thenReturn(destinationSite);
@@ -133,8 +139,10 @@ public class ReplicatorImplTest {
 
     ReplicationSite sourceSite = mock(ReplicationSite.class);
     when(sourceSite.getUrl()).thenReturn(SOURCE_URL);
+    when(sourceSite.getType()).thenReturn(NodeAdapterType.DDF.name());
     ReplicationSite destinationSite = mock(ReplicationSite.class);
     when(destinationSite.getUrl()).thenReturn(DESTINATION_URL);
+    when(destinationSite.getType()).thenReturn(NodeAdapterType.DDF.name());
 
     when(siteManager.get(SOURCE_ID)).thenReturn(sourceSite);
     when(siteManager.get(DESTINATION_ID)).thenReturn(destinationSite);
@@ -178,8 +186,10 @@ public class ReplicatorImplTest {
 
     ReplicationSite sourceSite = mock(ReplicationSite.class);
     when(sourceSite.getUrl()).thenReturn(SOURCE_URL);
+    when(sourceSite.getType()).thenReturn(NodeAdapterType.DDF.name());
     ReplicationSite destinationSite = mock(ReplicationSite.class);
     when(destinationSite.getUrl()).thenReturn(DESTINATION_URL);
+    when(destinationSite.getType()).thenReturn(NodeAdapterType.DDF.name());
 
     when(siteManager.get(SOURCE_ID)).thenReturn(sourceSite);
     when(siteManager.get(DESTINATION_ID)).thenReturn(destinationSite);
@@ -241,8 +251,10 @@ public class ReplicatorImplTest {
 
     ReplicationSite sourceSite = mock(ReplicationSite.class);
     when(sourceSite.getUrl()).thenReturn(SOURCE_URL);
+    when(sourceSite.getType()).thenReturn(NodeAdapterType.DDF.name());
     ReplicationSite destinationSite = mock(ReplicationSite.class);
     when(destinationSite.getUrl()).thenReturn(DESTINATION_URL);
+    when(destinationSite.getType()).thenReturn(NodeAdapterType.DDF.name());
 
     when(siteManager.get(SOURCE_ID)).thenReturn(sourceSite);
     when(siteManager.get(DESTINATION_ID)).thenReturn(destinationSite);
@@ -278,6 +290,27 @@ public class ReplicatorImplTest {
 
     // then
     verify(job).cancel();
+  }
+
+  @Test
+  public void testGetStoreForIdNoType() throws Exception {
+    ReplicationSite destinationSite = new ReplicationSiteImpl();
+    destinationSite.setUrl(DESTINATION_URL);
+    when(siteManager.get(DESTINATION_ID)).thenReturn(destinationSite);
+
+    NodeAdapter destinationNode = mock(NodeAdapter.class);
+    when(destinationNode.isAvailable()).thenReturn(true);
+
+    when(nodeAdapterFactory.create(new URL(DESTINATION_URL))).thenReturn(destinationNode);
+
+    when(nodeAdapters.factoryFor(NodeAdapterType.ION)).thenReturn(nodeAdapterFactory);
+    when(nodeAdapters.factoryFor(NodeAdapterType.DDF)).thenThrow(new RuntimeException("error"));
+
+    replicator.getStoreForId(DESTINATION_ID);
+
+    assertThat(destinationSite.getType(), is(NodeAdapterType.ION.name()));
+    verify(siteManager).save(destinationSite);
+    verify(nodeAdapters, times(3)).factoryFor(any(NodeAdapterType.class));
   }
 
   private ReplicatorConfig mockConfig() {

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/ReplicationSite.java
@@ -13,6 +13,8 @@
  */
 package org.codice.ditto.replication.api.data;
 
+import org.codice.ditto.replication.api.NodeAdapterType;
+
 /** A ReplicationSite holds information about a system to be replicated to/from */
 public interface ReplicationSite extends Persistable {
 
@@ -63,4 +65,19 @@ public interface ReplicationSite extends Persistable {
    * @return {@code true} if replication should not run locally, otherwise {@link false}.
    */
   boolean isRemoteManaged();
+
+  /**
+   * Get the type of this site as defined in {@link NodeAdapterType}. This type can be used to
+   * determine how to interact with the site.
+   *
+   * @return {@link NodeAdapterType}
+   */
+  String getType();
+
+  /**
+   * Sets the {@link NodeAdapterType} of this site.
+   *
+   * @param type the {@link NodeAdapterType}
+   */
+  void setType(String type);
 }


### PR DESCRIPTION
#### What does this PR do?
Adds an ION NodeAdapter

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@kcover @mcalcote 

#### How should this be tested? (List steps with links to updated documentation)
Create a node that points to an ION mock server.
Create a replication job with the ION node as the destination.
Verify product create requests are getting sent to the ION mock server. (the will not be successful because the mock server always returns failure.)

#### Any background context you want to provide?
This is just the initial adapter. The ION ingest endpoint is expected to change and mature so we will need to update this adapter as that happens.

#### What are the relevant tickets?
Fixes #102 

#### Checklist:
- [X] Update / Add Unit Tests
