### PR TITLE
Graphql Endpoint upgrades

### DIFF
--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/persist/CreateReplication.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/persist/CreateReplication.java
@@ -34,7 +34,7 @@ public class CreateReplication extends BaseFunctionField<ReplicationField> {
   public static final String FIELD_NAME = "createReplication";
 
   public static final String DESCRIPTION =
-      "Creates a replication. biDirectional defaults to false.";
+      "Creates a replication. If biDirectional is not provided, it defaults to false. If suspended is not provided, it defaults to false.";
 
   public static final ReplicationField RETURN_TYPE = new ReplicationField();
 
@@ -48,6 +48,8 @@ public class CreateReplication extends BaseFunctionField<ReplicationField> {
 
   private BooleanField biDirectional;
 
+  private BooleanField suspended;
+
   private ReplicationUtils replicationUtils;
 
   public CreateReplication(ReplicationUtils replicationUtils) {
@@ -58,6 +60,9 @@ public class CreateReplication extends BaseFunctionField<ReplicationField> {
     destination = new PidField("destinationId");
     filter = new StringField("filter");
     biDirectional = new BooleanField("biDirectional");
+    biDirectional.setValue(false);
+    suspended = new BooleanField("suspended");
+    suspended.setValue(false);
     name.isRequired(true);
     source.isRequired(true);
     destination.isRequired(true);
@@ -71,7 +76,8 @@ public class CreateReplication extends BaseFunctionField<ReplicationField> {
         source.getValue(),
         destination.getValue(),
         filter.getValue(),
-        biDirectional.getValue() == null ? false : biDirectional.getValue());
+        biDirectional.getValue(),
+        suspended.getValue());
   }
 
   @Override
@@ -81,7 +87,7 @@ public class CreateReplication extends BaseFunctionField<ReplicationField> {
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(name, source, destination, filter, biDirectional);
+    return ImmutableList.of(name, source, destination, filter, biDirectional, suspended);
   }
 
   @Override

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/persist/UpdateReplication.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/persist/UpdateReplication.java
@@ -24,15 +24,14 @@ import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ditto.replication.admin.query.ReplicationUtils;
-import org.codice.ditto.replication.admin.query.replications.fields.ReplicationField;
 
-public class UpdateReplication extends BaseFunctionField<ReplicationField> {
+public class UpdateReplication extends BaseFunctionField<BooleanField> {
 
   public static final String FIELD_NAME = "updateReplication";
 
   public static final String DESCRIPTION = "Updates a replication.";
 
-  public static final ReplicationField RETURN_TYPE = new ReplicationField();
+  public static final BooleanField RETURN_TYPE = new BooleanField();
 
   private PidField id;
 
@@ -46,6 +45,8 @@ public class UpdateReplication extends BaseFunctionField<ReplicationField> {
 
   private BooleanField biDirectional;
 
+  private BooleanField suspended;
+
   private ReplicationUtils replicationUtils;
 
   public UpdateReplication(ReplicationUtils replicationUtils) {
@@ -57,33 +58,35 @@ public class UpdateReplication extends BaseFunctionField<ReplicationField> {
     destination = new PidField("destinationId");
     filter = new StringField("filter");
     biDirectional = new BooleanField("biDirectional");
+    suspended = new BooleanField("suspended");
 
     id.isRequired(true);
   }
 
   @Override
-  public ReplicationField performFunction() {
-    return replicationUtils.updateReplication(
-        id.getValue(),
-        name.getValue(),
-        source.getValue(),
-        destination.getValue(),
-        filter.getValue(),
-        biDirectional.getValue());
+  public BooleanField performFunction() {
+    return new BooleanField(
+        replicationUtils.updateReplication(
+            id.getValue(),
+            name.getValue(),
+            source.getValue(),
+            destination.getValue(),
+            filter.getValue(),
+            biDirectional.getValue()));
   }
 
   @Override
-  public ReplicationField getReturnType() {
+  public BooleanField getReturnType() {
     return RETURN_TYPE;
   }
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(id, name, source, destination, filter, biDirectional);
+    return ImmutableList.of(id, name, source, destination, filter, biDirectional, suspended);
   }
 
   @Override
-  public FunctionField<ReplicationField> newInstance() {
+  public FunctionField<BooleanField> newInstance() {
     return new UpdateReplication(replicationUtils);
   }
 

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/fields/ReplicationSiteField.java
@@ -94,8 +94,8 @@ public class ReplicationSiteField extends BaseObjectField {
     return this;
   }
 
-  public ReplicationSiteField isDisableLocal(boolean isDisableLocal) {
-    this.remoteManaged.setValue(isDisableLocal);
+  public ReplicationSiteField isRemoteManaged(boolean isRemoteManaged) {
+    this.remoteManaged.setValue(isRemoteManaged);
     return this;
   }
 

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/CreateReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/CreateReplicationSite.java
@@ -24,6 +24,7 @@ import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ditto.replication.admin.query.ReplicationMessages;
 import org.codice.ditto.replication.admin.query.ReplicationUtils;
+import org.codice.ditto.replication.admin.query.sites.fields.RemoteManagedField;
 import org.codice.ditto.replication.admin.query.sites.fields.ReplicationSiteField;
 
 public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteField> {
@@ -31,7 +32,7 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
   public static final String FIELD_NAME = "createReplicationSite";
 
   public static final String DESCRIPTION =
-      "Creates a replication site. If no rootContext is provided, it will default to 'services'";
+      "Creates a replication site. If no rootContext is provided, it will default to 'services'. If no remoteManaged is provided, it will default to false.";
 
   private static final ReplicationSiteField RETURN_TYPE = new ReplicationSiteField();
 
@@ -40,6 +41,8 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
   private AddressField address;
 
   private StringField rootContext;
+
+  private RemoteManagedField remoteManagedField;
 
   private ReplicationUtils replicationUtils;
 
@@ -50,6 +53,9 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
     this.name = new StringField("name");
     this.address = new AddressField();
     this.rootContext = new StringField("rootContext");
+    this.remoteManagedField = new RemoteManagedField();
+    this.remoteManagedField.setValue(false);
+
     this.name.isRequired(true);
     this.address.isRequired(true);
     this.rootContext.isRequired(true);
@@ -57,7 +63,8 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
 
   @Override
   public ReplicationSiteField performFunction() {
-    return replicationUtils.createSite(name.getValue(), address, rootContext.getValue(), false);
+    return replicationUtils.createSite(
+        name.getValue(), address, rootContext.getValue(), remoteManagedField.getValue());
   }
 
   @Override
@@ -67,7 +74,7 @@ public class CreateReplicationSite extends BaseFunctionField<ReplicationSiteFiel
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(name, address, rootContext);
+    return ImmutableList.of(name, address, rootContext, remoteManagedField);
   }
 
   @Override

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSite.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSite.java
@@ -27,6 +27,7 @@ import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ditto.replication.admin.query.ReplicationMessages;
 import org.codice.ditto.replication.admin.query.ReplicationUtils;
+import org.codice.ditto.replication.admin.query.sites.fields.RemoteManagedField;
 
 public class UpdateReplicationSite extends BaseFunctionField<BooleanField> {
 
@@ -44,6 +45,8 @@ public class UpdateReplicationSite extends BaseFunctionField<BooleanField> {
 
   private StringField rootContext;
 
+  private RemoteManagedField remoteManagedField;
+
   private ReplicationUtils replicationUtils;
 
   public UpdateReplicationSite(ReplicationUtils replicationUtils) {
@@ -54,6 +57,8 @@ public class UpdateReplicationSite extends BaseFunctionField<BooleanField> {
     this.name = new StringField("name");
     this.address = new AddressField();
     this.rootContext = new StringField("rootContext");
+    this.remoteManagedField = new RemoteManagedField();
+    remoteManagedField.setValue(false);
 
     this.id.isRequired(true);
   }
@@ -62,7 +67,11 @@ public class UpdateReplicationSite extends BaseFunctionField<BooleanField> {
   public BooleanField performFunction() {
     return new BooleanField(
         replicationUtils.updateSite(
-            id.getValue(), name.getValue(), address, rootContext.getValue()));
+            id.getValue(),
+            name.getValue(),
+            address,
+            rootContext.getValue(),
+            remoteManagedField.getValue()));
   }
 
   @Override
@@ -72,7 +81,7 @@ public class UpdateReplicationSite extends BaseFunctionField<BooleanField> {
 
   @Override
   public List<Field> getArguments() {
-    return ImmutableList.of(id, name, address, rootContext);
+    return ImmutableList.of(id, name, address, rootContext, remoteManagedField);
   }
 
   @Override

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/replications/persist/CreateReplicationTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/replications/persist/CreateReplicationTest.java
@@ -34,16 +34,18 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CreateReplicationTest {
-  CreateReplication create;
 
-  Map<String, Object> input;
+  private CreateReplication create;
+
+  private Map<String, Object> input;
 
   @Mock ReplicationUtils utils;
 
   @Before
   public void setUp() throws Exception {
     create = new CreateReplication(utils);
-    when(utils.createReplication(anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+    when(utils.createReplication(
+            anyString(), anyString(), anyString(), anyString(), anyBoolean(), anyBoolean()))
         .thenReturn(new ReplicationField());
     input = new HashMap<>();
     input.put("id", "myid");
@@ -52,6 +54,7 @@ public class CreateReplicationTest {
     input.put("sourceId", "srcId");
     input.put("destinationId", "destId");
     input.put("biDirectional", false);
+    input.put("suspended", false);
   }
 
   @Test

--- a/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSiteTest.java
+++ b/admin/query/src/test/java/org/codice/ditto/replication/admin/query/sites/persist/UpdateReplicationSiteTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -65,7 +66,7 @@ public class UpdateReplicationSiteTest {
 
   private static final String SITE_HOSTNAME = "siteHostname";
 
-  private static final boolean SITE_IS_DISABLED_LOCAL = true;
+  private static final boolean IS_REMOTE_MANAGED = true;
 
   private UpdateReplicationSite updateReplicationSite;
 
@@ -88,7 +89,7 @@ public class UpdateReplicationSiteTest {
     input.put(NAME, SITE_NAME);
     input.put(ROOT_CONTEXT, SITE_CONTEXT);
     input.put(ADDRESS, addressField);
-    input.put(REMOTE_MANAGED, SITE_IS_DISABLED_LOCAL);
+    input.put(REMOTE_MANAGED, IS_REMOTE_MANAGED);
   }
 
   @Test
@@ -100,13 +101,14 @@ public class UpdateReplicationSiteTest {
 
     final boolean updateResult = true;
     when(replicationUtils.updateSite(
-            anyString(), anyString(), any(AddressField.class), anyString()))
+            anyString(), anyString(), any(AddressField.class), anyString(), anyBoolean()))
         .thenReturn(updateResult);
 
     ArgumentCaptor<AddressField> addressFieldCaptor = ArgumentCaptor.forClass(AddressField.class);
     ArgumentCaptor<String> nameCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> contextCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Boolean> remoteManagedCaptor = ArgumentCaptor.forClass(Boolean.class);
 
     // when
     FunctionReport<BooleanField> report = updateReplicationSite.execute(input, null);
@@ -119,7 +121,8 @@ public class UpdateReplicationSiteTest {
             idCaptor.capture(),
             nameCaptor.capture(),
             addressFieldCaptor.capture(),
-            contextCaptor.capture());
+            contextCaptor.capture(),
+            remoteManagedCaptor.capture());
 
     AddressField address = addressFieldCaptor.getValue();
     assertThat(address.host().hostname(), is(SITE_HOSTNAME));
@@ -127,6 +130,7 @@ public class UpdateReplicationSiteTest {
     assertThat(idCaptor.getValue(), is(SITE_ID));
     assertThat(nameCaptor.getValue(), is(SITE_NAME));
     assertThat(contextCaptor.getValue(), is(SITE_CONTEXT));
+    assertThat(remoteManagedCaptor.getValue(), is(IS_REMOTE_MANAGED));
   }
 
   @Test

--- a/distributions/test/itests/pom.xml
+++ b/distributions/test/itests/pom.xml
@@ -111,6 +111,32 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-ddf-common</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.codice.ddf.admin.query</groupId>
+                                    <artifactId>admin-query-common</artifactId>
+                                    <version>${admin-query.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                                    <excludes>**/META-INF/**,**/OSGI-INF/**</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/requests/GraphQLRequests.java
+++ b/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/requests/GraphQLRequests.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.requests;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.junit.Assert.fail;
+
+import com.jayway.restassured.response.ExtractableResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.IOUtils;
+import org.boon.Boon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class to facilitate sending GraphQL requests. Takes advantage of GraphQL variables to support
+ * graphql files that hold queries.
+ */
+public class GraphQLRequests {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GraphQLRequests.class);
+
+  public static final String USERNAME = "admin";
+
+  @SuppressWarnings("squid:S2068" /* Password used internally */)
+  public static final String PASSWORD = "admin";
+
+  private Class resourceClass;
+
+  private String queryResourcePath;
+
+  private String mutationResourcePath;
+
+  private String graphQlEndpoint;
+
+  public GraphQLRequests(
+      Class resourceClass,
+      String queryResourcePath,
+      String mutationResourcePath,
+      String graphQlEndpoint) {
+    this.resourceClass = resourceClass;
+    this.queryResourcePath = queryResourcePath;
+    this.mutationResourcePath = mutationResourcePath;
+    this.graphQlEndpoint = graphQlEndpoint;
+  }
+
+  public GraphQLRequest createRequest() {
+    return new GraphQLRequest(queryResourcePath, mutationResourcePath, graphQlEndpoint);
+  }
+
+  public static boolean responseHasErrors(ExtractableResponse response) {
+    return response != null && response.jsonPath().get("errors") != null;
+  }
+
+  public static <T> T extractResponse(ExtractableResponse response, String jsonPath) {
+    return response.jsonPath().get(jsonPath);
+  }
+
+  public class GraphQLRequest {
+    private String queryResourcePath;
+
+    private String mutationResourcePath;
+
+    private String mutationFile;
+
+    private String queryFile;
+
+    private String graphQlEndpoint;
+
+    private Map<String, Object> reqArgs;
+
+    private ExtractableResponse response;
+
+    public GraphQLRequest(
+        String queryResourcePath, String mutationResourcePath, String graphQlEndpoint) {
+      this.queryResourcePath = queryResourcePath;
+      this.mutationResourcePath = mutationResourcePath;
+      this.graphQlEndpoint = graphQlEndpoint;
+      this.reqArgs = new HashMap<>();
+    }
+
+    public GraphQLRequest addArgument(String argName, Object argValue) {
+      reqArgs.put(argName, argValue);
+      return this;
+    }
+
+    public GraphQLRequest addArguments(Map<String, Object> args) {
+      for (Map.Entry<String, Object> arg : args.entrySet()) {
+        addArgument(arg.getKey(), arg.getValue());
+      }
+      return this;
+    }
+
+    public GraphQLRequest usingQuery(String queryFileName) {
+      this.queryFile = queryFileName;
+      return this;
+    }
+
+    public GraphQLRequest usingMutation(String mutationFileName) {
+      this.mutationFile = mutationFileName;
+      return this;
+    }
+
+    private String getResourceAsString(String filePath) {
+      try {
+        return IOUtils.toString(resourceClass.getResourceAsStream(filePath), "UTF-8");
+      } catch (IOException e) {
+        fail("Unable to retrieve resource: " + filePath);
+      }
+
+      return null;
+    }
+
+    public GraphQLRequest send() {
+      Map<String, String> query = new HashMap<>();
+
+      String queryBody = null;
+
+      if (queryFile != null) {
+        queryBody = getResourceAsString(queryResourcePath + queryFile);
+      } else if (mutationFile != null) {
+        queryBody = getResourceAsString(mutationResourcePath + mutationFile);
+      } else {
+        fail(
+            "Failed to send GraphQLRequest. A query or mutation file must be specified before attempting to send the request.");
+      }
+      query.put("query", queryBody);
+
+      if (!reqArgs.isEmpty()) {
+        query.put("variables", Boon.toJson(reqArgs));
+      }
+
+      String queryStr = Boon.toPrettyJson(query);
+      LOGGER.debug("\nSending request:\n{}", queryStr);
+
+      response =
+          given()
+              .header("Content-Type", "application/json")
+              .relaxedHTTPSValidation()
+              .auth()
+              .preemptive()
+              .basic(USERNAME, PASSWORD)
+              .header("X-Requested-With", "XMLHttpRequest")
+              .body(queryStr)
+              .post(graphQlEndpoint)
+              .then()
+              .extract();
+
+      String responseBody = response.body().asString();
+      LOGGER.debug("\nReplied with:\n{}", responseBody);
+
+      return this;
+    }
+
+    public ExtractableResponse getResponse() {
+      return response;
+    }
+  }
+}

--- a/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/requests/ReplicationsGraphQL.java
+++ b/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/requests/ReplicationsGraphQL.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.requests;
+
+import com.jayway.restassured.response.ExtractableResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.codice.ditto.replication.admin.query.requests.GraphQLRequests.GraphQLRequest;
+
+public class ReplicationsGraphQL {
+
+  private GraphQLRequests requestFactory;
+
+  public ReplicationsGraphQL(String graphqlEndpoint) {
+    requestFactory =
+        new GraphQLRequests(
+            ReplicationsGraphQL.class,
+            "/query/replications/query/",
+            "/query/replications/mutation/",
+            graphqlEndpoint);
+  }
+
+  public List<Map<String, Object>> getAllReplications() {
+    GraphQLRequest graphQLRequest = requestFactory.createRequest();
+    graphQLRequest.usingQuery("AllReplications.graphql");
+
+    ExtractableResponse response = graphQLRequest.send().getResponse();
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return Collections.emptyList();
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.replication.replications");
+  }
+
+  public void waitForNoReplications() {
+    Awaitility.await("wait for no replications")
+        .atMost(30L, TimeUnit.SECONDS)
+        .until(() -> getAllReplications().size() == 0);
+  }
+
+  public Map<String, Object> createReplication(
+      String name,
+      String sourceId,
+      String destinationId,
+      String filter,
+      boolean biDirectional,
+      boolean suspended) {
+    ExtractableResponse response =
+        requestFactory
+            .createRequest()
+            .usingMutation("CreateReplication.graphql")
+            .addArgument("name", name)
+            .addArgument("sourceId", sourceId)
+            .addArgument("destinationId", destinationId)
+            .addArgument("filter", filter)
+            .addArgument("biDirectional", biDirectional)
+            .addArgument("suspended", suspended)
+            .send()
+            .getResponse();
+
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return Collections.emptyMap();
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.createReplication");
+  }
+
+  public boolean updateReplication(
+      String id,
+      String name,
+      String sourceId,
+      String destinationId,
+      String filter,
+      boolean biDirectional,
+      boolean suspended) {
+    ExtractableResponse response =
+        requestFactory
+            .createRequest()
+            .usingMutation("UpdateReplication.graphql")
+            .addArgument("id", id)
+            .addArgument("name", name)
+            .addArgument("sourceId", sourceId)
+            .addArgument("destinationId", destinationId)
+            .addArgument("filter", filter)
+            .addArgument("biDirectional", biDirectional)
+            .addArgument("suspended", suspended)
+            .send()
+            .getResponse();
+
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return false;
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.updateReplication");
+  }
+
+  public void waitForReplicationWithName(String name) {
+    Awaitility.await(String.format("failed to retrieve expected replication with name %s", name))
+        .atMost(30L, TimeUnit.SECONDS)
+        .until(
+            () ->
+                getAllReplications().stream().anyMatch(config -> config.get("name").equals(name)));
+  }
+
+  public boolean deleteReplication(String pid) {
+    ExtractableResponse response =
+        requestFactory
+            .createRequest()
+            .usingMutation("DeleteReplication.graphql")
+            .addArgument("id", pid)
+            .send()
+            .getResponse();
+
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return false;
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.deleteReplication");
+  }
+
+  public void waitForReplication(Map<String, Object> expectedConfig) {
+    Awaitility.await("failed to retrieve expected replication")
+        .atMost(30L, TimeUnit.SECONDS)
+        .until(() -> getAllReplications().stream().anyMatch(expectedConfig::equals));
+  }
+}

--- a/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/requests/SitesGraphQL.java
+++ b/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/requests/SitesGraphQL.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.requests;
+
+import com.jayway.restassured.response.ExtractableResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.codice.ddf.admin.common.fields.common.AddressField;
+import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ditto.replication.admin.query.requests.GraphQLRequests.GraphQLRequest;
+
+public class SitesGraphQL {
+
+  private GraphQLRequests requestFactory;
+
+  public SitesGraphQL(String graphqlEndpoint) {
+    requestFactory =
+        new GraphQLRequests(
+            SitesGraphQL.class, "/query/sites/query/", "/query/sites/mutation/", graphqlEndpoint);
+  }
+
+  public void waitForSitesInSchema() {
+    Awaitility.await("get sites in schema")
+        .atMost(30L, TimeUnit.SECONDS)
+        .until(
+            () -> {
+              GraphQLRequest graphQLRequest = requestFactory.createRequest();
+              graphQLRequest.usingQuery("AllSites.graphql");
+
+              ExtractableResponse response = graphQLRequest.send().getResponse();
+              if (GraphQLRequests.responseHasErrors(response)) {
+                return false;
+              }
+
+              return GraphQLRequests.extractResponse(response, "data") != null;
+            });
+  }
+
+  public List<Map<String, Object>> getAllSites() {
+    GraphQLRequest graphQLRequest = requestFactory.createRequest();
+    graphQLRequest.usingQuery("AllSites.graphql");
+
+    ExtractableResponse response = graphQLRequest.send().getResponse();
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return Collections.emptyList();
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.replication.sites");
+  }
+
+  public Map<String, Object> createSite(
+      String name, String rootContext, AddressField address, boolean remoteManaged) {
+    ExtractableResponse response =
+        requestFactory
+            .createRequest()
+            .usingMutation("CreateSite.graphql")
+            .addArgument("name", name)
+            .addArgument("rootContext", rootContext)
+            .addArgument("address", address.getValue())
+            .addArgument("remoteManaged", remoteManaged)
+            .send()
+            .getResponse();
+
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return Collections.emptyMap();
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.createReplicationSite");
+  }
+
+  public boolean updateSite(
+      String id, String name, String rootContext, AddressField address, boolean remoteManaged) {
+    ExtractableResponse response =
+        requestFactory
+            .createRequest()
+            .usingMutation("UpdateSite.graphql")
+            .addArgument("id", id)
+            .addArgument("name", name)
+            .addArgument("rootContext", rootContext)
+            .addArgument("address", address.getValue())
+            .addArgument("remoteManaged", remoteManaged)
+            .send()
+            .getResponse();
+
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return false;
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.updateReplicationSite");
+  }
+
+  public void waitForSite(Map<String, Object> expectedConfig) {
+    Awaitility.await("failed to retrieve expected site")
+        .atMost(30L, TimeUnit.SECONDS)
+        .until(() -> getAllSites().stream().anyMatch(expectedConfig::equals));
+  }
+
+  public void waitForSiteWithName(String name) {
+    Awaitility.await(String.format("failed to retrieve expected site with name %s", name))
+        .atMost(30L, TimeUnit.SECONDS)
+        .until(() -> getAllSites().stream().anyMatch(config -> config.get("name").equals(name)));
+  }
+
+  public boolean deleteSite(String pid) {
+    PidField pidField = new PidField();
+    pidField.setValue(pid);
+
+    ExtractableResponse response =
+        requestFactory
+            .createRequest()
+            .usingMutation("DeleteSite.graphql")
+            .addArgument("id", pidField.getValue())
+            .send()
+            .getResponse();
+
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return false;
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.deleteReplicationSite");
+  }
+}

--- a/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/requests/StatsGraphQL.java
+++ b/distributions/test/itests/src/test/java/org/codice/ditto/replication/admin/query/requests/StatsGraphQL.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ditto.replication.admin.query.requests;
+
+import com.jayway.restassured.response.ExtractableResponse;
+import java.util.Map;
+
+public class StatsGraphQL {
+
+  private GraphQLRequests requestFactory;
+
+  public StatsGraphQL(String graphqlEndpoint) {
+    requestFactory =
+        new GraphQLRequests(
+            StatsGraphQL.class, "/query/stats/query/", "/query/stats/mutation/", graphqlEndpoint);
+  }
+
+  public boolean updateStats(String replicationName, Map<String, Object> stats) {
+    ExtractableResponse response =
+        requestFactory
+            .createRequest()
+            .usingMutation("UpdateStats.graphql")
+            .addArgument("replicationName", replicationName)
+            .addArgument("stats", stats)
+            .send()
+            .getResponse();
+
+    if (GraphQLRequests.responseHasErrors(response)) {
+      return false;
+    }
+
+    return GraphQLRequests.extractResponse(response, "data.updateReplicationStats");
+  }
+}

--- a/distributions/test/itests/src/test/resources/query/replications/mutation/CreateReplication.graphql
+++ b/distributions/test/itests/src/test/resources/query/replications/mutation/CreateReplication.graphql
@@ -1,0 +1,10 @@
+mutation CreateReplication($name: String!, $sourceId: Pid!, $destinationId: Pid!, $filter: String!, $biDirectional: Boolean, $suspended: Boolean) {
+    createReplication(name: $name, sourceId: $sourceId, destinationId: $destinationId, filter: $filter, biDirectional: $biDirectional, suspended: $suspended) {
+        name
+        id
+        filter
+        biDirectional
+        suspended
+        version
+    }
+}

--- a/distributions/test/itests/src/test/resources/query/replications/mutation/DeleteReplication.graphql
+++ b/distributions/test/itests/src/test/resources/query/replications/mutation/DeleteReplication.graphql
@@ -1,0 +1,3 @@
+mutation DeleteReplication($id: Pid!) {
+    deleteReplication(id: $id)
+}

--- a/distributions/test/itests/src/test/resources/query/replications/mutation/UpdateReplication.graphql
+++ b/distributions/test/itests/src/test/resources/query/replications/mutation/UpdateReplication.graphql
@@ -1,0 +1,3 @@
+mutation UpdateReplication($id: Pid!, $name: String!, $sourceId: Pid!, $destinationId: Pid!, $filter: String!, $biDirectional: Boolean, $suspended: Boolean) {
+    updateReplication(id: $id, name: $name, sourceId: $sourceId, destinationId: $destinationId, filter: $filter, biDirectional: $biDirectional, suspended: $suspended)
+}

--- a/distributions/test/itests/src/test/resources/query/replications/query/AllReplications.graphql
+++ b/distributions/test/itests/src/test/resources/query/replications/query/AllReplications.graphql
@@ -1,0 +1,12 @@
+query GetReplications {
+    replication {
+        replications {
+            name
+            id
+            filter
+            biDirectional
+            suspended
+            version
+        }
+    }
+}

--- a/distributions/test/itests/src/test/resources/query/sites/mutation/CreateSite.graphql
+++ b/distributions/test/itests/src/test/resources/query/sites/mutation/CreateSite.graphql
@@ -1,0 +1,12 @@
+mutation CreateReplicationSite($name: String!, $address: Address!, $rootContext: String!, $remoteManaged: Boolean) {
+    createReplicationSite(name: $name, address: $address, rootContext: $rootContext, remoteManaged: $remoteManaged) {
+        id
+        name
+        rootContext
+        address {
+            url
+        }
+        version
+        remoteManaged
+    }
+}

--- a/distributions/test/itests/src/test/resources/query/sites/mutation/DeleteSite.graphql
+++ b/distributions/test/itests/src/test/resources/query/sites/mutation/DeleteSite.graphql
@@ -1,0 +1,3 @@
+mutation DeleteReplicationSite ($id: Pid!) {
+    deleteReplicationSite (id: $id)
+}

--- a/distributions/test/itests/src/test/resources/query/sites/mutation/UpdateSite.graphql
+++ b/distributions/test/itests/src/test/resources/query/sites/mutation/UpdateSite.graphql
@@ -1,0 +1,3 @@
+mutation UpdateSite($id: Pid!, $name: String, $address: Address, $rootContext: String, $remoteManaged: Boolean){
+    updateReplicationSite(id: $id, name: $name, address: $address, rootContext: $rootContext, remoteManaged: $remoteManaged)
+}

--- a/distributions/test/itests/src/test/resources/query/sites/query/AllSites.graphql
+++ b/distributions/test/itests/src/test/resources/query/sites/query/AllSites.graphql
@@ -1,0 +1,14 @@
+query allSites {
+  replication {
+    sites {
+      id
+      name
+      rootContext
+      address {
+        url
+      }
+      version
+      remoteManaged
+    }
+  }
+}

--- a/distributions/test/itests/src/test/resources/query/stats/mutation/UpdateStats.graphql
+++ b/distributions/test/itests/src/test/resources/query/stats/mutation/UpdateStats.graphql
@@ -1,0 +1,3 @@
+mutation UpdateStats($replicationName: String!, $stats: ReplicationStats!) {
+    updateReplicationStats(replicationName: $replicationName, stats: $stats)
+}

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationStatusImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/data/ReplicationStatusImpl.java
@@ -27,27 +27,27 @@ public class ReplicationStatusImpl implements ReplicationStatus {
 
   private volatile Date startTime;
 
-  @Nullable private volatile Date lastSuccess;
+  @Nullable private Date lastSuccess;
 
-  @Nullable private volatile Date lastRun;
+  @Nullable private Date lastRun;
 
-  @Nullable private volatile Date lastMetadataModified;
+  @Nullable private Date lastMetadataModified;
 
-  private volatile long duration = -1;
+  private long duration = -1;
 
-  private volatile Status status = Status.PENDING;
+  private Status status = Status.PENDING;
 
-  private volatile long pushCount = 0;
+  private long pushCount = 0;
 
-  private volatile long pullCount = 0;
+  private long pullCount = 0;
 
-  private volatile long pushFailCount = 0;
+  private long pushFailCount = 0;
 
-  private volatile long pullFailCount = 0;
+  private long pullFailCount = 0;
 
-  private volatile long pushBytes = 0;
+  private long pushBytes = 0;
 
-  private volatile long pullBytes = 0;
+  private long pullBytes = 0;
 
   public ReplicationStatusImpl(String replicatorName) {
     this.replicatorName = replicatorName;

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,6 +23,7 @@
     "@babel/polyfill": "7.2.5",
     "@material-ui/core": "3.9.2",
     "@material-ui/icons": "3.0.2",
+    "@material-ui/styles": "4.1.2",
     "apollo-cache-inmemory": "1.5.1",
     "apollo-client": "2.5.1",
     "apollo-link-http": "1.5.14",
@@ -76,8 +77,8 @@
     "coverageThreshold": {
       "global": {
         "statements": 5,
-        "branches": 6,
-        "lines": 6,
+        "branches": 5,
+        "lines": 5,
         "functions": 1
       }
     },

--- a/ui/src/main/webapp/components/replications/gql/fragments.js
+++ b/ui/src/main/webapp/components/replications/gql/fragments.js
@@ -1,0 +1,29 @@
+import gql from 'graphql-tag'
+import { sites } from '../../sites/gql/fragments'
+
+export const replications = gql`
+  fragment ReplicationConfig on ReplicationConfigPayload {
+    name
+    id
+    source {
+      ...ReplicationSite
+    }
+    destination {
+      ...ReplicationSite
+    }
+    biDirectional
+    filter
+    suspended
+    stats {
+      replicationStatus
+      pushCount
+      pullCount
+      pushBytes
+      pullBytes
+      lastRun
+      lastSuccess
+      startTime
+    }
+  }
+  ${sites}
+`

--- a/ui/src/main/webapp/components/replications/gql/mutations.js
+++ b/ui/src/main/webapp/components/replications/gql/mutations.js
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 import gql from 'graphql-tag'
+import { replications } from './fragments'
 
 export const addReplication = gql`
   mutation createReplication(
@@ -28,37 +29,10 @@ export const addReplication = gql`
       filter: $filter
       biDirectional: $biDirectional
     ) {
-      name
-      id
-      source {
-        id
-        name
-        address {
-          url
-        }
-      }
-      destination {
-        id
-        name
-        address {
-          url
-        }
-      }
-      biDirectional
-      filter
-      suspended
-      stats {
-        replicationStatus
-        pushCount
-        pullCount
-        pushBytes
-        pullBytes
-        lastRun
-        lastSuccess
-        startTime
-      }
+      ...ReplicationConfig
     }
   }
+  ${replications}
 `
 export const suspendReplication = gql`
   mutation suspendReplication($id: Pid!, $suspend: Boolean!) {

--- a/ui/src/main/webapp/components/replications/gql/queries.js
+++ b/ui/src/main/webapp/components/replications/gql/queries.js
@@ -12,41 +12,15 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 import gql from 'graphql-tag'
+import { replications } from './fragments'
 
 export const allReplications = gql`
   {
     replication {
       replications {
-        id
-        name
-        source {
-          id
-          name
-          address {
-            url
-          }
-        }
-        destination {
-          id
-          name
-          address {
-            url
-          }
-        }
-        biDirectional
-        filter
-        suspended
-        stats {
-          replicationStatus
-          pushCount
-          pullCount
-          pushBytes
-          pullBytes
-          lastRun
-          lastSuccess
-          startTime
-        }
+        ...ReplicationConfig
       }
     }
   }
+  ${replications}
 `

--- a/ui/src/main/webapp/components/sites/Site.js
+++ b/ui/src/main/webapp/components/sites/Site.js
@@ -22,6 +22,7 @@ import {
   Tooltip,
 } from '@material-ui/core'
 import DeleteForever from '@material-ui/icons/DeleteForever'
+import Cloud from '@material-ui/icons/Cloud'
 import CardActions from '@material-ui/core/CardActions'
 import { Mutation } from 'react-apollo'
 import { allSites } from './gql/queries'
@@ -58,7 +59,14 @@ const styles = {
 
 class Site extends React.Component {
   render() {
-    const { name, content, id, classes, enqueueSnackbar } = this.props
+    const {
+      name,
+      content,
+      remoteManaged,
+      id,
+      classes,
+      enqueueSnackbar,
+    } = this.props
 
     return (
       <Card className={classes.card}>
@@ -138,6 +146,11 @@ class Site extends React.Component {
               {content}
             </Typography>
           </Tooltip>
+          {remoteManaged ? (
+            <Tooltip title='This Node has been identified as Cloud ready and any Replication involving this Node will be remotely managed, and will no longer run locally.'>
+              <Cloud />
+            </Tooltip>
+          ) : null}
         </CardContent>
       </Card>
     )
@@ -148,6 +161,7 @@ Site.propTypes = {
   name: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
+  remoteManaged: PropTypes.bool.isRequired,
 }
 
 export default withStyles(styles)(withSnackbar(Site))

--- a/ui/src/main/webapp/components/sites/Sites.js
+++ b/ui/src/main/webapp/components/sites/Sites.js
@@ -27,6 +27,7 @@ export default function Sites(props) {
             name={site.name}
             content={site.address.url}
             id={site.id}
+            remoteManaged={site.remoteManaged}
           />
         ))}
     </Fragment>

--- a/ui/src/main/webapp/components/sites/gql/fragments.js
+++ b/ui/src/main/webapp/components/sites/gql/fragments.js
@@ -1,0 +1,12 @@
+import gql from 'graphql-tag'
+
+export const sites = gql`
+  fragment ReplicationSite on ReplicationSitePayload {
+    id
+    name
+    remoteManaged
+    address {
+      url
+    }
+  }
+`

--- a/ui/src/main/webapp/components/sites/gql/mutations.js
+++ b/ui/src/main/webapp/components/sites/gql/mutations.js
@@ -12,6 +12,7 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 import gql from 'graphql-tag'
+import { sites } from './fragments'
 
 export const deleteSite = gql`
   mutation deleteReplicationSite($id: Pid!) {
@@ -29,12 +30,9 @@ export const addSite = gql`
       address: $address
       rootContext: $rootContext
     ) {
-      id
-      name
-      address {
-        url
-      }
+      ...ReplicationSite
       rootContext
     }
   }
+  ${sites}
 `

--- a/ui/src/main/webapp/components/sites/gql/queries.js
+++ b/ui/src/main/webapp/components/sites/gql/queries.js
@@ -12,17 +12,15 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
 import gql from 'graphql-tag'
+import { sites } from './fragments'
 
 export const allSites = gql`
   {
     replication {
       sites {
-        id
-        name
-        address {
-          url
-        }
+        ...ReplicationSite
       }
     }
   }
+  ${sites}
 `

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -690,6 +690,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.3.1":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
+  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.0.0", "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -732,6 +739,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@emotion/hash@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
+  integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==
+
 "@material-ui/core@3.9.2":
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.9.2.tgz#41ed1a470e981d199829eb5d9317a671c66a6f7d"
@@ -773,6 +785,30 @@
     "@babel/runtime" "^7.2.0"
     recompose "0.28.0 - 0.30.0"
 
+"@material-ui/styles@4.1.2":
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.1.2.tgz#f22cb0d8f60a5e4a4b92f1ffb4b56f825ff89034"
+  integrity sha512-IRwhGI3OzxMKIDXnYl/vi9FD/i5ZktVP2m/5PIf/HVdvhqUZGIzqR2OB/9f3W1hc+kKKExdOPlpZpVihIsJWkA==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    "@emotion/hash" "^0.7.1"
+    "@material-ui/types" "^4.1.1"
+    "@material-ui/utils" "^4.1.0"
+    clsx "^1.0.2"
+    csstype "^2.5.2"
+    deepmerge "^3.0.0"
+    hoist-non-react-statics "^3.2.1"
+    jss "10.0.0-alpha.17"
+    jss-plugin-camel-case "10.0.0-alpha.17"
+    jss-plugin-default-unit "10.0.0-alpha.17"
+    jss-plugin-global "10.0.0-alpha.17"
+    jss-plugin-nested "10.0.0-alpha.17"
+    jss-plugin-props-sort "10.0.0-alpha.17"
+    jss-plugin-rule-value-function "10.0.0-alpha.17"
+    jss-plugin-vendor-prefixer "10.0.0-alpha.17"
+    prop-types "^15.7.2"
+    warning "^4.0.1"
+
 "@material-ui/system@^3.0.0-alpha.0":
   version "3.0.0-alpha.1"
   resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-3.0.0-alpha.1.tgz#9309e79a88dc069323b4adbf42e844a2facaf93b"
@@ -783,6 +819,13 @@
     prop-types "^15.6.0"
     warning "^4.0.1"
 
+"@material-ui/types@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-4.1.1.tgz#b65e002d926089970a3271213a3ad7a21b17f02b"
+  integrity sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==
+  dependencies:
+    "@types/react" "*"
+
 "@material-ui/utils@^3.0.0-alpha.2":
   version "3.0.0-alpha.3"
   resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-3.0.0-alpha.3.tgz#836c62ea46f5ffc6f0b5ea05ab814704a86908b1"
@@ -791,6 +834,15 @@
     "@babel/runtime" "^7.2.0"
     prop-types "^15.6.0"
     react-is "^16.6.3"
+
+"@material-ui/utils@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.1.0.tgz#45fd6698db49f3528fe45c922c496235021d76ec"
+  integrity sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    prop-types "^15.7.2"
+    react-is "^16.8.0"
 
 "@types/jss@^9.5.6":
   version "9.5.7"
@@ -1894,6 +1946,11 @@ cliui@^4.0.0:
     strip-ansi "^4.0.0"
     wrap-ansi "^2.0.0"
 
+clsx@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
+  integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2176,6 +2233,14 @@ css-vendor@^0.3.8:
   resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-0.3.8.tgz#6421cfd3034ce664fe7673972fd0119fc28941fa"
   integrity sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=
   dependencies:
+    is-in-browser "^1.0.2"
+
+css-vendor@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.5.tgz#949c58fd5307e79a9417daa0939506f0e5d0a187"
+  integrity sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
     is-in-browser "^1.0.2"
 
 css-what@2.1:
@@ -3738,6 +3803,11 @@ hyphenate-style-name@^1.0.2:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
   integrity sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=
 
+hyphenate-style-name@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
+  integrity sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ==
+
 iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
@@ -4746,6 +4816,65 @@ jss-nested@^6.0.1:
   dependencies:
     warning "^3.0.0"
 
+jss-plugin-camel-case@10.0.0-alpha.17:
+  version "10.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.17.tgz#6f7c9d9742e349bb061e53cd9b1c3cb006169a67"
+  integrity sha512-aPY4kr6MwliH7KToLRzeSk1NxXUo9n7MQsAa0Hghwj01x9UnMkDkGAKENMKUtPjGkQZfiJpB9tTLFrSJ/6VrIQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hyphenate-style-name "^1.0.3"
+    jss "10.0.0-alpha.17"
+
+jss-plugin-default-unit@10.0.0-alpha.17:
+  version "10.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.17.tgz#4e3bf6d8e9691a8e05d50b5abf300515eb0f67ee"
+  integrity sha512-KQgiXczvzJ9AlFdD8NS7FZLub0NSctSrCA9Yi/GqdsfJg4ZCriU4DzIybCZBHCi/INFGJmLIESYWSxnuhAzgSQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.0.0-alpha.17"
+
+jss-plugin-global@10.0.0-alpha.17:
+  version "10.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.17.tgz#13005f6b963aee3c1498fe2bad767967ad2eb838"
+  integrity sha512-WYxiwwI+CLk0ozW8loeceqXBAZXBMsLBEZeRwVf9WX+FljdJkGwVZpRCk6LBX4aXnqAGyKqCxIAIJ3KP2yBdEg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.0.0-alpha.17"
+
+jss-plugin-nested@10.0.0-alpha.17:
+  version "10.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.17.tgz#cb1c20cdc81558c164eaa333bbb24c88bef12202"
+  integrity sha512-onpFqv904KCujryf2t6IIV1/QoB7cSF7ojrd4UujcN5TPvYOvXF5bchi7jnHG5U0SLlRSDGMLJ9fhtoCknhEbw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.0.0-alpha.17"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@10.0.0-alpha.17:
+  version "10.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.17.tgz#a49be72b8dc8e2861f8136661c53d130abb07ccd"
+  integrity sha512-KnbyrxCbtQTqpDx2mSZU/r/E5QnDPIVfIxRi8K+W/q4gZpomBvqWC+xgvAk9hbpmA6QBoQaOilV8o12w2IZ6fg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.0.0-alpha.17"
+
+jss-plugin-rule-value-function@10.0.0-alpha.17:
+  version "10.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.17.tgz#45617ccc2d695d77287554e7dbe3b9c37f5f5af4"
+  integrity sha512-8AuJB44Q+ehfkWVRi2XlRbUf6SrLmrHTa5EXd6dgQRCCRuvGmqX8Dl4fZvNeKRFjTLPZgzg9+31rqeOMhKa2vA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.0.0-alpha.17"
+
+jss-plugin-vendor-prefixer@10.0.0-alpha.17:
+  version "10.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.17.tgz#7bb05076d1a14d20b567231c36e57ebf6cb6625f"
+  integrity sha512-wDq9EL0QaoMGSGifPEBb+/SA9LBcqPEW0jpL9ht+Z2t+lV7NNz0j7uCEOuE6FvNWqHzUKTsiATs1rTHPkzNBEQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    css-vendor "^2.0.1"
+    jss "10.0.0-alpha.17"
+
 jss-props-sort@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/jss-props-sort/-/jss-props-sort-6.0.0.tgz#9105101a3b5071fab61e2d85ea74cc22e9b16323"
@@ -4757,6 +4886,15 @@ jss-vendor-prefixer@^7.0.0:
   integrity sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==
   dependencies:
     css-vendor "^0.3.8"
+
+jss@10.0.0-alpha.17:
+  version "10.0.0-alpha.17"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.0.0-alpha.17.tgz#3057c85a846c3bd207c04aafd91c8277955d9c57"
+  integrity sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 jss@^9.8.7:
   version "9.8.7"
@@ -6075,7 +6213,7 @@ prop-types@15.6.2, prop-types@^15.6.0, prop-types@^15.6.1:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6292,6 +6430,11 @@ react-is@^16.3.2, react-is@^16.6.1, react-is@^16.6.3, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
+react-is@^16.8.0:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 react-is@^16.8.1:
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
@@ -6467,6 +6610,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.13.3:
   version "0.13.3"
@@ -7407,6 +7555,11 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-warning@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.2.tgz#1dfae771ee1a04396bdfde27a3adcebc6b648b28"
+  integrity sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
#### What does this PR do?
- Exposes additional fields over the graphql endpoint
- Adds itests
- UI support for displaying remote managed sites/configs

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@kcover @clockard 

#### How should this be tested? (List steps with links to updated documentation)
Full build.

- Create a remote managed site through GraphiQL
- Create a suspended replication with the remote site through GraphiQL
- Verify creating a Replication and Site through the UI.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/17572782/60139618-68f5b380-9763-11e9-844e-8a886c59412c.png)
![image](https://user-images.githubusercontent.com/17572782/60139637-7b6fed00-9763-11e9-8209-b7b737b84d63.png)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
