### PR TITLE
REP-119 Fix failure retry query bug

### DIFF
--- a/adapters/ddf-adapter/pom.xml
+++ b/adapters/ddf-adapter/pom.xml
@@ -244,7 +244,7 @@
                     <limit implementation="org.codice.jacoco.LenientLimit">
                       <counter>COMPLEXITY</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.82</minimum>
+                      <minimum>0.83</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/DdfNodeAdapter.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/DdfNodeAdapter.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status.Family;
@@ -261,13 +262,14 @@ public class DdfNodeAdapter implements NodeAdapter {
 
   @Override
   public QueryResponse query(QueryRequest queryRequest) {
+    // Failed items and new items are queried separately due to a bug in DDF that was only fixed
+    // recently
     Iterable<Metadata> results =
         ResultIterable.resultIterable(
             this::getRecords,
-            new QueryRequestImpl(
-                createQueryFilter(queryRequest),
-                queryRequest.getStartIndex(),
-                queryRequest.getPageSize()));
+            createDdfFailedItemQueryRequest(queryRequest),
+            createDdfQueryRequest(queryRequest));
+
     return new QueryResponseImpl(results);
   }
 
@@ -367,7 +369,24 @@ public class DdfNodeAdapter implements NodeAdapter {
   }
 
   @VisibleForTesting
-  String createQueryFilter(QueryRequest queryRequest) {
+  @Nullable
+  QueryRequest createDdfFailedItemQueryRequest(QueryRequest queryRequest) {
+    if (queryRequest.getFailedItemIds().isEmpty()) {
+      return null;
+    }
+
+    final List<String> failedItemFilters = new ArrayList<>();
+    for (String itemId : queryRequest.getFailedItemIds()) {
+      failedItemFilters.add(equalTo(METACARD_ID, itemId));
+    }
+
+    String filter = anyOf(failedItemFilters);
+    LOGGER.debug("Failed items filter: {}", filter);
+    return new QueryRequestImpl(filter, queryRequest.getStartIndex(), queryRequest.getPageSize());
+  }
+
+  @VisibleForTesting
+  QueryRequest createDdfQueryRequest(QueryRequest queryRequest) {
     String cql = queryRequest.getCql();
     if (!cql.trim().startsWith("[")) {
       cql = "[ " + cql + " ]";
@@ -380,12 +399,11 @@ public class DdfNodeAdapter implements NodeAdapter {
     }
     filters.add(equalTo(METACARD_TAGS, DEFAULT_TAG));
 
-    final List<String> failedItemFilters = new ArrayList<>();
+    final List<String> deletedFailedItemFilters = new ArrayList<>();
     for (String itemId : queryRequest.getFailedItemIds()) {
-      failedItemFilters.add(
-          anyOf(
-              equalTo(METACARD_ID, itemId),
-              allOf(equalTo(Constants.VERSION_OF_ID, itemId), like(ACTION, "Deleted*"))));
+      // filter for items that failed to replicate and were deleted since the last attempt
+      deletedFailedItemFilters.add(
+          allOf(equalTo(Constants.VERSION_OF_ID, itemId), like(ACTION, "Deleted*")));
     }
 
     String finalFilter;
@@ -409,12 +427,13 @@ public class DdfNodeAdapter implements NodeAdapter {
       finalFilter = allOf(filters);
     }
 
-    if (!failedItemFilters.isEmpty()) {
-      String failedItemsFilter = anyOf(failedItemFilters);
-      LOGGER.debug("Failed items filter: {}", failedItemsFilter);
-      finalFilter = anyOf(finalFilter, failedItemsFilter);
+    if (!deletedFailedItemFilters.isEmpty()) {
+      String deletedFailedItemsFilter = anyOf(deletedFailedItemFilters);
+      LOGGER.debug("Deleted failed items filter: {}", anyOf(deletedFailedItemFilters));
+      finalFilter = anyOf(finalFilter, deletedFailedItemsFilter);
     }
     LOGGER.debug("Final cql query filter: {}", finalFilter);
-    return finalFilter;
+    return new QueryRequestImpl(
+        finalFilter, queryRequest.getStartIndex(), queryRequest.getPageSize());
   }
 }

--- a/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/ResultIterableTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/ResultIterableTest.java
@@ -32,10 +32,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.codice.ditto.replication.api.data.Metadata;
 import org.codice.ditto.replication.api.data.QueryRequest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -98,6 +100,65 @@ public class ResultIterableTest {
     ResultIterable resultIterable =
         ResultIterable.resultIterable(queryFunction, new QueryRequestImpl("title like '*'"));
     assertThat(resultIterable.stream().count(), is(1l));
+  }
+
+  @Test
+  public void multipleQueryRequests() {
+    String filter1 = "title like 'failed'";
+    String filter2 = "title like '*'";
+    QueryRequest request1 = new QueryRequestImpl(filter1);
+    QueryRequest request2 = new QueryRequestImpl(filter2);
+    when(queryFunction.apply(any(QueryRequest.class))).thenReturn(Collections.emptyList());
+    Iterator<Metadata> iter =
+        ResultIterable.resultIterable(queryFunction, request1, request2).iterator();
+    assertThat(iter.hasNext(), is(false));
+    ArgumentCaptor<QueryRequest> requestCaptor = ArgumentCaptor.forClass(QueryRequest.class);
+    verify(queryFunction, times(2)).apply(requestCaptor.capture());
+    List<String> queryFilters =
+        requestCaptor
+            .getAllValues()
+            .stream()
+            .map(QueryRequest::getCql)
+            .collect(Collectors.toList());
+    assertTrue(queryFilters.contains(filter1));
+    assertTrue(queryFilters.contains(filter2));
+  }
+
+  @Test
+  public void multipleQueryRequestsMultiplePages() {
+    String filter1 = "title like 'failed'";
+    String filter2 = "title like '*'";
+    QueryRequest request1 = new QueryRequestImpl(filter1);
+    QueryRequest request2 = new QueryRequestImpl(filter2);
+    when(queryFunction.apply(any(QueryRequest.class)))
+        .thenReturn(
+            Arrays.asList(getMetadata(), getMetadata()),
+            Collections.emptyList(),
+            Collections.singletonList(getMetadata()),
+            Collections.emptyList());
+    Iterator<Metadata> iter =
+        ResultIterable.resultIterable(queryFunction, request1, request2).iterator();
+    assertThat(iter.next(), is(notNullValue()));
+    assertThat(iter.next(), is(notNullValue()));
+    assertThat(iter.next(), is(notNullValue()));
+    assertThat(iter.hasNext(), is(false));
+    verify(queryFunction, times(4)).apply(any(QueryRequest.class));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void allNullQueryRequestsThrowsException() {
+    ResultIterable.resultIterable(queryFunction, null);
+  }
+
+  @Test
+  public void nullQueryRequestIsRemoved() {
+    String filter1 = "title like '*'";
+    QueryRequest request1 = new QueryRequestImpl(filter1);
+    when(queryFunction.apply(any(QueryRequest.class))).thenReturn(Collections.emptyList());
+    Iterator<Metadata> iter =
+        ResultIterable.resultIterable(queryFunction, null, request1).iterator();
+    assertThat(iter.hasNext(), is(false));
+    verify(queryFunction, times(1)).apply(any(QueryRequest.class));
   }
 
   private Metadata getMetadata() {


### PR DESCRIPTION
#### What does this PR do?
This commit fixes a bug where no new items are returned when failure
retries are included in a csw query to DDF

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)? @clockard @peterhuffer @paouelle @mcalcote 

#### How should this be tested? (List steps with links to updated documentation)
Test steps are too long to list here and will likely change soon 😄. See me for information.
  
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #119 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
