### PR TITLE
REP-129 Fix initial replication to Ion bug

### DIFF
--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/rest/DdfRestClient.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/rest/DdfRestClient.java
@@ -137,7 +137,7 @@ public class DdfRestClient {
         null,
         (InputStream) response.getEntity(),
         response.getMediaType().toString(),
-        response.getLength(),
+        metadata.getResourceSize(),
         metadata);
   }
 

--- a/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/rest/DdfRestClientTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/rest/DdfRestClientTest.java
@@ -142,13 +142,13 @@ public class DdfRestClientTest {
   @Test
   public void getResource() {
     Metadata metadata = getMetadata("123456789");
+    metadata.setResourceSize(123L);
     Response response = mock(Response.class);
     when(response.getHeaderString("Content-Disposition")).thenReturn("filename=myfile.txt");
     StatusType status = mock(StatusType.class);
     when(status.getFamily()).thenReturn(Family.SUCCESSFUL);
     when(response.getStatusInfo()).thenReturn(status);
     when(response.getMediaType()).thenReturn(MediaType.APPLICATION_OCTET_STREAM_TYPE);
-    when(response.getLength()).thenReturn(123);
     when(webClient.get()).thenReturn(response);
     when(webClient.getCurrentURI())
         .thenReturn(URI.create("https://host:1234/context/catalog/123456789"));

--- a/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/IonNodeAdapter.java
+++ b/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/IonNodeAdapter.java
@@ -131,7 +131,7 @@ public class IonNodeAdapter implements NodeAdapter {
         ResponseEntity<String> response =
             restOps.exchange(
                 this.ionUrl.toString() + "/ingest", HttpMethod.POST, requestEntity, String.class);
-        if (response.getStatusCodeValue() != 202) {
+        if (!response.getStatusCode().is2xxSuccessful()) {
           LOGGER.debug(
               "Failed to replicate {}. Message: {}", resource.getName(), response.getBody());
           success = false;

--- a/adapters/ion-adapter/src/test/java/com/connexta/replication/adapters/ion/IonNodeAdapterTest.java
+++ b/adapters/ion-adapter/src/test/java/com/connexta/replication/adapters/ion/IonNodeAdapterTest.java
@@ -80,22 +80,33 @@ public class IonNodeAdapterTest {
   }
 
   @Test
-  public void createResourceFailed401() {
+  public void createResource200() {
     mockServer
         .expect(requestTo("http://localhost:1234/ingest"))
         .andExpect(method(HttpMethod.POST))
-        .andRespond(MockRestResponseCreators.withStatus(HttpStatus.UNAUTHORIZED));
+        .andRespond(MockRestResponseCreators.withStatus(HttpStatus.OK));
+
+    assertThat(adapter.createResource(getCreateStorageRequest()), is(true));
+    mockServer.verify();
+  }
+
+  @Test
+  public void createResourceFailed300() {
+    mockServer
+        .expect(requestTo("http://localhost:1234/ingest"))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(MockRestResponseCreators.withStatus(HttpStatus.MULTIPLE_CHOICES));
 
     assertThat(adapter.createResource(getCreateStorageRequest()), is(false));
     mockServer.verify();
   }
 
   @Test
-  public void createResourceFailed200() {
+  public void createResourceFailed401() {
     mockServer
         .expect(requestTo("http://localhost:1234/ingest"))
         .andExpect(method(HttpMethod.POST))
-        .andRespond(MockRestResponseCreators.withStatus(HttpStatus.OK));
+        .andRespond(MockRestResponseCreators.withStatus(HttpStatus.UNAUTHORIZED));
 
     assertThat(adapter.createResource(getCreateStorageRequest()), is(false));
     mockServer.verify();


### PR DESCRIPTION
### What does this PR do?
*Fixes a bug where initial attempts to replicate a resource to Ion, that
wasn't a text resource, would fail because the file size sent to Ion was
-1.

*Modifies the IonNodeAdapter to consider any create resource response
with a status code in the 200 range to be successful.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)? @peterhuffer @mcalcote @clockard @paouelle 

#### How should this be tested? (List steps with links to updated documentation)
- Set up a replication to Ion which will replicate an image.
- Verify that the replication is successful on the first attempt.

#### What are the relevant tickets?
Fixes #129 

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
