### PR TITLE
REP-133 Make connection timeouts configurable

### DIFF
--- a/docs/src/main/resources/content/replication-configuring.adoc
+++ b/docs/src/main/resources/content/replication-configuring.adoc
@@ -105,3 +105,17 @@ of the replication configuration regardless of the results of the above options.
 
 To view a list of all currently saved replication configurations, simply execute `replication:config-list`
 in the ${command-console}.
+
+=== Setting Timeouts
+
+By default, requests made by the replication feature have a connection timeout of 30 seconds and a receive
+timeout of 60 seconds. If your network is slow, or the ${branding} you are trying to replicate with is
+slow to respond, these timeouts can be increased to allow more time for transferring information.
+Here's how you can set these timeouts:
+
+. Navigate to the `<${branding}-home>/etc` directory.
+. Open the `custom.system.properties` file.
+. Create an entry specifying the connection timeout in seconds ex: `replication.connection.timeout=30`.
+. Create an entry specifying the receive timeout in seconds ex: `replication.receive.timeout=60`.
+. Save the file.
+. Restart the ${branding} if it is running.

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -328,7 +328,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.59</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/HybridStore.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/HybridStore.java
@@ -49,7 +49,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
-import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -91,6 +90,10 @@ public class HybridStore extends AbstractCswStore implements ReplicationStore {
 
   private static final String CONTENT_DISPOSITION = "Content-Disposition";
 
+  private static final int DEFAULT_CONNECTION_TIMEOUT = 30;
+
+  private static final int DEFAULT_RECEIVE_TIMEOUT = 60;
+
   private SecureCxfClientFactory<RESTService> restClientFactory;
 
   private String remoteName;
@@ -101,11 +104,9 @@ public class HybridStore extends AbstractCswStore implements ReplicationStore {
       Converter provider,
       ClientFactoryFactory clientFactoryFactory,
       EncryptionService encryptionService,
-      URL url) {
+      SecureCxfClientFactory<RESTService> restClientFactory) {
     super(context, cswSourceConfiguration, provider, clientFactoryFactory, encryptionService);
-    this.restClientFactory =
-        clientFactoryFactory.getSecureCxfClientFactory(
-            url.toString() + "/catalog", RESTService.class);
+    this.restClientFactory = restClientFactory;
   }
 
   @Override

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/SyncHelper.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/SyncHelper.java
@@ -163,9 +163,9 @@ class SyncHelper {
       mcard = metacardResult.getMetacard();
       existingReplicationItem = persistentStore.getItem(mcard.getId(), sourceName, destinationName);
 
-      boolean deletedMetacard = isDeletedMetacard();
+      boolean isDeletedMetacard = isDeletedMetacard();
       try {
-        process(deletedMetacard);
+        process(isDeletedMetacard);
       } catch (Exception e) {
         if (causedByConnectionLoss(e)) {
           logConnectionLoss();
@@ -177,7 +177,7 @@ class SyncHelper {
       }
 
       final Date modifiedDate;
-      if (deletedMetacard) {
+      if (isDeletedMetacard) {
         modifiedDate = (Date) mcard.getAttribute(MetacardVersion.VERSIONED_ON).getValue();
       } else {
         modifiedDate = (Date) mcard.getAttribute(Core.METACARD_MODIFIED).getValue();
@@ -187,8 +187,9 @@ class SyncHelper {
   }
 
   @SuppressWarnings("squid:S3655" /*isUpdatable performs the needed optional check*/)
-  private void process(boolean deletedMetacard) throws IngestException, SourceUnavailableException {
-    if (deletedMetacard) {
+  private void process(boolean isDeletedMetacard)
+      throws IngestException, SourceUnavailableException {
+    if (isDeletedMetacard) {
       processDeletedMetacard();
     } else if (isUpdatable()) {
       processUpdate(existingReplicationItem.get());


### PR DESCRIPTION
#### What does this PR do?
Makes the connect and receive timeouts for contacting DDF configurable
via system property.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)? @mcalcote @peterhuffer @paouelle @clockard 

#### How should this be tested? (List steps with links to updated documentation)
-Install and configure a DDF for replication.
-Follow the added documentation to configure the replication timeouts
-Install replication
-Set the log level for `org.codice.ditto.replication.api.impl.ReplicatorStoreFactoryImpl` to DEBUG
-Create and run a replication
-Watch for the timeouts to be logged and verify they are the expected values

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #133 

#### Screenshots (if appropriate)

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
