### PR TITLE
REP-139 Add ssl property for cert alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ javax.net.ssl.trustStorePassword=changeit
 javax.net.ssl.trustStoreType=jks
 javax.net.ssl.keyStorePassword=changeit
 javax.net.ssl.keyStoreType=jks
+javax.net.ssl.certAlias=localhost
 ```
 Only the properties that differ from the defaults above need to be specified in replication-ssl
 

--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/DdfNodeAdapterFactory.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/DdfNodeAdapterFactory.java
@@ -13,6 +13,7 @@
  */
 package com.connexta.ion.replication.adapters.ddf;
 
+import com.connexta.ion.replication.ReplicationConstants;
 import com.connexta.ion.replication.adapters.ddf.csw.Constants;
 import com.connexta.ion.replication.adapters.ddf.csw.Csw;
 import com.connexta.ion.replication.adapters.ddf.csw.CswJAXBElementProvider;
@@ -84,7 +85,10 @@ public class DdfNodeAdapterFactory implements NodeAdapterFactory {
             true,
             false,
             connectionTimeout,
-            receiveTimeout);
+            receiveTimeout,
+            ReplicationConstants.getCertAlias(),
+            ReplicationConstants.getKeystore(),
+            ReplicationConstants.TLS_PROTOCOL);
     return new DdfNodeAdapter(ddfRestClientFactory, ddfCswClientFactory, url);
   }
 

--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/rest/DdfRestClientFactory.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/rest/DdfRestClientFactory.java
@@ -13,6 +13,7 @@
  */
 package com.connexta.ion.replication.adapters.ddf.rest;
 
+import com.connexta.ion.replication.ReplicationConstants;
 import java.net.URL;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -59,7 +60,6 @@ public class DdfRestClientFactory {
 
   public DdfRestClient createWithSubject(URL url) {
     String pathlessUrl = url.getProtocol() + "://" + url.getHost() + ":" + url.getPort();
-
     WebClient whoamiClient =
         clientFactoryFactory
             .getSecureCxfClientFactory(
@@ -70,7 +70,10 @@ public class DdfRestClientFactory {
                 false,
                 false,
                 connectionTimeout,
-                receiveTimeout)
+                receiveTimeout,
+                ReplicationConstants.getCertAlias(),
+                ReplicationConstants.getKeystore(),
+                ReplicationConstants.TLS_PROTOCOL)
             .getWebClient();
     whoamiClient.path("/whoami");
     whoamiClient.accept(MediaType.APPLICATION_XML);
@@ -92,7 +95,10 @@ public class DdfRestClientFactory {
             false,
             false,
             connectionTimeout,
-            receiveTimeout);
+            receiveTimeout,
+            ReplicationConstants.getCertAlias(),
+            ReplicationConstants.getKeystore(),
+            ReplicationConstants.TLS_PROTOCOL);
 
     WebClient webClient = restClientFactory.getWebClient();
     webClient.accept(MediaType.APPLICATION_XML);

--- a/adapters/ddf-adapter/src/test/java/com/connexta/ion/replication/adapters/ddf/DdfNodeAdapterFactoryTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/ion/replication/adapters/ddf/DdfNodeAdapterFactoryTest.java
@@ -20,11 +20,15 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
+import com.connexta.ion.replication.ReplicationConstants;
 import com.connexta.ion.replication.adapters.ddf.csw.Csw;
+import java.net.InetAddress;
 import java.net.URL;
 import java.util.List;
 import org.apache.cxf.interceptor.Interceptor;
 import org.codice.ddf.cxf.client.ClientFactoryFactory;
+import org.codice.junit.rules.RestoreSystemProperties;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -32,10 +36,14 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DdfNodeAdapterFactoryTest {
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
   @Mock ClientFactoryFactory clientFactoryFactory;
 
   @Test
   public void create() throws Exception {
+    System.setProperty("javax.net.ssl.keyStore", "/my/keystore.jks");
     DdfNodeAdapterFactory factory = new DdfNodeAdapterFactory(clientFactoryFactory, 30000, 60000);
     assertThat(factory.create(new URL("https://localhost:8993/context")), is(notNullValue()));
     verify(clientFactoryFactory)
@@ -47,6 +55,30 @@ public class DdfNodeAdapterFactoryTest {
             eq(true),
             eq(false),
             eq(30000),
-            eq(60000));
+            eq(60000),
+            eq(InetAddress.getLocalHost().getCanonicalHostName()),
+            eq("/my/keystore.jks"),
+            eq(ReplicationConstants.TLS_PROTOCOL));
+  }
+
+  @Test
+  public void createWithAlias() throws Exception {
+    System.setProperty("javax.net.ssl.keyStore", "/my/keystore.jks");
+    System.setProperty("javax.net.ssl.certAlias", "myAlias");
+    DdfNodeAdapterFactory factory = new DdfNodeAdapterFactory(clientFactoryFactory, 30000, 60000);
+    assertThat(factory.create(new URL("https://localhost:8993/context")), is(notNullValue()));
+    verify(clientFactoryFactory)
+        .getSecureCxfClientFactory(
+            eq("https://localhost:8993/context/csw"),
+            eq(Csw.class),
+            any(List.class),
+            (Interceptor) eq(null),
+            eq(true),
+            eq(false),
+            eq(30000),
+            eq(60000),
+            eq("myAlias"),
+            eq("/my/keystore.jks"),
+            eq(ReplicationConstants.TLS_PROTOCOL));
   }
 }

--- a/adapters/ddf-adapter/src/test/java/com/connexta/ion/replication/adapters/ddf/rest/DdfRestClientFactoryTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/ion/replication/adapters/ddf/rest/DdfRestClientFactoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.connexta.ion.replication.ReplicationConstants;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
@@ -34,8 +35,10 @@ import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadContext;
 import org.codice.ddf.cxf.client.ClientFactoryFactory;
 import org.codice.ddf.cxf.client.SecureCxfClientFactory;
+import org.codice.junit.rules.RestoreSystemProperties;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -44,6 +47,10 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DdfRestClientFactoryTest {
+
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
   @Mock Subject subject;
   @Mock ClientFactoryFactory clientFactory;
   @Mock SecureCxfClientFactory secureCxfClientFactory;
@@ -56,6 +63,8 @@ public class DdfRestClientFactoryTest {
   @Before
   public void setUp() throws Exception {
     ThreadContext.bind(subject);
+    System.setProperty("javax.net.ssl.keyStore", "/my/keystore.jks");
+    System.setProperty("javax.net.ssl.certAlias", "myAlias");
     when(clientFactory.getSecureCxfClientFactory(
             any(String.class),
             any(Class.class),
@@ -64,7 +73,10 @@ public class DdfRestClientFactoryTest {
             anyBoolean(),
             anyBoolean(),
             any(Integer.class),
-            any(Integer.class)))
+            any(Integer.class),
+            any(String.class),
+            any(String.class),
+            any(String.class)))
         .thenReturn(secureCxfClientFactory);
   }
 
@@ -89,7 +101,10 @@ public class DdfRestClientFactoryTest {
             false,
             false,
             DEFAULT_CONNECTION_TIMEOUT_MILLIS,
-            DEFAULT_RECEIVE_TIMEOUT_MILLIS);
+            DEFAULT_RECEIVE_TIMEOUT_MILLIS,
+            "myAlias",
+            "/my/keystore.jks",
+            ReplicationConstants.TLS_PROTOCOL);
     verify(secureCxfClientFactory).getWebClient();
   }
 
@@ -116,7 +131,10 @@ public class DdfRestClientFactoryTest {
             false,
             false,
             DEFAULT_CONNECTION_TIMEOUT_MILLIS,
-            DEFAULT_RECEIVE_TIMEOUT_MILLIS);
+            DEFAULT_RECEIVE_TIMEOUT_MILLIS,
+            "myAlias",
+            "/my/keystore.jks",
+            ReplicationConstants.TLS_PROTOCOL);
     verify(secureCxfClientFactory, times(2)).getWebClient();
     ArgumentCaptor<NewCookie> resultCookie = ArgumentCaptor.forClass(NewCookie.class);
     verify(webClient).cookie(resultCookie.capture());

--- a/commons/src/main/java/com/connexta/ion/replication/ReplicationConstants.java
+++ b/commons/src/main/java/com/connexta/ion/replication/ReplicationConstants.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.ion.replication;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+public class ReplicationConstants {
+
+  public static final String TLS_PROTOCOL = "TLSv1.2";
+
+  private ReplicationConstants() {}
+
+  public static String getCertAlias() {
+    try {
+      return System.getProperty(
+          "javax.net.ssl.certAlias", InetAddress.getLocalHost().getCanonicalHostName());
+    } catch (UnknownHostException e) {
+      return "localhost";
+    }
+  }
+
+  public static String getKeystore() {
+    return System.getProperty("javax.net.ssl.keyStore");
+  }
+}

--- a/distributions/application/src/main/resources/ssl.properties
+++ b/distributions/application/src/main/resources/ssl.properties
@@ -4,4 +4,5 @@ javax.net.ssl.trustStoreType=jks
 javax.net.ssl.keyStore=config/keystores/serverKeystore.jks
 javax.net.ssl.keyStorePassword=changeit
 javax.net.ssl.keyStoreType=jks
+javax.net.ssl.certAlias=localhost
 


### PR DESCRIPTION
#### What does this PR do?
Adds and uses a new ssl property to set the cert alias used for https communication.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@kcover @peterhuffer @paouelle @mcalcote 

#### How should this be tested? (List steps with links to updated documentation)
Create a keystore with a non localhost aliased cert and use it when running replication.
Verify you can connect to a DDF system for replication.

#### What are the relevant tickets?
Fixes #139 
