### PR TITLE
Fix javadoc to work with latest plugin

### DIFF
--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/ResultIterable.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/ResultIterable.java
@@ -79,6 +79,7 @@ public class ResultIterable implements Iterable<Metadata> {
    * @param queryFunction reference to the {@link Function} to call to retrieve the results.
    * @param queryRequest request used to retrieve the results.
    * @param queryRequests subsequent requests to retrieve results after the first is completed.
+   * @return a {@link ResultIterable} for the given queryFunction
    */
   public static ResultIterable resultIterable(
       Function<QueryRequest, List<Metadata>> queryFunction,

--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/csw/Csw.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/csw/Csw.java
@@ -29,8 +29,9 @@ public interface Csw {
   /**
    * GetCapabilities - HTTP POST
    *
-   * @param request
-   * @return
+   * @param request the csw getCapabilities request
+   * @return {@link CapabilitiesType}
+   * @throws Exception if the request fails for any reason
    */
   @SuppressWarnings("squid:S00112" /* Pulled from DDF to match that interface */)
   @POST
@@ -41,8 +42,9 @@ public interface Csw {
   /**
    * GetRecords - HTTP POST
    *
-   * @param request
-   * @return
+   * @param request the csw getRecords request
+   * @return {@link CswRecordCollection}
+   * @throws Exception if the request fails for any reason
    */
   @SuppressWarnings("squid:S00112" /* Pulled from DDF to match that interface */)
   @POST

--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/csw/CswRecordCollection.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/csw/CswRecordCollection.java
@@ -34,7 +34,7 @@ public class CswRecordCollection {
   /**
    * Retrieves the list of metadata built from the CSW Records returned in a GetRecordsResponse.
    *
-   * @return
+   * @return a list of metadata objects
    */
   public List<Metadata> getCswRecords() {
     return cswRecords;
@@ -43,7 +43,7 @@ public class CswRecordCollection {
   /**
    * Sets the list of metadata built from the CSW Records returned in a GetRecordsResponse.
    *
-   * @param cswRecords
+   * @param cswRecords a list of metadata objects
    */
   public void setCswRecords(List<Metadata> cswRecords) {
     this.cswRecords = cswRecords;

--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/csw/GetRecordsResponseConverter.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/csw/GetRecordsResponseConverter.java
@@ -66,8 +66,6 @@ public class GetRecordsResponseConverter implements Converter {
   /**
    * Parses GetRecordsResponse XML of this form:
    *
-   * <p>
-   *
    * <pre>{@code
    * <csw:GetRecordsResponse xmlns:csw="http://www.opengis.net/cat/csw">
    *     <csw:SearchStatus status="subset" timestamp="2013-05-01T02:13:36+0200"/>

--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/rest/RESTService.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/rest/RESTService.java
@@ -36,11 +36,12 @@ public interface RESTService {
    * REST Get. Retrieves the metadata entry specified by the id. Transformer argument is optional,
    * but is used to specify what format the data should be returned.
    *
-   * @param id
-   * @param transformerParam (OPTIONAL)
-   * @param uriInfo
-   * @return
-   * @throws InternalServerErrorException
+   * @param id the unique metadata id
+   * @param transformerParam (OPTIONAL) transform used to turn raw resource into desired response
+   *     format
+   * @param uriInfo the request UriInfo
+   * @param httpRequest the http request
+   * @return REST response containing resource in the requested format
    */
   @GET
   @Path("/{id}")
@@ -53,9 +54,9 @@ public interface RESTService {
   /**
    * REST Get. Retrieves information regarding sources available.
    *
-   * @param uriInfo
-   * @param httpRequest
-   * @return
+   * @param uriInfo the request UriInfo
+   * @param httpRequest the http request
+   * @return REST response
    */
   @GET
   @Path("/sources")
@@ -66,11 +67,12 @@ public interface RESTService {
    * by sourceid. Transformer argument is optional, but is used to specify what format the data
    * should be returned.
    *
-   * @param sourceid
-   * @param id
-   * @param transformerParam
-   * @param uriInfo
-   * @return
+   * @param sourceid the source to retrieve the metadata from
+   * @param id the unique metadata id
+   * @param transformerParam transform used to turn raw resource into desired response format
+   * @param uriInfo the request UriInfo
+   * @param httpRequest the http request
+   * @return REST response containing resource in the requested format
    */
   @GET
   @Path("/sources/{sourceid}/{id}")
@@ -84,9 +86,12 @@ public interface RESTService {
   /**
    * REST Put. Updates the specified metadata entry with the provided metadata.
    *
-   * @param id
-   * @param message
-   * @return
+   * @param id the unique metadata id
+   * @param headers the http headers
+   * @param httpRequest the http request
+   * @param transformerParam transform used to turn raw resource into desired response format
+   * @param message the updated metadata
+   * @return REST response indicating the success/failure of the operation
    */
   @PUT
   @Path("/{id}")
@@ -100,9 +105,13 @@ public interface RESTService {
   /**
    * REST Put. Updates the specified metadata entry with the provided metadata.
    *
-   * @param id
-   * @param message
-   * @return
+   * @param id the unique metadata id
+   * @param headers the http headers
+   * @param httpRequest the http request
+   * @param multipartBody the multipart body containing the resource
+   * @param transformerParam transform used to turn raw resource into desired response format
+   * @param message the updated metadata
+   * @return REST response indicating the success/failure of the operation
    */
   @PUT
   @Path("/{id}")
@@ -117,8 +126,12 @@ public interface RESTService {
   /**
    * REST Post. Creates a new metadata entry in the catalog.
    *
-   * @param message
-   * @return
+   * @param headers the http headers
+   * @param requestUriInfo the request UriInfo
+   * @param httpRequest the http request
+   * @param transformerParam transform used to turn raw resource into desired response format
+   * @param message the metadata to be added
+   * @return REST response indicating the success/failure of the operation
    */
   @POST
   Response addDocument(
@@ -131,8 +144,13 @@ public interface RESTService {
   /**
    * REST Post. Creates a new metadata entry in the catalog.
    *
-   * @param message
-   * @return
+   * @param headers the http headers
+   * @param requestUriInfo the request UriInfo
+   * @param httpRequest the http request
+   * @param multipartBody the multipart body containing the resource
+   * @param transformerParam transform used to turn raw resource into desired response format
+   * @param message the metadata to be added
+   * @return REST response indicating the success/failure of the operation
    */
   @POST
   Response addDocument(
@@ -146,8 +164,9 @@ public interface RESTService {
   /**
    * REST Delete. Deletes a record from the catalog.
    *
-   * @param id
-   * @return
+   * @param id the unique metadata id
+   * @param httpRequest the http request
+   * @return REST response indicating the success/failure of the operation
    */
   @DELETE
   @Path("/{id}")

--- a/adapters/ion-adapter/src/main/java/com/connexta/ion/replication/adapters/ion/IonNodeAdapterFactory.java
+++ b/adapters/ion-adapter/src/main/java/com/connexta/ion/replication/adapters/ion/IonNodeAdapterFactory.java
@@ -26,7 +26,7 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * Factory for creating {@link IonNodeAdapter}s for the {@link
- * org.codice.ditto.replication.api.Replicator}.
+ * com.connexta.ion.replication.api.Replicator}.
  */
 public class IonNodeAdapterFactory implements NodeAdapterFactory {
 

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.0.1</version>
                     <configuration>
                         <aggregate>true</aggregate>
                         <show>protected</show>

--- a/replication-api/src/main/java/com/connexta/ion/replication/api/NodeAdapter.java
+++ b/replication-api/src/main/java/com/connexta/ion/replication/api/NodeAdapter.java
@@ -41,7 +41,7 @@ public interface NodeAdapter extends Closeable {
    * @param queryRequest query criteria to determine creates, updates, and/or deletes
    * @return a {@link QueryResponse} containing the {@link Metadata} matching the {@link
    *     QueryRequest} criteria
-   * @throws {@link AdapterException} if there is an error communicating with the remote server
+   * @throws AdapterException if there is an error communicating with the remote server
    */
   QueryResponse query(QueryRequest queryRequest);
 

--- a/replication-api/src/main/java/com/connexta/ion/replication/api/Replicator.java
+++ b/replication-api/src/main/java/com/connexta/ion/replication/api/Replicator.java
@@ -22,6 +22,7 @@ public interface Replicator {
    * Submits a {@link SyncRequest} to be executed
    *
    * @param syncRequest The {@link SyncRequest} to run
+   * @throws InterruptedException on thread interrupt when inserting request into the queue
    */
   void submitSyncRequest(final SyncRequest syncRequest) throws InterruptedException;
 
@@ -40,19 +41,17 @@ public interface Replicator {
   void cancelSyncRequest(final String configId);
 
   /**
-   * Gets the {@link Queue<SyncRequest>} that have been submitted but have not yet been executed.
-   * Does not contain duplicates.
+   * Gets the {@link Queue} that have been submitted but have not yet been executed. Does not
+   * contain duplicates.
    *
-   * @return A unmodifiable {@link Queue<SyncRequest>} or an empty {@link Queue<SyncRequest>} if
-   *     there are none
+   * @return A unmodifiable {@link Queue} or an empty {@link Queue} if there are none
    */
   Queue<SyncRequest> getPendingSyncRequests();
 
   /**
-   * Gets the {@link Set<SyncRequest>} that are currently being executed
+   * Gets the {@link Set} that are currently being executed
    *
-   * @return A unmodifiable {@link Set<SyncRequest>} or an empty {@link Set<SyncRequest>} if there
-   *     are none
+   * @return A unmodifiable {@link Set} or an empty {@link Set} if there are none
    */
   Set<SyncRequest> getActiveSyncRequests();
 }

--- a/replication-api/src/main/java/com/connexta/ion/replication/api/data/QueryRequest.java
+++ b/replication-api/src/main/java/com/connexta/ion/replication/api/data/QueryRequest.java
@@ -58,14 +58,14 @@ public interface QueryRequest {
   /**
    * The result index at which the query results should start from
    *
-   * @return
+   * @return the start index to run the query from
    */
   int getStartIndex();
 
   /**
    * The maximum number of results to return for any single query run
    *
-   * @return
+   * @return the max number of results to return in one query attempt
    */
   int getPageSize();
 }

--- a/replication-api/src/main/java/com/connexta/ion/replication/api/data/ReplicationStatus.java
+++ b/replication-api/src/main/java/com/connexta/ion/replication/api/data/ReplicationStatus.java
@@ -229,7 +229,11 @@ public interface ReplicationStatus extends Persistable {
   /** Increments the pull/push failure count based on the current {@link Status} */
   void incrementFailure();
 
-  /** Increments the pull/push bytes based on the current {@link Status} */
+  /**
+   * Increments the pull/push bytes based on the current {@link Status}
+   *
+   * @param numBytes the number of bytes to increment by
+   */
   void incrementBytesTransferred(long numBytes);
 
   /**

--- a/replication-api/src/main/java/com/connexta/ion/replication/api/persistence/DataManager.java
+++ b/replication-api/src/main/java/com/connexta/ion/replication/api/persistence/DataManager.java
@@ -21,8 +21,10 @@ public interface DataManager<T extends Persistable> {
    *
    * @param id The object id
    * @return the T object with the given id
-   * @throws ReplicationPersistenceException if an error occurs while trying to retrieve the object
-   * @throws NotFoundException if an object with the given id cannot be found
+   * @throws com.connexta.ion.replication.api.ReplicationPersistenceException if an error occurs
+   *     while trying to retrieve the object
+   * @throws com.connexta.ion.replication.api.NotFoundException if an object with the given id
+   *     cannot be found
    * @throws IllegalStateException if multiple objects were found with the given id
    */
   T get(String id);
@@ -31,7 +33,8 @@ public interface DataManager<T extends Persistable> {
    * Gets all the currently saved T objects
    *
    * @return Stream of all T objects
-   * @throws ReplicationPersistenceException if an error occurs while trying to retrieve the objects
+   * @throws com.connexta.ion.replication.api.ReplicationPersistenceException if an error occurs
+   *     while trying to retrieve the objects
    */
   Stream<T> objects();
 
@@ -41,7 +44,8 @@ public interface DataManager<T extends Persistable> {
    * method included in this interface.
    *
    * @param object The T object to save or update
-   * @throws ReplicationPersistenceException if an error occurs while trying to save the object
+   * @throws com.connexta.ion.replication.api.ReplicationPersistenceException if an error occurs
+   *     while trying to save the object
    * @throws IllegalArgumentException if the T implementation is not one that can be saved
    */
   void save(T object);
@@ -50,8 +54,10 @@ public interface DataManager<T extends Persistable> {
    * Deletes a T object with the given id
    *
    * @param id The id of the object to be removed
-   * @throws ReplicationPersistenceException if an error occurs while trying to delete the object
-   * @throws NotFoundException if an object with the given id cannot be found
+   * @throws com.connexta.ion.replication.api.ReplicationPersistenceException if an error occurs
+   *     while trying to delete the object
+   * @throws com.connexta.ion.replication.api.NotFoundException if an object with the given id
+   *     cannot be found
    */
   void remove(String id);
 }

--- a/replication-api/src/main/java/com/connexta/ion/replication/api/persistence/ReplicationItemManager.java
+++ b/replication-api/src/main/java/com/connexta/ion/replication/api/persistence/ReplicationItemManager.java
@@ -55,7 +55,7 @@ public interface ReplicationItemManager {
   /**
    * Deletes all {@code ReplicationItem}s.
    *
-   * @throws ReplicationPersistenceException
+   * @throws ReplicationPersistenceException RuntimeException thrown if delete was unsuccessful
    */
   void deleteAllItems();
 
@@ -76,7 +76,7 @@ public interface ReplicationItemManager {
    *     should not exceed.
    * @param source the source {@link NodeAdapter} name
    * @param destination the destination {@link NodeAdapter} name
-   * @return
+   * @return list of string ids of items that have failed to previously transfer
    */
   List<String> getFailureList(int maximumFailureCount, String source, String destination);
 

--- a/replication-api/src/main/java/com/connexta/ion/replication/api/persistence/ReplicatorHistoryManager.java
+++ b/replication-api/src/main/java/com/connexta/ion/replication/api/persistence/ReplicatorHistoryManager.java
@@ -25,8 +25,8 @@ public interface ReplicatorHistoryManager extends DataManager<ReplicationStatus>
    * @param replicatorId the replication configuration id
    * @return the {@link ReplicationStatus} associated with the given
    * @throws ReplicationPersistenceException if an error occurs while trying to retrieve the object
-   * @throws NotFoundException if a {@link ReplicationStatus} with the given replicator id cannot be
-   *     found
+   * @throws com.connexta.ion.replication.api.NotFoundException if a {@link ReplicationStatus} with
+   *     the given replicator id cannot be found
    */
   ReplicationStatus getByReplicatorId(String replicatorId);
 }


### PR DESCRIPTION
#### What does this PR do?
Fix javadoc to work with latest plugin
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @kcover @paouelle 

#### How should this be tested? (List steps with links to updated documentation)
Manual javadoc build since CI on a PR will not run the javadoc

#### Any background context you want to provide?
Updated the javadoc plugin via dependabot which resulted in stricter javadoc checking.
Some of the javadoc added for interfaces copied from DDF is not very descriptive but I think thats ok for now


