### PR TITLE
DITTO-124 Support for limiting the replication to a set of destination sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ replication:
   period: 300
   connectionTimeout: 30
   receiveTimeout: 60
+  sites:
+  - site1
+  - site2
   
 # Exposes metrics
 management:

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -54,6 +54,10 @@
       <artifactId>spring-boot-starter</artifactId>
       <version>${spring-boot-starter.version}</version>
     </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/commons/src/main/java/com/connexta/ion/replication/spring/ReplicationProperties.java
+++ b/commons/src/main/java/com/connexta/ion/replication/spring/ReplicationProperties.java
@@ -1,6 +1,9 @@
 package com.connexta.ion.replication.spring;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +24,9 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "replication")
 public class ReplicationProperties {
+
+  /** Sets of destination sites to be handled by this replicator or none to handle all. */
+  private final Set<String> sites = new HashSet<>();
 
   /** The interval, in seconds, on which to execute replication jobs */
   private long period;
@@ -63,5 +69,25 @@ public class ReplicationProperties {
 
   public void setReceiveTimeout(int receiveTimeout) {
     this.receiveTimeout = receiveTimeout;
+  }
+
+  /**
+   * Gets the internal set of all destination site identifiers handled by this replicator or empty
+   * to have all sites handled.
+   *
+   * @return the internal set of all destination sites or empty to have all sites handled
+   */
+  public Set<String> getSites() {
+    return sites;
+  }
+
+  /**
+   * Gets the destination site identifiers handled by this replicator or empty to have all sites
+   * handled.
+   *
+   * @return the destination sites or empty to have all sites handled
+   */
+  public Stream<String> sites() {
+    return sites.stream();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <jts.version>1.14.0</jts.version>
         <jaxb.version>2.3.0</jaxb.version>
         <cxf.frontend.version>3.3.2</cxf.frontend.version>
-        <validation.version>1.1.0.Final</validation.version>
+        <validation.api.version>2.0.1.Final</validation.api.version>
         <xstream.version>1.4.11.1</xstream.version>
         <xerces.version>2.12.0</xerces.version>
         <jsr305.version>3.0.2_1</jsr305.version>
@@ -108,7 +108,6 @@
         <rest-assured.version>3.3.0</rest-assured.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <awaitility.version>3.1.6</awaitility.version>
-        <codice-test.version>0.3</codice-test.version>
         <mockito.version>1.10.19</mockito.version>
         <mockito-core.version>2.8.47</mockito-core.version>
         <codice-maven.version>0.2</codice-maven.version>
@@ -144,6 +143,11 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter</artifactId>
                 <version>${spring-boot-starter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${validation.api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -158,7 +158,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.77</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/ReplicatorRunner.java
+++ b/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/ReplicatorRunner.java
@@ -21,10 +21,12 @@ import com.connexta.ion.replication.api.impl.data.SyncRequestImpl;
 import com.connexta.ion.replication.api.persistence.ReplicatorConfigManager;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,15 +44,34 @@ public class ReplicatorRunner {
 
   private final ScheduledExecutorService scheduledExecutor;
 
+  private final Set<String> sites;
+
   private final long period;
 
   private static final long STARTUP_DELAY = TimeUnit.MINUTES.toSeconds(1);
 
   private static final long DEFAULT_REPLICATION_PERIOD = TimeUnit.MINUTES.toSeconds(5);
 
+  /**
+   * Instantiates a new replication runner.
+   *
+   * @param replicator the replicator where to send replication requests
+   * @param replicatorConfigManager the config manager
+   * @param sites the set of sites to be handled by this replication runner or empty to have all
+   *     sites handled
+   * @param period the replication polling period in seconds
+   */
   public ReplicatorRunner(
-      Replicator replicator, ReplicatorConfigManager replicatorConfigManager, long period) {
-    this(Executors.newSingleThreadScheduledExecutor(), replicator, replicatorConfigManager, period);
+      Replicator replicator,
+      ReplicatorConfigManager replicatorConfigManager,
+      Stream<String> sites,
+      long period) {
+    this(
+        Executors.newSingleThreadScheduledExecutor(),
+        replicator,
+        replicatorConfigManager,
+        sites,
+        period);
   }
 
   @VisibleForTesting
@@ -58,17 +79,23 @@ public class ReplicatorRunner {
       ScheduledExecutorService scheduledExecutor,
       Replicator replicator,
       ReplicatorConfigManager replicatorConfigManager,
+      Stream<String> sites,
       long period) {
     this.scheduledExecutor = notNull(scheduledExecutor);
     this.replicator = notNull(replicator);
     this.replicatorConfigManager = notNull(replicatorConfigManager);
+    this.sites = sites.collect(Collectors.toSet());
     this.period = period > 0 ? period : DEFAULT_REPLICATION_PERIOD;
   }
 
   public void init() {
+    if (sites.isEmpty()) {
+      LOGGER.info("Replication for all sites scheduled for every {} seconds.", period);
+    } else {
+      LOGGER.info("Replication for sites: {} scheduled for every {} seconds.", sites, period);
+    }
     scheduledExecutor.scheduleAtFixedRate(
         this::scheduleReplication, STARTUP_DELAY, period, TimeUnit.SECONDS);
-    LOGGER.info("Replication checks scheduled for every {} seconds.", period);
   }
 
   public void destroy() {
@@ -85,7 +112,9 @@ public class ReplicatorRunner {
             .collect(Collectors.toList());
     try {
       for (ReplicatorConfig config : configsToSchedule) {
-        replicator.submitSyncRequest(new SyncRequestImpl(config));
+        if (sites.isEmpty() || sites.contains(config.getDestination())) {
+          replicator.submitSyncRequest(new SyncRequestImpl(config));
+        }
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/spring/ServiceConfig.java
+++ b/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/spring/ServiceConfig.java
@@ -78,7 +78,8 @@ public class ServiceConfig {
       ReplicatorConfigManager replicatorConfigManager,
       ReplicationProperties properties) {
     ReplicatorRunner replicatorRunner =
-        new ReplicatorRunner(replicator, replicatorConfigManager, properties.getPeriod());
+        new ReplicatorRunner(
+            replicator, replicatorConfigManager, properties.sites(), properties.getPeriod());
     replicatorRunner.init();
     return replicatorRunner;
   }


### PR DESCRIPTION
## What does this PR do?
It adds new sites property and modifies the replicator runner to skip destination sites that are not configured. If no sites are configured (the default right now), all configurations are handled as we did before making the same configuration works the same way.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard 
@peterhuffer 
@kcover 

#### How should this be tested? (List steps with links to updated documentation)
- Deploy and start Solr as usual
- Push 2 sites with id xxx1 and xxx2
- Push 2 replication configurations to Solr:
--- unidirectional from site xxx1 to xxx2 with a query 
--- unidirectional from site xxx2 to xxx1 with a different query
- Push 2 application.yaml in Docker:
--- the first configures the new replication.sites property defined as xxx1
--- the second configures the new replication.sites property defined as xxx2
- Deploy 2 replication docker instance each using its own application.yaml
- Start the 2 replication docker instances
- Check out the logs to ensure they each monitor a different destination site
- Verifies that each are replicating their corresponding configuration

We should also retest the standard deployment where replication.sites is not configured to verify that all configurations are being handled by the one replication docker instance.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #175

#### Screenshots (if appropriate)

#### Checklist:
- [x] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
