### PR TITLE
Bump spring-data-solr from 4.0.9.RELEASE to 4.1.0.RC2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
         <gpg-plugin.version>1.6</gpg-plugin.version>
         <org.eclipse-jetty.version>9.4.19.v20190610</org.eclipse-jetty.version>
         <micrometer.version>1.1.5</micrometer.version>
+        <jackson-databind.version>2.9.9.3</jackson-databind.version>
 
         <!-- documentation replacements -->
         <platform>DDF Base</platform>
@@ -247,7 +248,16 @@
                         <groupId>org.eclipse.jetty.http2</groupId>
                         <artifactId>http2-http-client-transport</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson-databind.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.7.RELEASE</version>
-    </parent>
 
     <name>Replication :: Service</name>
     <groupId>com.connexta.ion.replication</groupId>
@@ -126,7 +121,7 @@
         <javax.xml.soap.version>1.4.0</javax.xml.soap.version>
         <jackson.version>2.10.0.pr1</jackson.version>
         <spring.version>5.1.9.RELEASE</spring.version>
-        <spring-boot-starter.version>2.1.6.RELEASE</spring-boot-starter.version>
+        <spring-boot-starter.version>2.1.7.RELEASE</spring-boot-starter.version>
         <annotation.version>1.3.1</annotation.version>
         <reactive-streams.version>1.0.2</reactive-streams.version>
         <fabric8.docker.plugin.version>0.30.0</fabric8.docker.plugin.version>
@@ -135,6 +130,7 @@
         <slf4j.version>1.7.26</slf4j.version>
         <gpg-plugin.version>1.6</gpg-plugin.version>
         <org.eclipse-jetty.version>9.4.19.v20190610</org.eclipse-jetty.version>
+        <micrometer.version>1.1.5</micrometer.version>
 
         <!-- documentation replacements -->
         <platform>DDF Base</platform>
@@ -148,6 +144,31 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter</artifactId>
                 <version>${spring-boot-starter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-actuator</artifactId>
+                <version>${spring-boot-starter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>${spring-boot-starter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-test</artifactId>
+                <version>${spring-boot-starter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-core</artifactId>
+                <version>${micrometer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-registry-prometheus</artifactId>
+                <version>${micrometer.version}</version>
             </dependency>
 
             <dependency>
@@ -261,6 +282,22 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot-starter.version}</version>
+                    <executions>
+                        <execution>
+                            <id>repackage</id>
+                            <goals>
+                                <goal>repackage</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <mainClass>${start-class}</mainClass>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <xstream.version>1.4.11.1</xstream.version>
         <xerces.version>2.12.0</xerces.version>
         <jsr305.version>3.0.2_1</jsr305.version>
-        <jetty.version>9.4.11.v20180605</jetty.version>
+        <jetty.version>9.4.19.v20190610</jetty.version>
         <common.codec.version>1.11</common.codec.version>
         <rest-assured.version>3.3.0</rest-assured.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
@@ -120,7 +120,7 @@
         <opengis.version>19.1</opengis.version>
         <javax.xml.soap.version>1.4.0</javax.xml.soap.version>
         <jackson.version>2.10.0.pr1</jackson.version>
-        <spring.version>5.1.9.RELEASE</spring.version>
+        <spring.version>5.2.0.RC1</spring.version>
         <spring-boot-starter.version>2.1.7.RELEASE</spring-boot-starter.version>
         <annotation.version>1.3.1</annotation.version>
         <reactive-streams.version>1.0.2</reactive-streams.version>
@@ -129,9 +129,8 @@
         <owasp.version>5.2.1</owasp.version>
         <slf4j.version>1.7.26</slf4j.version>
         <gpg-plugin.version>1.6</gpg-plugin.version>
-        <org.eclipse-jetty.version>9.4.19.v20190610</org.eclipse-jetty.version>
         <micrometer.version>1.1.5</micrometer.version>
-        <jackson-databind.version>2.9.9.3</jackson-databind.version>
+        <javax-validation-api.version>2.0.1.Final</javax-validation-api.version>
 
         <!-- documentation replacements -->
         <platform>DDF Base</platform>
@@ -172,6 +171,7 @@
                 <version>${micrometer.version}</version>
             </dependency>
 
+            <!-- START spring-data-solr vulnerability workaround -->
             <dependency>
                 <groupId>org.springframework.data</groupId>
                 <artifactId>spring-data-solr</artifactId>
@@ -257,8 +257,65 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-java-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-common</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-hpack</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-http-client-transport</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <!-- Hibernate 5.x compatible version. Hibernate 5.x brought in by spring version 5.2.0.RC1 -->
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>${javax-validation-api.version}</version>
+            </dependency>
+            <!-- END spring-data-solr vulnerability workaround -->
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.6.RELEASE</version>
+        <version>2.1.7.RELEASE</version>
     </parent>
 
     <name>Replication :: Service</name>
@@ -120,7 +120,8 @@
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
         <maven-jacoco-plugin.version>0.8.4</maven-jacoco-plugin.version>
         <failsafe.version>1.1.0</failsafe.version>
-        <spring-data-solr.version>4.0.9.RELEASE</spring-data-solr.version>
+        <spring-data-solr.version>4.1.0.RC2</spring-data-solr.version>
+        <solr.version>8.2.0</solr.version>
         <opengis.version>19.1</opengis.version>
         <javax.xml.soap.version>1.4.0</javax.xml.soap.version>
         <jackson.version>2.10.0.pr1</jackson.version>
@@ -130,9 +131,10 @@
         <reactive-streams.version>1.0.2</reactive-streams.version>
         <fabric8.docker.plugin.version>0.30.0</fabric8.docker.plugin.version>
         <project.report.output.directory>project-info</project.report.output.directory>
-        <owasp.version>5.2.0</owasp.version>
+        <owasp.version>5.2.1</owasp.version>
         <slf4j.version>1.7.26</slf4j.version>
         <gpg-plugin.version>1.6</gpg-plugin.version>
+        <org.eclipse-jetty.version>9.4.19.v20190610</org.eclipse-jetty.version>
 
         <!-- documentation replacements -->
         <platform>DDF Base</platform>
@@ -146,6 +148,85 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter</artifactId>
                 <version>${spring-boot-starter.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-solr</artifactId>
+                <version>${spring-data-solr.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>solr-solrj</artifactId>
+                        <groupId>org.apache.solr</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.solr</groupId>
+                <artifactId>solr-solrj</artifactId>
+                <version>${solr.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>jcl-over-slf4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>stax2-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>woodstox-core-asl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-alpn-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-alpn-java-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-http</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-io</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-util</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.http2</groupId>
+                        <artifactId>http2-client</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.http2</groupId>
+                        <artifactId>http2-common</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.http2</groupId>
+                        <artifactId>http2-hpack</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty.http2</groupId>
+                        <artifactId>http2-http-client-transport</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/replication-api-impl/owasp-suppressions.xml
+++ b/replication-api-impl/owasp-suppressions.xml
@@ -1,19 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
-    <suppress>
-        <notes>
-            This is for a vulnerability in zookeeper 3.4.13 coming in through the spring-data-solr artifact.
-            This is not an issue for replication because the solr cloud configuration is not used which is where
-            zookeeper is used.
-        </notes>
-        <cve>CVE-2018-8012</cve>
-        <cve>CVE-2019-0201</cve>
-    </suppress>
-    <suppress>
-        <notes>
-            This is for a vulnerability in jackson-databind 2.9.9 coming in through the spring-data-solr artifact.
-            This is not an issue for replication because we don't expose any json endpoints at this time.
-        </notes>
-        <cve>CVE-2019-12814</cve>
-    </suppress>
 </suppressions>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -22,10 +22,6 @@
     <artifactId>replication-api-impl</artifactId>
     <name>Replication :: API Impl</name>
 
-    <properties>
-        <org.eclipse-jetty.version>9.4.19.v20190610</org.eclipse-jetty.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.connexta.ion.replication</groupId>
@@ -36,62 +32,56 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-solr</artifactId>
         </dependency>
+        <!-- START spring-data-solr vulnerability workaround -->
         <dependency>
-            <artifactId>solr-solrj</artifactId>
             <groupId>org.apache.solr</groupId>
+            <artifactId>solr-solrj</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-client</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-java-client</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>http2-client</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>http2-common</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>http2-hpack</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.http2</groupId>
             <artifactId>http2-http-client-transport</artifactId>
-            <version>${org.eclipse-jetty.version}</version>
         </dependency>
-
-
+        <!-- END spring-data-solr vulnerability workaround -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -21,6 +21,11 @@
     </parent>
     <artifactId>replication-api-impl</artifactId>
     <name>Replication :: API Impl</name>
+
+    <properties>
+        <org.eclipse-jetty.version>9.4.19.v20190610</org.eclipse-jetty.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.connexta.ion.replication</groupId>
@@ -30,8 +35,63 @@
         <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-solr</artifactId>
-            <version>${spring-data-solr.version}</version>
         </dependency>
+        <dependency>
+            <artifactId>solr-solrj</artifactId>
+            <groupId>org.apache.solr</groupId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-client</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-java-client</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-client</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-common</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-hpack</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-http-client-transport</artifactId>
+            <version>${org.eclipse-jetty.version}</version>
+        </dependency>
+
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>

--- a/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/persistence/ReplicationItemManagerImpl.java
+++ b/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/persistence/ReplicationItemManagerImpl.java
@@ -125,7 +125,7 @@ public class ReplicationItemManagerImpl implements ReplicationItemManager {
 
   private GroupPage<ReplicationItemImpl> doSolrQuery(String configId, Pageable pageable) {
     Criteria queryCriteria = Crotch.where("config_id").is(configId);
-    Sort doneTimeDescSort = new Sort(Direction.DESC, "done_time");
+    Sort doneTimeDescSort = Sort.by(Direction.DESC, "done_time");
     SimpleQuery groupQuery =
         new SimpleQuery(queryCriteria).addSort(doneTimeDescSort).setPageRequest(pageable);
     GroupOptions options =


### PR DESCRIPTION
#### What does this PR do?
- Upgrades spring-data-solr to address some CVEs
- Remove spring boot parent pom as parent

Solr docker 8.2.0 is not available yet so can't upgrade that container in this PR

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@kcover @paouelle @clockard 

#### How should this be tested? (List steps with links to updated documentation)
- Startup solr and verify creating and deleting a site config works fine.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
