### PR TITLE
Bump fmt-maven-plugin from 2.0.0 to 2.9

### DIFF
--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/CqlBuilder.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/CqlBuilder.java
@@ -12,7 +12,6 @@ package com.connexta.ion.replication.adapters.ddf;
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-
 import java.util.Date;
 import java.util.List;
 

--- a/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/csw/MetacardMarshaller.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/ion/replication/adapters/ddf/csw/MetacardMarshaller.java
@@ -95,11 +95,10 @@ public class MetacardMarshaller {
     }
     Map<String, MetacardAttribute> attributes = new HashMap<>();
     ((Map) metadata.getRawMetadata())
-        .values()
-        .stream()
-        .filter(MetacardAttribute.class::isInstance)
-        .map(MetacardAttribute.class::cast)
-        .forEach(e -> attributes.put(((MetacardAttribute) e).getName(), (MetacardAttribute) e));
+        .values().stream()
+            .filter(MetacardAttribute.class::isInstance)
+            .map(MetacardAttribute.class::cast)
+            .forEach(e -> attributes.put(((MetacardAttribute) e).getName(), (MetacardAttribute) e));
     return attributes;
   }
 

--- a/adapters/ddf-adapter/src/test/java/com/connexta/ion/replication/adapters/ddf/ResultIterableTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/ion/replication/adapters/ddf/ResultIterableTest.java
@@ -115,9 +115,7 @@ public class ResultIterableTest {
     ArgumentCaptor<QueryRequest> requestCaptor = ArgumentCaptor.forClass(QueryRequest.class);
     verify(queryFunction, times(2)).apply(requestCaptor.capture());
     List<String> queryFilters =
-        requestCaptor
-            .getAllValues()
-            .stream()
+        requestCaptor.getAllValues().stream()
             .map(QueryRequest::getCql)
             .collect(Collectors.toList());
     assertTrue(queryFilters.contains(filter1));

--- a/pom.xml
+++ b/pom.xml
@@ -662,7 +662,7 @@
                     <plugin>
                         <groupId>com.coveo</groupId>
                         <artifactId>fmt-maven-plugin</artifactId>
-                        <version>2.0.0</version>
+                        <version>2.9</version>
                         <executions>
                             <execution>
                                 <phase>validate</phase>

--- a/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/NodeAdapters.java
+++ b/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/NodeAdapters.java
@@ -31,8 +31,7 @@ public class NodeAdapters {
    * @return the {@link NodeAdapter}s factory.
    */
   public NodeAdapterFactory factoryFor(NodeAdapterType type) {
-    return nodeAdapterFactories
-        .stream()
+    return nodeAdapterFactories.stream()
         .filter(factory -> factory.getType().equals(type))
         .findFirst()
         .orElseThrow(

--- a/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/persistence/ReplicationItemManagerImpl.java
+++ b/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/persistence/ReplicationItemManagerImpl.java
@@ -106,9 +106,7 @@ public class ReplicationItemManagerImpl implements ReplicationItemManager {
       Page<GroupEntry<ReplicationItemImpl>> page = groupResult.getGroupEntries();
       pageTotal = page.getTotalElements();
       for (GroupEntry<ReplicationItemImpl> entry : page.getContent()) {
-        entry
-            .getResult()
-            .stream()
+        entry.getResult().stream()
             .findFirst()
             .ifPresent(
                 item -> {


### PR DESCRIPTION
#### What does this PR do?
Bumps fmt-maven-plugin from 2.0.0 to 2.9.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard 

#### How should this be tested? (List steps with links to updated documentation)
CI

