### PR TITLE
REP-207 Add filter config

### DIFF
--- a/distributions/docker/solr/src/main/docker/Dockerfile
+++ b/distributions/docker/solr/src/main/docker/Dockerfile
@@ -2,4 +2,4 @@ FROM solr:8.1.1
 
 COPY maven/replication-solr-managed-schema.xml /opt/solr/server/solr/configsets/_default/conf/managed-schema
 
-ENTRYPOINT  bash -c "precreate-core replication_item;precreate-core replication_site;precreate-core replication_config;exec solr -f"
+ENTRYPOINT  bash -c "precreate-core replication_item;precreate-core replication_site;precreate-core replication_config;precreate-core replication_filter;exec solr -f"

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -208,7 +208,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.84</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
@@ -218,7 +218,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.82</minimum>
+                                            <minimum>0.84</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/spring/ServiceConfig.java
+++ b/replication-api-impl/src/main/java/com/connexta/ion/replication/api/impl/spring/ServiceConfig.java
@@ -20,12 +20,15 @@ import com.connexta.ion.replication.api.impl.ReplicatorImpl;
 import com.connexta.ion.replication.api.impl.ReplicatorRunner;
 import com.connexta.ion.replication.api.impl.Syncer;
 import com.connexta.ion.replication.spring.ReplicationProperties;
+import com.connexta.replication.api.impl.data.FilterManagerImpl;
 import com.connexta.replication.api.impl.data.ReplicationItemManagerImpl;
 import com.connexta.replication.api.impl.data.ReplicatorConfigManagerImpl;
 import com.connexta.replication.api.impl.data.SiteManagerImpl;
 import com.connexta.replication.api.impl.persistence.spring.ConfigRepository;
+import com.connexta.replication.api.impl.persistence.spring.FilterRepository;
 import com.connexta.replication.api.impl.persistence.spring.ItemRepository;
 import com.connexta.replication.api.impl.persistence.spring.SiteRepository;
+import com.connexta.replication.api.persistence.FilterManager;
 import com.connexta.replication.api.persistence.ReplicationItemManager;
 import com.connexta.replication.api.persistence.ReplicatorConfigManager;
 import com.connexta.replication.api.persistence.SiteManager;
@@ -52,6 +55,19 @@ public class ServiceConfig {
   @Bean
   public SiteManager siteManager(SiteRepository siteRepository) {
     return new SiteManagerImpl(siteRepository);
+  }
+
+  /**
+   * Used to create a {@link FilterManager} bean which provides an abstraction layer for CRUD
+   * operations involving {@link com.connexta.replication.api.data.Filter}s.
+   *
+   * @param filterRepository a {@link org.springframework.data.repository.CrudRepository} for basic
+   *     CRUD operations
+   * @return the {@link FilterManager}
+   */
+  @Bean
+  public FilterManager filterManager(FilterRepository filterRepository) {
+    return new FilterManagerImpl(filterRepository);
   }
 
   @Bean

--- a/replication-api-impl/src/main/java/com/connexta/replication/api/impl/data/FilterImpl.java
+++ b/replication-api-impl/src/main/java/com/connexta/replication/api/impl/data/FilterImpl.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.impl.data;
+
+import com.connexta.ion.replication.api.ReplicationPersistenceException;
+import com.connexta.replication.api.data.Filter;
+import com.connexta.replication.api.impl.persistence.pojo.FilterPojo;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+
+/**
+ * A filter describing what data to replicate to a site. A site can have multiple filters associated
+ * with it to describe what data it would like to receive.
+ */
+public class FilterImpl extends AbstractPersistable<FilterPojo> implements Filter {
+  private static final String TYPE = "replication filter";
+
+  private String siteId;
+
+  private String filter;
+
+  private String name;
+
+  private String description;
+
+  private boolean isSuspended;
+
+  private byte priority;
+
+  /** Creates a default filter. */
+  public FilterImpl() {
+    super(FilterImpl.TYPE);
+  }
+
+  /**
+   * Creates a filter from the given {@link FilterPojo}.
+   *
+   * @param pojo a pojo containing the values this filter should be instantiated with.
+   */
+  protected FilterImpl(FilterPojo pojo) {
+    super(FilterImpl.TYPE);
+    readFrom(pojo);
+  }
+
+  @Override
+  public String getSiteId() {
+    return siteId;
+  }
+
+  @Override
+  public String getFilter() {
+    return filter;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public Optional<String> getDescription() {
+    return Optional.ofNullable(description);
+  }
+
+  @Override
+  public boolean isSuspended() {
+    return isSuspended;
+  }
+
+  @Override
+  public byte getPriority() {
+    return priority;
+  }
+
+  @VisibleForTesting
+  void setSiteId(String siteId) {
+    this.siteId = siteId;
+  }
+
+  @VisibleForTesting
+  void setFilter(String filter) {
+    this.filter = filter;
+  }
+
+  @VisibleForTesting
+  void setName(String name) {
+    this.name = name;
+  }
+
+  @VisibleForTesting
+  void setDescription(String description) {
+    this.description = description;
+  }
+
+  @VisibleForTesting
+  void setSuspended(boolean suspended) {
+    this.isSuspended = suspended;
+  }
+
+  @VisibleForTesting
+  void setPriority(byte priority) {
+    if (priority < 1 || priority > 10) {
+      throw new IllegalArgumentException(
+          "Filter priority must be between 1 and 10 but was " + priority);
+    } else {
+      this.priority = priority;
+    }
+  }
+
+  @Override
+  protected FilterPojo writeTo(FilterPojo pojo) {
+    super.writeTo(pojo);
+    setOrFailIfNullOrEmpty("siteId", this::getSiteId, pojo::setSiteId);
+    setOrFailIfNullOrEmpty("filter", this::getFilter, pojo::setFilter);
+    setOrFailIfNullOrEmpty("name", this::getName, pojo::setName);
+    return pojo.setVersion(FilterPojo.CURRENT_VERSION)
+        .setDescription(description)
+        .setSuspended(isSuspended)
+        .setPriority(priority);
+  }
+
+  @Override
+  protected void readFrom(FilterPojo pojo) {
+    super.readFrom(pojo);
+    if (pojo.getVersion() < FilterPojo.MINIMUM_VERSION) {
+      throw new ReplicationPersistenceException(
+          "unsupported "
+              + FilterImpl.TYPE
+              + " version: "
+              + pojo.getVersion()
+              + " for object: "
+              + getId());
+    } // do support pojo.getVersion() > CURRENT_VERSION for forward compatibility
+    readFromCurrentOrFutureVersion(pojo);
+  }
+
+  private void readFromCurrentOrFutureVersion(FilterPojo pojo) {
+    setOrFailIfNullOrEmpty("siteId", pojo::getSiteId, this::setSiteId);
+    setOrFailIfNullOrEmpty("filter", pojo::getFilter, this::setFilter);
+    setOrFailIfNullOrEmpty("name", pojo::getName, this::setName);
+    this.description = pojo.getDescription();
+    this.isSuspended = pojo.isSuspended();
+    this.priority = (byte) Math.min(Math.max(pojo.getPriority(), 1), 10);
+  }
+}

--- a/replication-api-impl/src/main/java/com/connexta/replication/api/impl/data/FilterManagerImpl.java
+++ b/replication-api-impl/src/main/java/com/connexta/replication/api/impl/data/FilterManagerImpl.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.impl.data;
+
+import com.connexta.ion.replication.api.NotFoundException;
+import com.connexta.replication.api.data.Filter;
+import com.connexta.replication.api.impl.persistence.pojo.FilterPojo;
+import com.connexta.replication.api.impl.persistence.spring.FilterRepository;
+import com.connexta.replication.api.persistence.FilterManager;
+import java.util.Spliterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/** Performs CRUD operations for {@link Filter}s. */
+public class FilterManagerImpl implements FilterManager {
+
+  private final FilterRepository filterRepository;
+
+  public FilterManagerImpl(FilterRepository filterRepository) {
+    this.filterRepository = filterRepository;
+  }
+
+  @Override
+  public Filter create() {
+    return new FilterImpl();
+  }
+
+  @Override
+  public Filter get(String id) {
+    return filterRepository
+        .findById(id)
+        .map(FilterImpl::new)
+        .orElseThrow(
+            () -> new NotFoundException(String.format("Cannot find filter with ID: %s", id)));
+  }
+
+  @Override
+  public Stream<Filter> objects() {
+    return filterStreamOf(filterRepository.findAll().spliterator());
+  }
+
+  @Override
+  public void save(Filter filter) {
+    if (filter instanceof FilterImpl) {
+      filterRepository.save(((FilterImpl) filter).writeTo(new FilterPojo()));
+    } else {
+      throw new IllegalArgumentException(
+          "Expected a FilterImpl but got a " + filter.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public void remove(String id) {
+    filterRepository.deleteById(id);
+  }
+
+  @Override
+  public Stream<Filter> filtersForSite(String siteId) {
+    return filterStreamOf(filterRepository.findBySiteId(siteId).spliterator());
+  }
+
+  // coverts the pojos to Filters and returns them as a stream
+  private Stream<Filter> filterStreamOf(Spliterator<FilterPojo> filterPojos) {
+    return StreamSupport.stream(filterPojos, false).map(FilterImpl::new).map(Filter.class::cast);
+  }
+}

--- a/replication-api-impl/src/main/java/com/connexta/replication/api/impl/persistence/pojo/FilterPojo.java
+++ b/replication-api-impl/src/main/java/com/connexta/replication/api/impl/persistence/pojo/FilterPojo.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.impl.persistence.pojo;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.springframework.data.solr.core.mapping.Indexed;
+import org.springframework.data.solr.core.mapping.SolrDocument;
+
+/** A pojo used to load filters from persistence. */
+@SolrDocument(collection = FilterPojo.COLLECTION)
+public class FilterPojo extends Pojo<FilterPojo> {
+
+  /**
+   * List of possible versions:
+   *
+   * <ul>
+   *   <li>1 - initial version.
+   * </ul>
+   */
+  public static final int CURRENT_VERSION = 1;
+
+  /** The oldest version supported by the current code (anything before that will fail). */
+  public static final int MINIMUM_VERSION = 1;
+
+  public static final String COLLECTION = "replication_filter";
+
+  @Indexed(name = "site_id")
+  @Nullable
+  private String siteId;
+
+  @Indexed(name = "filter", searchable = false)
+  @Nullable
+  private String filter;
+
+  @Indexed(name = "name")
+  @Nullable
+  private String name;
+
+  @Indexed(name = "description", searchable = false)
+  @Nullable
+  private String description;
+
+  @Indexed(name = "suspended", searchable = false)
+  private boolean suspended;
+
+  @Indexed(name = "priority", searchable = false, type = "pint")
+  private byte priority;
+
+  /** Instantiates a default filter pojo set with the current version. */
+  public FilterPojo() {
+    super.setVersion(CURRENT_VERSION);
+  }
+
+  /**
+   * Gets the ID of the site associated with this filter.
+   *
+   * @return the site id
+   */
+  @Nullable
+  public String getSiteId() {
+    return siteId;
+  }
+
+  /**
+   * Sets the site id for this filter
+   *
+   * @param siteId the id of the site to associate with this filter.
+   * @return this for chaining
+   */
+  public FilterPojo setSiteId(@Nullable String siteId) {
+    this.siteId = siteId;
+    return this;
+  }
+
+  /**
+   * Gets the query text for this filter.
+   *
+   * @return the query text for this filter
+   */
+  @Nullable
+  public String getFilter() {
+    return filter;
+  }
+
+  /**
+   * Sets the query text for this filter.
+   *
+   * @param filter the query text to give this filter
+   * @return this for chaining
+   */
+  public FilterPojo setFilter(@Nullable String filter) {
+    this.filter = filter;
+    return this;
+  }
+
+  /**
+   * Gets the name for this filter.
+   *
+   * @return the name of this filter
+   */
+  @Nullable
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Sets the name of this filter.
+   *
+   * @param name the name to give this filter
+   * @return this for chaining
+   */
+  public FilterPojo setName(@Nullable String name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Gets the description of this filter.
+   *
+   * @return the description of this filter
+   */
+  @Nullable
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Sets the description of this filter.
+   *
+   * @param description the description to give this filter
+   * @return this for chaining
+   */
+  public FilterPojo setDescription(@Nullable String description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
+   * Gets the suspended status of this filter.
+   *
+   * @return the suspended status of this filter
+   */
+  public boolean isSuspended() {
+    return suspended;
+  }
+
+  /**
+   * Sets the suspended status of this filter.
+   *
+   * @param suspended the suspended status to give this filter
+   * @return this for chaining
+   */
+  public FilterPojo setSuspended(boolean suspended) {
+    this.suspended = suspended;
+    return this;
+  }
+
+  /**
+   * Gets the priority of this filter.
+   *
+   * @return the priority of this filter
+   */
+  public byte getPriority() {
+    return priority;
+  }
+
+  /**
+   * Sets the priority of this filter.
+   *
+   * @param priority the priority to give this filter
+   * @return this for chaining
+   */
+  public FilterPojo setPriority(byte priority) {
+    this.priority = priority;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), siteId, filter, name, description, suspended, priority);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (super.equals(obj) && (obj instanceof FilterPojo)) {
+      final FilterPojo pojo = (FilterPojo) obj;
+
+      return (suspended == pojo.suspended)
+          && (priority == pojo.priority)
+          && Objects.equals(siteId, pojo.siteId)
+          && Objects.equals(filter, pojo.filter)
+          && Objects.equals(name, pojo.name)
+          && Objects.equals(description, pojo.description);
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "FilterPojo[id=%s, version=%d, siteId=%s, filter=%s, name=%s, description=%s, suspended=%b, priority=%d]",
+        getId(), getVersion(), siteId, filter, name, description, suspended, priority);
+  }
+}

--- a/replication-api-impl/src/main/java/com/connexta/replication/api/impl/persistence/spring/FilterRepository.java
+++ b/replication-api-impl/src/main/java/com/connexta/replication/api/impl/persistence/spring/FilterRepository.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.impl.persistence.spring;
+
+import com.connexta.replication.api.impl.persistence.pojo.FilterPojo;
+import org.springframework.data.repository.CrudRepository;
+
+// This will be AUTO IMPLEMENTED by Spring into a Bean called filterRepository
+public interface FilterRepository extends CrudRepository<FilterPojo, String> {
+
+  Iterable<FilterPojo> findBySiteId(String siteId);
+}

--- a/replication-api-impl/src/test/java/com/connexta/replication/api/impl/data/FilterImplTest.java
+++ b/replication-api-impl/src/test/java/com/connexta/replication/api/impl/data/FilterImplTest.java
@@ -1,0 +1,372 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.impl.data;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+import com.connexta.ion.replication.api.ReplicationPersistenceException;
+import com.connexta.replication.api.impl.persistence.pojo.FilterPojo;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class FilterImplTest {
+
+  private static final String ID = "id";
+
+  private static final String SITE_ID = "site_id";
+
+  private static final String FILTER = "filter";
+
+  private static final String NAME = "name";
+
+  private static final String DESCRIPTION = "description";
+
+  private static final byte PRIORITY = 2;
+
+  private FilterImpl filter;
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    filter = new FilterImpl();
+  }
+
+  @Test
+  public void gettersAndSetters() {
+    filter.setSiteId(SITE_ID);
+    filter.setFilter(FILTER);
+    filter.setName(NAME);
+    filter.setDescription(DESCRIPTION);
+    filter.setSuspended(true);
+    filter.setPriority(PRIORITY);
+    assertThat(filter.getSiteId(), is(SITE_ID));
+    assertThat(filter.getFilter(), is(FILTER));
+    assertThat(filter.getName(), is(NAME));
+    assertThat(filter.getDescription().get(), is(DESCRIPTION));
+    assertThat(filter.isSuspended(), is(true));
+    assertThat(filter.getPriority(), is(PRIORITY));
+  }
+
+  @Test
+  public void readFrom() {
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority(PRIORITY);
+    filter = new FilterImpl(pojo);
+    assertThat(filter.getId(), is(ID));
+    assertThat(filter.getSiteId(), is(SITE_ID));
+    assertThat(filter.getFilter(), is(FILTER));
+    assertThat(filter.getName(), is(NAME));
+    assertThat(filter.getDescription().get(), is(DESCRIPTION));
+    assertThat(filter.isSuspended(), is(true));
+    assertThat(filter.getPriority(), is(PRIORITY));
+  }
+
+  @Test
+  public void readFromWithUnsupportedVersion() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*replication filter.*"));
+
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(0)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority(PRIORITY);
+    filter = new FilterImpl(pojo);
+    assertThat(filter.getSiteId(), is(SITE_ID));
+    assertThat(filter.getFilter(), is(FILTER));
+    assertThat(filter.getName(), is(NAME));
+    assertThat(filter.getDescription().get(), is(DESCRIPTION));
+    assertThat(filter.isSuspended(), is(true));
+    assertThat(filter.getPriority(), is(PRIORITY));
+  }
+
+  @Test
+  public void readFromWithNullSiteId() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*missing.*siteId.*"));
+
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority(PRIORITY);
+    filter = new FilterImpl(pojo);
+  }
+
+  @Test
+  public void readFromWithEmptySiteId() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*empty.*siteId.*"));
+
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setSiteId("")
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority(PRIORITY);
+    filter = new FilterImpl(pojo);
+  }
+
+  @Test
+  public void readFromWithNullFilter() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*missing.*filter.*"));
+
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setSiteId(SITE_ID)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority(PRIORITY);
+    filter = new FilterImpl(pojo);
+  }
+
+  @Test
+  public void readFromWithEmptyFilter() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*empty.*filter.*"));
+
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter("")
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority(PRIORITY);
+    filter = new FilterImpl(pojo);
+  }
+
+  @Test
+  public void readFromWithNullName() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*missing.*name.*"));
+
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority(PRIORITY);
+    filter = new FilterImpl(pojo);
+  }
+
+  @Test
+  public void readFromWithEmptyName() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*empty.*name.*"));
+
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setName("")
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority(PRIORITY);
+    filter = new FilterImpl(pojo);
+  }
+
+  @Test
+  public void readfromWithPriorityLessThanOne() {
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority((byte) 0);
+    filter = new FilterImpl(pojo);
+    assertThat(filter.getSiteId(), is(SITE_ID));
+    assertThat(filter.getFilter(), is(FILTER));
+    assertThat(filter.getName(), is(NAME));
+    assertThat(filter.getDescription().get(), is(DESCRIPTION));
+    assertThat(filter.isSuspended(), is(true));
+    assertThat(filter.getPriority(), is((byte) 1));
+  }
+
+  @Test
+  public void readfromWithPriorityGreaterThanTen() {
+    FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(FilterPojo.CURRENT_VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(true)
+            .setPriority((byte) 11);
+    filter = new FilterImpl(pojo);
+    assertThat(filter.getSiteId(), is(SITE_ID));
+    assertThat(filter.getFilter(), is(FILTER));
+    assertThat(filter.getName(), is(NAME));
+    assertThat(filter.getDescription().get(), is(DESCRIPTION));
+    assertThat(filter.isSuspended(), is(true));
+    assertThat(filter.getPriority(), is((byte) 10));
+  }
+
+  @Test
+  public void writeTo() {
+    FilterPojo pojo = new FilterPojo();
+    filter.setId(ID);
+    filter.setSiteId(SITE_ID);
+    filter.setFilter(FILTER);
+    filter.setName(NAME);
+    filter.setDescription(DESCRIPTION);
+    filter.setSuspended(true);
+    filter.setPriority(PRIORITY);
+    filter.writeTo(pojo);
+    assertThat(pojo.getId(), is(ID));
+    assertThat(pojo.getVersion(), is(FilterPojo.CURRENT_VERSION));
+    assertThat(pojo.getSiteId(), is(SITE_ID));
+    assertThat(pojo.getFilter(), is(FILTER));
+    assertThat(pojo.getName(), is(NAME));
+    assertThat(pojo.getDescription(), is(DESCRIPTION));
+    assertThat(pojo.isSuspended(), is(true));
+    assertThat(pojo.getPriority(), is(PRIORITY));
+  }
+
+  @Test
+  public void writeToWithNullSiteId() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*missing.*siteId.*"));
+
+    FilterPojo pojo = new FilterPojo();
+    filter.setId(ID);
+    filter.setFilter(FILTER);
+    filter.setName(NAME);
+    filter.setDescription(DESCRIPTION);
+    filter.setSuspended(true);
+    filter.setPriority(PRIORITY);
+    filter.writeTo(pojo);
+  }
+
+  @Test
+  public void writeToWithEmptySiteId() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*empty.*siteId.*"));
+
+    FilterPojo pojo = new FilterPojo();
+    filter.setId(ID);
+    filter.setSiteId("");
+    filter.setFilter(FILTER);
+    filter.setName(NAME);
+    filter.setDescription(DESCRIPTION);
+    filter.setSuspended(true);
+    filter.setPriority(PRIORITY);
+    filter.writeTo(pojo);
+  }
+
+  @Test
+  public void writeToWithNullFilter() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*missing.*filter.*"));
+
+    FilterPojo pojo = new FilterPojo();
+    filter.setId(ID);
+    filter.setSiteId(SITE_ID);
+    filter.setName(NAME);
+    filter.setDescription(DESCRIPTION);
+    filter.setSuspended(true);
+    filter.setPriority(PRIORITY);
+    filter.writeTo(pojo);
+  }
+
+  @Test
+  public void writeToWithEmptyFilter() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*empty.*filter.*"));
+
+    FilterPojo pojo = new FilterPojo();
+    filter.setId(ID);
+    filter.setSiteId(SITE_ID);
+    filter.setFilter("");
+    filter.setName(NAME);
+    filter.setDescription(DESCRIPTION);
+    filter.setSuspended(true);
+    filter.setPriority(PRIORITY);
+    filter.writeTo(pojo);
+  }
+
+  @Test
+  public void writeToWithNullName() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*missing.*name.*"));
+
+    FilterPojo pojo = new FilterPojo();
+    filter.setId(ID);
+    filter.setSiteId(SITE_ID);
+    filter.setFilter(FILTER);
+    filter.setDescription(DESCRIPTION);
+    filter.setSuspended(true);
+    filter.setPriority(PRIORITY);
+    filter.writeTo(pojo);
+  }
+
+  @Test
+  public void writeToWithEmptyName() {
+    exception.expect(ReplicationPersistenceException.class);
+    exception.expectMessage(Matchers.matchesPattern(".*empty.*name.*"));
+
+    FilterPojo pojo = new FilterPojo();
+    filter.setId(ID);
+    filter.setSiteId(SITE_ID);
+    filter.setFilter(FILTER);
+    filter.setName("");
+    filter.setDescription(DESCRIPTION);
+    filter.setSuspended(true);
+    filter.setPriority(PRIORITY);
+    filter.writeTo(pojo);
+  }
+}

--- a/replication-api-impl/src/test/java/com/connexta/replication/api/impl/data/FilterManagerImplTest.java
+++ b/replication-api-impl/src/test/java/com/connexta/replication/api/impl/data/FilterManagerImplTest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.impl.data;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.connexta.ion.replication.api.NotFoundException;
+import com.connexta.ion.replication.api.ReplicationPersistenceException;
+import com.connexta.replication.api.data.Filter;
+import com.connexta.replication.api.impl.persistence.pojo.FilterPojo;
+import com.connexta.replication.api.impl.persistence.spring.FilterRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FilterManagerImplTest {
+
+  private static final String ID = "id";
+
+  private static final String SITE_ID = "site_id";
+
+  private static final String FILTER = "filter";
+
+  private static final String NAME = "name";
+
+  private static final String DESCRIPTION = "description";
+
+  private static final byte PRIORITY = 2;
+
+  @Mock private FilterRepository filterRepository;
+
+  private FilterManagerImpl filterManager;
+
+  @Before
+  public void setup() {
+    filterManager = new FilterManagerImpl(filterRepository);
+  }
+
+  @Test
+  public void create() {
+    assertTrue(filterManager.create() instanceof FilterImpl);
+  }
+
+  @Test
+  public void get() {
+    when(filterRepository.findById(anyString())).thenReturn(Optional.of(makeDefaultPojo()));
+    Filter filter = filterManager.get(ID);
+    assertThat(filter.getId(), is(ID));
+    assertThat(filter.getSiteId(), is(SITE_ID));
+    assertThat(filter.getDescription().get(), is(DESCRIPTION));
+    assertThat(filter.getFilter(), is(FILTER));
+    assertThat(filter.getName(), is(NAME));
+    assertThat(filter.getPriority(), is(PRIORITY));
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void getFilterNotFound() {
+    when(filterRepository.findById(anyString())).thenReturn(Optional.empty());
+    filterManager.get("id");
+  }
+
+  @Test(expected = ReplicationPersistenceException.class)
+  public void getThrowsPersistenceException() {
+    when(filterRepository.findById(anyString())).thenThrow(new ReplicationPersistenceException());
+    filterManager.get("id");
+  }
+
+  @Test
+  public void objects() {
+    when(filterRepository.findAll()).thenReturn(List.of(makeDefaultPojo()));
+    Filter filter = filterManager.objects().findFirst().orElse(null);
+    assertThat(filter.getId(), is(ID));
+    assertThat(filter.getSiteId(), is(SITE_ID));
+    assertThat(filter.getDescription().get(), is(DESCRIPTION));
+    assertThat(filter.getFilter(), is(FILTER));
+    assertThat(filter.getName(), is(NAME));
+    assertThat(filter.getPriority(), is(PRIORITY));
+  }
+
+  @Test(expected = ReplicationPersistenceException.class)
+  public void objectsThrowsPersistenceException() {
+    when(filterRepository.findAll()).thenThrow(new ReplicationPersistenceException());
+    filterManager.objects().findFirst().orElse(null);
+  }
+
+  @Test
+  public void save() {
+    FilterPojo filterPojo = makeDefaultPojo();
+    filterManager.save(new FilterImpl(filterPojo));
+    verify(filterRepository).save(eq(filterPojo));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void saveIllegalObject() {
+    Filter testFilter = mock(Filter.class);
+    filterManager.save(testFilter);
+  }
+
+  @Test(expected = ReplicationPersistenceException.class)
+  public void saveThrowsPersistenceException() {
+    when(filterRepository.save(any(FilterPojo.class)))
+        .thenThrow(new ReplicationPersistenceException());
+    filterManager.save(new FilterImpl(makeDefaultPojo()));
+  }
+
+  @Test
+  public void remove() {
+    filterManager.remove("id");
+    verify(filterRepository).deleteById("id");
+  }
+
+  @Test
+  public void filtersForSite() {
+    when(filterRepository.findBySiteId(anyString())).thenReturn(List.of(makeDefaultPojo()));
+    Filter filter = filterManager.filtersForSite(SITE_ID).findFirst().orElse(null);
+    assertThat(filter.getId(), is(ID));
+    assertThat(filter.getSiteId(), is(SITE_ID));
+    assertThat(filter.getDescription().get(), is(DESCRIPTION));
+    assertThat(filter.getFilter(), is(FILTER));
+    assertThat(filter.getName(), is(NAME));
+    assertThat(filter.getPriority(), is(PRIORITY));
+  }
+
+  @Test(expected = ReplicationPersistenceException.class)
+  public void filtersForSiteThrowsPersistenceException() {
+    when(filterRepository.findBySiteId(anyString()))
+        .thenThrow(new ReplicationPersistenceException());
+    filterManager.filtersForSite(SITE_ID).findFirst().orElse(null);
+  }
+
+  private FilterPojo makeDefaultPojo() {
+    return new FilterPojo()
+        .setId(ID)
+        .setVersion(1)
+        .setSiteId(SITE_ID)
+        .setFilter(FILTER)
+        .setName(NAME)
+        .setDescription(DESCRIPTION)
+        .setSuspended(true)
+        .setPriority(PRIORITY);
+  }
+}

--- a/replication-api-impl/src/test/java/com/connexta/replication/api/impl/persistence/pojo/FilterPojoTest.java
+++ b/replication-api-impl/src/test/java/com/connexta/replication/api/impl/persistence/pojo/FilterPojoTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.impl.persistence.pojo;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+import com.jparams.verifier.tostring.NameStyle;
+import com.jparams.verifier.tostring.ToStringVerifier;
+import org.junit.Test;
+
+public class FilterPojoTest {
+
+  private static final String SITE_ID = "site_id";
+
+  private static final String FILTER = "filter";
+
+  private static final String NAME = "name";
+
+  private static final String DESCRIPTION = "description";
+
+  private static final byte PRIORITY = 2;
+
+  private FilterPojo filterPojo = makeDefaultPojo();
+
+  @Test
+  public void gettersAndSetters() {
+    assertThat(filterPojo.getSiteId(), is(SITE_ID));
+    assertThat(filterPojo.getFilter(), is(FILTER));
+    assertThat(filterPojo.getName(), is(NAME));
+    assertThat(filterPojo.getDescription(), is(DESCRIPTION));
+    assertThat(filterPojo.isSuspended(), is(true));
+    assertThat(filterPojo.getPriority(), is(PRIORITY));
+  }
+
+  @Test
+  public void equals() {
+    FilterPojo filterPojo2 = makeDefaultPojo();
+    assertTrue(filterPojo.equals(filterPojo2));
+    assertTrue(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentId() {
+    FilterPojo filterPojo2 = makeDefaultPojo().setId("numbatwo");
+    assertFalse(filterPojo.equals(filterPojo2));
+    assertFalse(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentVersion() {
+    FilterPojo filterPojo2 = makeDefaultPojo().setVersion(2077);
+    assertFalse(filterPojo.equals(filterPojo2));
+    assertFalse(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentName() {
+    FilterPojo filterPojo2 = makeDefaultPojo().setName("numbatwo");
+    assertFalse(filterPojo.equals(filterPojo2));
+    assertFalse(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentSiteId() {
+    FilterPojo filterPojo2 = makeDefaultPojo().setSiteId("numbatwo");
+    assertFalse(filterPojo.equals(filterPojo2));
+    assertFalse(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentFilter() {
+    FilterPojo filterPojo2 = makeDefaultPojo().setFilter("numbatwo");
+    assertFalse(filterPojo.equals(filterPojo2));
+    assertFalse(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentDescription() {
+    FilterPojo filterPojo2 = makeDefaultPojo().setDescription("numbatwo");
+    assertFalse(filterPojo.equals(filterPojo2));
+    assertFalse(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentSuspendedValue() {
+    FilterPojo filterPojo2 = makeDefaultPojo().setSuspended(false);
+    assertFalse(filterPojo.equals(filterPojo2));
+    assertFalse(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentPriority() {
+    FilterPojo filterPojo2 = makeDefaultPojo().setPriority((byte) 5);
+    assertFalse(filterPojo.equals(filterPojo2));
+    assertFalse(filterPojo2.equals(filterPojo));
+  }
+
+  @Test
+  public void equalsWithDifferentObject() {
+    assertFalse(filterPojo.equals(new Object()));
+  }
+
+  @Test
+  public void equalsWithNull() {
+    assertFalse(filterPojo.equals(null));
+  }
+
+  @Test
+  public void hashcode() {
+    FilterPojo filterPojo2 = makeDefaultPojo();
+    assertThat(filterPojo.hashCode(), is(filterPojo2.hashCode()));
+    filterPojo2.setName("numbatwo");
+    assertThat(filterPojo.hashCode(), not(filterPojo2.hashCode()));
+  }
+
+  @Test
+  public void testToString() {
+    filterPojo.setId("1234");
+
+    ToStringVerifier.forClass(FilterPojo.class).withClassName(NameStyle.SIMPLE_NAME).verify();
+  }
+
+  private FilterPojo makeDefaultPojo() {
+    return new FilterPojo()
+        .setSiteId(SITE_ID)
+        .setFilter(FILTER)
+        .setName(NAME)
+        .setDescription(DESCRIPTION)
+        .setSuspended(true)
+        .setPriority(PRIORITY);
+  }
+}

--- a/replication-api-impl/src/test/java/com/connexta/replication/api/impl/persistence/spring/FilterRepositoryIntegrationTest.java
+++ b/replication-api-impl/src/test/java/com/connexta/replication/api/impl/persistence/spring/FilterRepositoryIntegrationTest.java
@@ -1,0 +1,390 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.impl.persistence.spring;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAnd;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.connexta.replication.api.impl.persistence.EmbeddedSolrServerFactory;
+import com.connexta.replication.api.impl.persistence.pojo.FilterPojo;
+import java.util.Arrays;
+import java.util.Optional;
+import org.apache.solr.client.solrj.SolrClient;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.solr.UncategorizedSolrException;
+import org.springframework.data.solr.repository.config.EnableSolrRepositories;
+import org.springframework.data.solr.server.SolrClientFactory;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@ComponentScan(
+    basePackageClasses = FilterRepository.class) // to make sure we pickup the repositories
+@RunWith(SpringRunner.class)
+public class FilterRepositoryIntegrationTest {
+  private static final int VERSION = 1;
+  private static final int VERSION2 = 2;
+  private static final int VERSION3 = 3;
+  private static final String ID = "1234";
+  private static final String ID2 = "1235";
+  private static final String ID3 = "1236";
+  private static final String SITE_ID = "site_id";
+  private static final String SITE_ID2 = "site_id2";
+  private static final String SITE_ID3 = "site_id3";
+  private static final String FILTER = "filter";
+  private static final String FILTER2 = "filter2";
+  private static final String FILTER3 = "filter3";
+  private static final String NAME = "name";
+  private static final String NAME2 = "name2";
+  private static final String NAME3 = "name3";
+  private static final String DESCRIPTION = "description";
+  private static final String DESCRIPTION2 = "description2";
+  private static final String DESCRIPTION3 = "description3";
+  private static final boolean SUSPENDED = true;
+  private static final boolean SUSPENDED2 = false;
+  private static final boolean SUSPENDED3 = true;
+  private static final byte PRIORITY = 2;
+  private static final byte PRIORITY2 = 3;
+  private static final byte PRIORITY3 = 4;
+
+  private static final FilterPojo POJO =
+      new FilterPojo()
+          .setId(ID)
+          .setVersion(VERSION)
+          .setSiteId(SITE_ID)
+          .setFilter(FILTER)
+          .setName(NAME)
+          .setDescription(DESCRIPTION)
+          .setSuspended(SUSPENDED)
+          .setPriority(PRIORITY);
+  private static final FilterPojo POJO2 =
+      new FilterPojo()
+          .setId(ID2)
+          .setVersion(VERSION2)
+          .setSiteId(SITE_ID2)
+          .setFilter(FILTER2)
+          .setName(NAME2)
+          .setDescription(DESCRIPTION2)
+          .setSuspended(SUSPENDED2)
+          .setPriority(PRIORITY2);
+  private static final FilterPojo POJO3 =
+      new FilterPojo()
+          .setId(ID3)
+          .setVersion(VERSION3)
+          .setSiteId(SITE_ID3)
+          .setFilter(FILTER3)
+          .setName(NAME3)
+          .setDescription(DESCRIPTION3)
+          .setSuspended(SUSPENDED3)
+          .setPriority(PRIORITY3);
+
+  @TestConfiguration
+  @EnableSolrRepositories(basePackages = "com.connexta.replication")
+  static class FilterRepositoryTestConfiguration {
+    @Bean
+    SolrClientFactory solrFactory() {
+      return new EmbeddedSolrServerFactory("classpath:solr", FilterPojo.COLLECTION);
+    }
+
+    @Bean
+    SolrClient solrClient(SolrClientFactory solrFactory) {
+      return solrFactory.getSolrClient();
+    }
+  }
+
+  @Rule public ExpectedException exception = ExpectedException.none();
+
+  @Autowired private FilterRepository repo;
+
+  @After
+  public void cleanup() {
+    repo.deleteAll();
+  }
+
+  @Test
+  public void testPojoPersistenceWhenIdIsNotDefined() {
+    exception.expect(UncategorizedSolrException.class);
+    exception.expectMessage(containsString("missing mandatory unique"));
+
+    final FilterPojo pojo =
+        new FilterPojo()
+            .setVersion(VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(SUSPENDED)
+            .setPriority(PRIORITY);
+
+    repo.save(pojo);
+  }
+
+  @Test
+  public void testPojoPersistenceWhenSiteIdIsNotDefined() {
+    final FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(VERSION)
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(SUSPENDED)
+            .setPriority(PRIORITY);
+
+    final FilterPojo saved = repo.save(pojo);
+    assertThat(saved, equalTo(pojo));
+
+    final Optional<FilterPojo> loaded = repo.findById(ID);
+    assertThat(loaded, isPresentAnd(equalTo(pojo)));
+  }
+
+  @Test
+  public void testPojoPersistenceWhenFilterIsNotDefined() {
+    final FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(VERSION)
+            .setSiteId(SITE_ID)
+            .setName(NAME)
+            .setDescription(DESCRIPTION)
+            .setSuspended(SUSPENDED)
+            .setPriority(PRIORITY);
+
+    final FilterPojo saved = repo.save(pojo);
+    assertThat(saved, equalTo(pojo));
+
+    final Optional<FilterPojo> loaded = repo.findById(ID);
+    assertThat(loaded, isPresentAnd(equalTo(pojo)));
+  }
+
+  @Test
+  public void testPojoPersistenceWhenNameIsNotDefined() {
+    final FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setDescription(DESCRIPTION)
+            .setSuspended(SUSPENDED)
+            .setPriority(PRIORITY);
+
+    final FilterPojo saved = repo.save(pojo);
+    assertThat(saved, equalTo(pojo));
+
+    final Optional<FilterPojo> loaded = repo.findById(ID);
+    assertThat(loaded, isPresentAnd(equalTo(pojo)));
+  }
+
+  @Test
+  public void testPojoPersistenceWhenDescriptionIsNotDefined() {
+    final FilterPojo pojo =
+        new FilterPojo()
+            .setId(ID)
+            .setVersion(VERSION)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER)
+            .setName(NAME)
+            .setSuspended(SUSPENDED)
+            .setPriority(PRIORITY);
+
+    final FilterPojo saved = repo.save(pojo);
+    assertThat(saved, equalTo(pojo));
+
+    final Optional<FilterPojo> loaded = repo.findById(ID);
+    assertThat(loaded, isPresentAnd(equalTo(pojo)));
+  }
+
+  @Test
+  public void testPojoPersistenceWhenAllFieldsAreDefined() {
+    final FilterPojo saved = repo.save(POJO);
+    assertThat(saved, equalTo(POJO));
+
+    final Optional<FilterPojo> loaded = repo.findById(ID);
+    assertThat(loaded, isPresentAnd(equalTo(POJO)));
+  }
+
+  @Test
+  public void testSaveAll() throws Exception {
+    final Iterable<FilterPojo> saved = repo.saveAll(Arrays.asList(POJO, POJO2));
+
+    assertThat(saved, contains(POJO, POJO2));
+    assertThat(repo.findById(ID), isPresentAnd(equalTo(POJO)));
+    assertThat(repo.findById(ID2), isPresentAnd(equalTo(POJO2)));
+  }
+
+  @Test
+  public void testFindById() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+
+    assertThat(repo.findById(ID), isPresentAnd(equalTo(POJO)));
+  }
+
+  @Test
+  public void testFindByIdWhenNotFound() throws Exception {
+    repo.save(POJO);
+
+    assertThat(repo.findById(ID2), isEmpty());
+  }
+
+  @Test
+  public void testExistById() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+
+    assertThat(repo.existsById(ID), equalTo(true));
+  }
+
+  @Test
+  public void testExistByIdWhenNotFound() throws Exception {
+    repo.save(POJO);
+
+    assertThat(repo.existsById(ID2), not(equalTo(true)));
+  }
+
+  @Test
+  public void testFindAll() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+
+    assertThat(repo.findAll(), containsInAnyOrder(POJO, POJO2));
+  }
+
+  @Test
+  public void testFindAllWhenNoneDefined() throws Exception {
+    assertThat(repo.findAll(), emptyIterable());
+  }
+
+  @Test
+  public void testFindAllById() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+    repo.save(POJO3);
+
+    assertThat(
+        repo.findAllById(Arrays.asList(ID, ID2, "unknown-id")), containsInAnyOrder(POJO, POJO2));
+  }
+
+  @Test
+  public void testCount() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+
+    assertThat(repo.count(), equalTo(2L));
+  }
+
+  @Test
+  public void testCountWhenNoneDefined() throws Exception {
+    assertThat(repo.count(), equalTo(0L));
+  }
+
+  @Test
+  public void testDeleteById() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+
+    repo.deleteById(ID);
+    assertThat(repo.findAll(), contains(POJO2));
+  }
+
+  @Test
+  public void testDeleteByIdWhenNotFound() throws Exception {
+    repo.save(POJO);
+
+    repo.deleteById(ID2);
+    assertThat(repo.findAll(), contains(POJO));
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+
+    repo.delete(POJO);
+    assertThat(repo.findAll(), contains(POJO2));
+  }
+
+  @Test
+  public void testDeleteWhenNotFound() throws Exception {
+    repo.save(POJO);
+
+    repo.delete(POJO2);
+    assertThat(repo.findAll(), contains(POJO));
+  }
+
+  @Test
+  public void testDeleteAllByObj() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+    repo.save(POJO3);
+
+    repo.deleteAll(Arrays.asList(POJO, POJO3));
+    assertThat(repo.findAll(), contains(POJO2));
+  }
+
+  @Test
+  public void testDeleteAllByObjWhenOneNotDefined() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+
+    repo.deleteAll(Arrays.asList(POJO, POJO3));
+    assertThat(repo.findAll(), contains(POJO2));
+  }
+
+  @Test
+  public void testDeleteAll() throws Exception {
+    repo.save(POJO);
+    repo.save(POJO2);
+    repo.save(POJO3);
+
+    assertThat(repo.count(), equalTo(3L));
+    repo.deleteAll();
+    assertThat(repo.count(), equalTo(0L));
+  }
+
+  @Test
+  public void testFindBySiteId() {
+    repo.save(POJO);
+    FilterPojo pojo2WithSiteId1 =
+        new FilterPojo()
+            .setId(ID2)
+            .setVersion(VERSION2)
+            .setSiteId(SITE_ID)
+            .setFilter(FILTER2)
+            .setName(NAME2)
+            .setDescription(DESCRIPTION2)
+            .setSuspended(SUSPENDED2)
+            .setPriority(PRIORITY2);
+    repo.save(pojo2WithSiteId1);
+    repo.save(POJO3);
+
+    Iterable<FilterPojo> results = repo.findBySiteId(SITE_ID);
+    assertThat(results, containsInAnyOrder(POJO, pojo2WithSiteId1));
+    assertThat(results, not(contains(POJO3)));
+  }
+}

--- a/replication-api/src/main/java/com/connexta/replication/api/data/Filter.java
+++ b/replication-api/src/main/java/com/connexta/replication/api/data/Filter.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.api.data;
+
+import java.util.Optional;
+
+/**
+ * A filter describing what data to replicate to a site. A site can have multiple filters associated
+ * with it to describe what data it would like to receive.
+ */
+public interface Filter extends Persistable {
+
+  /**
+   * Gets the ID of the site this filter is associated with.
+   *
+   * @return the id of the site associated with this filter
+   */
+  String getSiteId();
+
+  /**
+   * Gets the query text of this filter.
+   *
+   * @return the query text of this filter
+   */
+  String getFilter();
+
+  /**
+   * Gets the name of this filter.
+   *
+   * @return the name of this filter
+   */
+  String getName();
+
+  /**
+   * Gets the description of this filter. Can be null.
+   *
+   * @return the description of this filter or empty if no description was set
+   */
+  Optional<String> getDescription();
+
+  /**
+   * Gets the suspended status of this filter.
+   *
+   * @return true if replications using this filter should be suspended, otherwise false
+   */
+  boolean isSuspended();
+
+  /**
+   * Gets the priority level of this filter, represented as a number between 1 and 10.
+   *
+   * @return the priority level of this filter
+   */
+  byte getPriority();
+}

--- a/replication-api/src/main/java/com/connexta/replication/api/persistence/FilterManager.java
+++ b/replication-api/src/main/java/com/connexta/replication/api/persistence/FilterManager.java
@@ -11,32 +11,21 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package com.connexta.replication.queue;
+package com.connexta.replication.api.persistence;
 
-/** Defines the various priority levels supported for queued tasks. */
-public enum PriorityLevel {
-  HIGH((byte) 9),
-  MEDIUM((byte) 5),
-  LOW((byte) 0),
+import com.connexta.ion.replication.api.ReplicationPersistenceException;
+import com.connexta.replication.api.data.Filter;
+import java.util.stream.Stream;
 
-  /**
-   * The unknown value is used for forward compatibility where a worker might not be able to
-   * understand this new priority and would mapped it automatically to priority level 1.
-   */
-  UNKNOWN((byte) 1);
-
-  private final byte level;
-
-  private PriorityLevel(byte level) {
-    this.level = level;
-  }
+/** Performs CRUD operations for {@link Filter}s. */
+public interface FilterManager extends DataManager<Filter> {
 
   /**
-   * Gets the level for this priority ranging from 9 being the highest level to 0 being the lowest.
+   * Gets all the filters associated with the given site ID.
    *
-   * @return the level for this priority
+   * @param siteId the site ID to retrieve filters by
+   * @return a {@link Stream} containing all of the filters for the site
+   * @throws ReplicationPersistenceException if there is an error fetching the filters
    */
-  public byte getLevel() {
-    return level;
-  }
+  Stream<Filter> filtersForSite(String siteId);
 }

--- a/replication-api/src/main/java/com/connexta/replication/queue/TaskInfo.java
+++ b/replication-api/src/main/java/com/connexta/replication/queue/TaskInfo.java
@@ -20,11 +20,11 @@ import java.util.stream.Stream;
 /** Represents a task that can be queued for later processing by a worker. */
 public interface TaskInfo {
   /**
-   * Gets the priority for this task.
+   * Gets the priority for this task, represented as a number between 1 and 10.
    *
    * @return the priority for the task
    */
-  public PriorityLevel getPriority();
+  public byte getPriority();
 
   /**
    * Gets the identifier of the intel document this task is for.

--- a/solr-schema/src/main/resources/solr/conf/replication-solr-managed-schema.xml
+++ b/solr-schema/src/main/resources/solr/conf/replication-solr-managed-schema.xml
@@ -165,16 +165,17 @@
            multiValued="false" />
 
     <!-- replication_config fields -->
-    <field name="name" type="string" indexed="true" stored="true" required="false"
-           multiValued="false" />
     <field name="bidirectional" type="boolean" indexed="true" stored="true" required="false"
-           multiValued="false" />
-    <field name="filter" type="string" indexed="true" stored="true" required="false"
-           multiValued="false" />
-    <field name="suspended" type="boolean" indexed="true" stored="true" required="false"
            multiValued="false" />
     <field name="last_metadata_modified" type="pdate" indexed="true" stored="false" required="false"
            multiValued="false" />
+
+    <!-- replication_filter fields -->
+    <field name="name" type="string" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="site_id" type="string" indexed="true" stored="true" required="false" multiValued="false" />
+    <field name="filter" type="string" indexed="false" stored="true" required="false" multiValued="false" />
+    <field name="suspended" type="boolean" indexed="false" stored="true" required="false" multiValued="false" />
+    <field name="priority" type="pint" indexed="false" stored="true" required="false" multiValued="false" />
 
     <!-- This can be enabled, in case the client does not know what fields may be searched. It isn't enabled by default
          because it's very expensive to index everything twice. -->


### PR DESCRIPTION
#### What does this PR do?
Adds a filter config object to replication along with the persistence manager and tests to go with it.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @clockard @paouelle 

#### How should this be tested? (List steps with links to updated documentation)
CI Build 

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #207 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [x] Update / Add Integration Tests
