### PR TITLE
Add update resource method to WebHDFS adapter

### DIFF
--- a/adapters/webhdfs-adapter/pom.xml
+++ b/adapters/webhdfs-adapter/pom.xml
@@ -106,7 +106,6 @@
             <groupId>replication</groupId>
             <artifactId>replication-api-impl</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>replication-adapters</groupId>

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -322,8 +322,13 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
 
   @Override
   public boolean updateResource(UpdateStorageRequest updateStorageRequest) {
-    CreateStorageRequest createStorageRequest = convertToCreateStorageRequest(updateStorageRequest);
-    return createResource(createStorageRequest);
+    try {
+      CreateStorageRequest createStorageRequest = convertToCreateStorageRequest(updateStorageRequest);
+      return createResource(createStorageRequest);
+    } catch (ReplicationException e) {
+      LOGGER.error("Unable to update resource.", e);
+    }
+    return false;
   }
 
   @Override

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -326,7 +326,8 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
   @Override
   public boolean updateResource(UpdateStorageRequest updateStorageRequest) {
     try {
-      CreateStorageRequest createStorageRequest = convertToCreateStorageRequest(updateStorageRequest);
+      CreateStorageRequest createStorageRequest =
+          convertToCreateStorageRequest(updateStorageRequest);
       return createResource(createStorageRequest);
     } catch (ReplicationException e) {
       LOGGER.error("Unable to update resource.", e);

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -268,7 +268,8 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
       locationUri = uriBuilder.build().toString();
       LOGGER.debug("The location being written to is: {}", locationUri);
     } catch (URISyntaxException e) {
-      throw new ReplicationException("The location URI has syntax errors. {}", e);
+      throw new ReplicationException(
+          "Failed to write file. The location URI has syntax errors. {}", e);
     }
 
     HttpPut httpPut = new HttpPut(locationUri);
@@ -312,7 +313,8 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
       UpdateStorageRequest updateStorageRequest) {
     if (updateStorageRequest.getResources().isEmpty()
         || updateStorageRequest.getResources().get(0) == null) {
-      throw new ReplicationException("No compatible Resource was found.");
+      throw new ReplicationException(
+          "Unable to convert storage request. No compatible Resource was found.");
     }
 
     return new CreateStorageRequestImpl(updateStorageRequest.getResources());

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -46,6 +46,7 @@ import org.codice.ditto.replication.api.data.ResourceRequest;
 import org.codice.ditto.replication.api.data.ResourceResponse;
 import org.codice.ditto.replication.api.data.UpdateRequest;
 import org.codice.ditto.replication.api.data.UpdateStorageRequest;
+import org.codice.ditto.replication.api.impl.data.CreateStorageRequestImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +63,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
   private static final String HTTP_FILE_SYSTEM_ACTION_ALL = "rwx";
 
   private static final String HTTP_NO_REDIRECT_KEY = "noredirect";
+  private static final String HTTP_CREATE_OVERWRITE_KEY = "overwrite";
 
   private final URL webHdfsUrl;
 
@@ -259,8 +261,17 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
       throw new ReplicationException("No compatible Resource was found.");
     }
 
-    LOGGER.debug("The location being written to is: {}", location);
-    HttpPut httpPut = new HttpPut(location);
+    String locationUri;
+    try {
+      URIBuilder uriBuilder = new URIBuilder(location);
+      uriBuilder.setParameter(HTTP_CREATE_OVERWRITE_KEY, "false");
+      locationUri = uriBuilder.build().toString();
+      LOGGER.debug("The location being written to is: {}", locationUri);
+    } catch (URISyntaxException e) {
+      throw new ReplicationException("The location URI has syntax errors. {}", e);
+    }
+
+    HttpPut httpPut = new HttpPut(locationUri);
 
     // only a single resource is supported at this time and is the reason for always retrieving from
     // index zero
@@ -290,9 +301,27 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
     return sendHttpRequest(httpPut, responseHandler);
   }
 
+  /**
+   * Converts an {@link UpdateStorageRequest} to a {@link CreateStorageRequest} by simply extracting
+   * the contained list of {@link Resource} and creating a new object from it.
+   *
+   * @param updateStorageRequest - the {@link UpdateStorageRequest} to convert
+   * @return The new {@link CreateStorageRequest} with the same {@link Resource}s
+   */
+  private CreateStorageRequest convertToCreateStorageRequest(
+      UpdateStorageRequest updateStorageRequest) {
+    if (updateStorageRequest.getResources().isEmpty()
+        || updateStorageRequest.getResources().get(0) == null) {
+      throw new ReplicationException("No compatible Resource was found.");
+    }
+
+    return new CreateStorageRequestImpl(updateStorageRequest.getResources());
+  }
+
   @Override
   public boolean updateResource(UpdateStorageRequest updateStorageRequest) {
-    return false;
+    CreateStorageRequest createStorageRequest = convertToCreateStorageRequest(updateStorageRequest);
+    return createResource(createStorageRequest);
   }
 
   @Override

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -128,16 +128,19 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
 
   @Override
   public boolean createRequest(CreateRequest createRequest) {
+    LOGGER.debug("The WebHDFS adapter doesn't support metadata only creation at this time.");
     return false;
   }
 
   @Override
   public boolean updateRequest(UpdateRequest updateRequest) {
+    LOGGER.debug("The WebHDFS adapter doesn't support metadata only updates at this time.");
     return false;
   }
 
   @Override
   public boolean deleteRequest(DeleteRequest deleteRequest) {
+    LOGGER.debug("The WebHDFS adapter doesn't support metadata only deletion at this time.");
     return false;
   }
 

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -512,10 +512,7 @@ public class WebHdfsNodeAdapterTest {
     List<Resource> resources = Collections.emptyList();
     when(updateStorageRequest.getResources()).thenReturn(resources);
 
-    thrown.expect(ReplicationException.class);
-    thrown.expectMessage("Unable to convert storage request. No compatible Resource was found.");
-
-    webHdfsNodeAdapter.updateResource(updateStorageRequest);
+    assertThat(webHdfsNodeAdapter.updateResource(updateStorageRequest), is(false));
   }
 
   @Test
@@ -524,9 +521,6 @@ public class WebHdfsNodeAdapterTest {
     List<Resource> resources = Collections.singletonList(null);
     when(updateStorageRequest.getResources()).thenReturn(resources);
 
-    thrown.expect(ReplicationException.class);
-    thrown.expectMessage("Unable to convert storage request. No compatible Resource was found.");
-
-    webHdfsNodeAdapter.updateResource(updateStorageRequest);
+    assertThat(webHdfsNodeAdapter.updateResource(updateStorageRequest), is(false));
   }
 }

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -38,6 +38,7 @@ import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.data.CreateStorageRequest;
 import org.codice.ditto.replication.api.data.Metadata;
 import org.codice.ditto.replication.api.data.Resource;
+import org.codice.ditto.replication.api.data.UpdateStorageRequest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -437,5 +438,95 @@ public class WebHdfsNodeAdapterTest {
         webHdfsNodeAdapter.writeFileToLocation(
             createStorageRequest, "http://host:314/some/path/to/file123.json"),
         is(false));
+  }
+
+  @Test
+  public void testWriteFileLocationBadUri() {
+    CreateStorageRequest createStorageRequest = mock(CreateStorageRequest.class);
+    Resource resource = mock(Resource.class);
+    List<Resource> resources = Collections.singletonList(resource);
+    String badUri = "^^^^";
+
+    when(createStorageRequest.getResources()).thenReturn(resources);
+
+    thrown.expect(ReplicationException.class);
+    thrown.expectMessage("Failed to write file. The location URI has syntax errors.");
+
+    webHdfsNodeAdapter.writeFileToLocation(createStorageRequest, badUri);
+  }
+
+  @Test
+  public void testUpdateResource() throws IOException {
+    UpdateStorageRequest updateStorageRequest = mock(UpdateStorageRequest.class);
+    Resource resource = mock(Resource.class);
+    List<Resource> resources = Collections.singletonList(resource);
+
+    Metadata metadata = mock(Metadata.class);
+    Date date = new Date();
+
+    String resourceName = "updateTestFile.txt";
+    HttpResponse httpResponse = mock(HttpResponse.class);
+    StatusLine statusLine = mock(StatusLine.class);
+    HttpEntity httpEntity = mock(HttpEntity.class);
+    String testJson =
+        String.format("{\"Location\":\"http://host2:5678/some/other/path/%s\"}", resourceName);
+    InputStream content = new ByteArrayInputStream(testJson.getBytes());
+    InputStream resourceContent = mock(InputStream.class);
+
+    when(updateStorageRequest.getResources()).thenReturn(resources);
+    when(resource.getMetadata()).thenReturn(metadata);
+    when(resource.getMimeType()).thenReturn("text/plain");
+    when(resource.getInputStream()).thenReturn(resourceContent);
+    when(resource.getName()).thenReturn(resourceName);
+
+    when(metadata.getId()).thenReturn("123456789");
+    when(metadata.getResourceModified()).thenReturn(date);
+
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200).thenReturn(201);
+
+    when(httpResponse.getEntity()).thenReturn(httpEntity);
+    when(httpEntity.getContent()).thenReturn(content);
+
+    doAnswer(
+            invocationOnMock -> {
+              ResponseHandler<String> responseHandler =
+                  (ResponseHandler<String>) invocationOnMock.getArguments()[1];
+              return responseHandler.handleResponse(httpResponse);
+            })
+        .doAnswer(
+            invocationOnMock -> {
+              ResponseHandler<String> responseHandler =
+                  (ResponseHandler<String>) invocationOnMock.getArguments()[1];
+              return responseHandler.handleResponse(httpResponse);
+            })
+        .when(client)
+        .execute(any(HttpRequestBase.class), any(ResponseHandler.class));
+
+    assertThat(webHdfsNodeAdapter.updateResource(updateStorageRequest), is(true));
+  }
+
+  @Test
+  public void testUpdateResourceNoResource() {
+    UpdateStorageRequest updateStorageRequest = mock(UpdateStorageRequest.class);
+    List<Resource> resources = Collections.emptyList();
+    when(updateStorageRequest.getResources()).thenReturn(resources);
+
+    thrown.expect(ReplicationException.class);
+    thrown.expectMessage("Unable to convert storage request. No compatible Resource was found.");
+
+    webHdfsNodeAdapter.updateResource(updateStorageRequest);
+  }
+
+  @Test
+  public void testUpdateResourceNullResource() {
+    UpdateStorageRequest updateStorageRequest = mock(UpdateStorageRequest.class);
+    List<Resource> resources = Collections.singletonList(null);
+    when(updateStorageRequest.getResources()).thenReturn(resources);
+
+    thrown.expect(ReplicationException.class);
+    thrown.expectMessage("Unable to convert storage request. No compatible Resource was found.");
+
+    webHdfsNodeAdapter.updateResource(updateStorageRequest);
   }
 }


### PR DESCRIPTION
#### What does this PR do?

Implements the update resource method for the WebHDFS adapter. It takes an update request and updates the resource in the HDFS. The approach was to utilize the create resource method to write a new file with the updated timestamp.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@cjlange 
@aaronilovici 
@josephthweatt

#### How should this be tested? (List steps with links to updated documentation)

Verify that all unit tests pass.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #316 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
