### PR TITLE
REF-322 Replicated files contain HTTP headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ bin/
 atlassian-ide-plugin.xml
 *.sonar-ide.properties
 
+# Generated file ignores
+adapters/webhdfs-adapter/embedded_hdfs/
+
 # Node/Yarn ignores
 yarn-error.log*
 npm-debug.log*

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
@@ -334,8 +334,8 @@ public class WebHdfsClientTest {
   }
 
   /**
-   * Utilizes the "Open and Read a File" WebHDFS operation to verify that the content within
-   * the given <code>filename</code> is what is expected.
+   * Utilizes the "Open and Read a File" WebHDFS operation to verify that the content within the
+   * given <code>filename</code> is what is expected.
    *
    * @param filename - the name of the file to verify
    * @param expected - the {@link String} value of a file's content

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
@@ -68,6 +68,8 @@ public class WebHdfsClientTest {
   private static HdfsLocalCluster hdfsLocalCluster;
   private WebHdfsNodeAdapter adapter;
 
+  private static final String RESOURCE_CONTENT = "my-data";
+
   @BeforeClass
   public static void setUpClass() {
     hdfsLocalCluster =
@@ -272,7 +274,7 @@ public class WebHdfsClientTest {
 
     adapter.createResource(createStorageRequest);
 
-    verifyFileContents(originalFilename, "my-data");
+    verifyFileContents(originalFilename, RESOURCE_CONTENT);
   }
 
   @Test
@@ -326,7 +328,7 @@ public class WebHdfsClientTest {
     }
 
     assertThat(hdfsLocalCluster.getHdfsFormat(), is(true));
-    assertThat(uri.toString(), is(String.format("%s%s?op=GETFILESTATUS", BASE_URL, filename)));
+    assertThat(uri.toString(), is(url));
     assertThat(fileStatus, notNullValue());
     assertThat(fileStatus.get("type"), is("FILE"));
   }
@@ -348,7 +350,7 @@ public class WebHdfsClientTest {
     String responseContent = sendGetRequestToString(getRequest);
 
     assertThat(hdfsLocalCluster.getHdfsFormat(), is(true));
-    assertThat(uri.toString(), is(String.format("%s/%s?op=OPEN", BASE_URL, filename)));
+    assertThat(url, is(url));
     assertThat(responseContent, is(expected));
   }
 
@@ -515,7 +517,7 @@ public class WebHdfsClientTest {
         name,
         URI.create("my:uri"),
         null,
-        new ByteArrayInputStream("my-data".getBytes()),
+        new ByteArrayInputStream(RESOURCE_CONTENT.getBytes()),
         MediaType.TEXT_PLAIN,
         10,
         getMetadata(id, metadataModified, resourceModified));

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
@@ -334,7 +334,7 @@ public class WebHdfsClientTest {
   }
 
   /**
-   * Utilizes the "Status of a File/Directory" WebHDFS operation to verify that the content within
+   * Utilizes the "Open and Read a File" WebHDFS operation to verify that the content within
    * the given <code>filename</code> is what is expected.
    *
    * @param filename - the name of the file to verify

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
@@ -326,11 +326,7 @@ public class WebHdfsClientTest {
     }
 
     assertThat(hdfsLocalCluster.getHdfsFormat(), is(true));
-    assertThat(
-        uri.toString(),
-        is(
-            String.format(
-                "http://localhost:%s/webhdfs/v1/%s?op=GETFILESTATUS", HDFS_PORT, filename)));
+    assertThat(uri.toString(), is(String.format("%s%s?op=GETFILESTATUS", BASE_URL, filename)));
     assertThat(fileStatus, notNullValue());
     assertThat(fileStatus.get("type"), is("FILE"));
   }
@@ -344,8 +340,7 @@ public class WebHdfsClientTest {
    * @throws URISyntaxException If the URL string does not have valid syntax
    */
   private void verifyFileContents(String filename, String expected) throws URISyntaxException {
-    String filePath = "webhdfs/v1/" + filename;
-    String url = String.format("%s/%s", BASE_URL, filePath);
+    String url = String.format("%s/%s", BASE_URL, filename);
     URIBuilder builder = new URIBuilder(url);
     builder.addParameter("op", "OPEN");
     URI uri = builder.build();
@@ -353,9 +348,7 @@ public class WebHdfsClientTest {
     String responseContent = sendGetRequestToString(getRequest);
 
     assertThat(hdfsLocalCluster.getHdfsFormat(), is(true));
-    assertThat(
-        uri.toString(),
-        is(String.format("http://localhost:%s/webhdfs/v1/%s?op=OPEN", HDFS_PORT, filename)));
+    assertThat(uri.toString(), is(String.format("%s/%s?op=OPEN", BASE_URL, filename)));
     assertThat(responseContent, is(expected));
   }
 

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -217,7 +217,7 @@ public class WebHdfsNodeAdapterTest {
   }
 
   @Test
-  public void testWriteFileToLocationNoResource() {
+  public void testWriteFileToLocationNoResource() throws IOException {
     CreateStorageRequest createStorageRequest = mock(CreateStorageRequest.class);
     List<Resource> resources = Collections.emptyList();
     when(createStorageRequest.getResources()).thenReturn(resources);
@@ -229,7 +229,7 @@ public class WebHdfsNodeAdapterTest {
   }
 
   @Test
-  public void testWriteFileToLocationNullResource() {
+  public void testWriteFileToLocationNullResource() throws IOException {
     CreateStorageRequest createStorageRequest = mock(CreateStorageRequest.class);
     List<Resource> resources = Collections.singletonList(null);
     when(createStorageRequest.getResources()).thenReturn(resources);
@@ -441,7 +441,7 @@ public class WebHdfsNodeAdapterTest {
   }
 
   @Test
-  public void testWriteFileLocationBadUri() {
+  public void testWriteFileLocationBadUri() throws IOException {
     CreateStorageRequest createStorageRequest = mock(CreateStorageRequest.class);
     Resource resource = mock(Resource.class);
     List<Resource> resources = Collections.singletonList(resource);

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -13,9 +13,14 @@
  */
 package com.connexta.replication.adapters.webhdfs;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -26,6 +31,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -117,12 +123,11 @@ public class WebHdfsNodeAdapterTest {
     HttpEntity httpEntity = mock(HttpEntity.class);
     String testJson = "{\"Location\":\"http://host2:5678/some/other/path/file123.json\"}";
     InputStream content = new ByteArrayInputStream(testJson.getBytes());
-    InputStream resourceContent = mock(InputStream.class);
 
     when(createStorageRequest.getResources()).thenReturn(resources);
     when(resource.getMetadata()).thenReturn(metadata);
     when(resource.getMimeType()).thenReturn("application/json");
-    when(resource.getInputStream()).thenReturn(resourceContent);
+    when(resource.getInputStream()).thenReturn(IOUtils.toInputStream("my-data", UTF_8));
     when(resource.getName()).thenReturn("file123.json");
 
     when(metadata.getId()).thenReturn("112358");
@@ -373,8 +378,7 @@ public class WebHdfsNodeAdapterTest {
     when(metadata.getId()).thenReturn("1234");
     when(metadata.getResourceModified()).thenReturn(date);
 
-    InputStream inputStream = mock(InputStream.class);
-    when(resource.getInputStream()).thenReturn(inputStream);
+    when(resource.getInputStream()).thenReturn(IOUtils.toInputStream("my-data", UTF_8));
     when(resource.getMimeType()).thenReturn("application/json");
     when(resource.getName()).thenReturn("file123.json");
 
@@ -412,8 +416,7 @@ public class WebHdfsNodeAdapterTest {
     when(metadata.getId()).thenReturn("1234");
     when(metadata.getResourceModified()).thenReturn(date);
 
-    InputStream inputStream = mock(InputStream.class);
-    when(resource.getInputStream()).thenReturn(inputStream);
+    when(resource.getInputStream()).thenReturn(IOUtils.toInputStream("my-data", UTF_8));
     when(resource.getMimeType()).thenReturn("application/json");
     when(resource.getName()).thenReturn("file123.json");
 
@@ -471,12 +474,11 @@ public class WebHdfsNodeAdapterTest {
     String testJson =
         String.format("{\"Location\":\"http://host2:5678/some/other/path/%s\"}", resourceName);
     InputStream content = new ByteArrayInputStream(testJson.getBytes());
-    InputStream resourceContent = mock(InputStream.class);
 
     when(updateStorageRequest.getResources()).thenReturn(resources);
     when(resource.getMetadata()).thenReturn(metadata);
     when(resource.getMimeType()).thenReturn("text/plain");
-    when(resource.getInputStream()).thenReturn(resourceContent);
+    when(resource.getInputStream()).thenReturn(IOUtils.toInputStream("my-data", UTF_8));
     when(resource.getName()).thenReturn(resourceName);
 
     when(metadata.getId()).thenReturn("123456789");


### PR DESCRIPTION
#### What does this PR do?
Removes headers in files uploaded to HDFS. 

#### Who is reviewing it 
@mdang8 
@cjlange 

#### How should this be tested? (List steps with links to updated documentation)
1. Build branch and add to a running DDF instance. Follow normal instructions to set up Replication between DDF and a local Hdfs node.
2. Ingest a file to DDF. Once replication has uploaded the file to hdfs, go onto hdfs' webpage and view the file. 
3. Download or select "tail from head" to view the content. Verify there are no headers before or after the original file content.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #322 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
