### PR TITLE
Add read resource method to WebHDFS adapter

### DIFF
--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterFactory.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterFactory.java
@@ -15,7 +15,7 @@ package com.connexta.replication.adapters.webhdfs;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.codice.ditto.replication.api.AdapterException;
 import org.codice.ditto.replication.api.NodeAdapter;
 import org.codice.ditto.replication.api.NodeAdapterFactory;
@@ -46,7 +46,8 @@ public class WebHdfsNodeAdapterFactory implements NodeAdapterFactory {
     }
 
     try {
-      return new WebHdfsNodeAdapter(new URL(baseUrl), HttpClients.createDefault());
+      return new WebHdfsNodeAdapter(
+          new URL(baseUrl), HttpClientBuilder.create().disableRedirectHandling().build());
     } catch (MalformedURLException e) {
       throw new AdapterException("Failed to create adapter", e);
     }

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
@@ -67,6 +67,8 @@ public class WebHdfsClientTest {
   private static final String HDFS_PATH = "/webhdfs/v1";
   private static final String HDFS_PORT = "12341";
   private static final String BASE_URL = "http://localhost:" + HDFS_PORT + HDFS_PATH;
+  private static final String TEST_DATA_STRING =
+      "Grumpy wizards make toxic brew for the evil queen and jack.";
   private static final Logger LOGGER = LoggerFactory.getLogger(WebHdfsClientTest.class);
   private static final WebHdfsNodeAdapterFactory adapterFactory = new WebHdfsNodeAdapterFactory();
   private static HdfsLocalCluster hdfsLocalCluster;
@@ -136,7 +138,7 @@ public class WebHdfsClientTest {
 
     assertThat(readResource.getId(), is(testId));
     assertThat(readResource.getName(), is(String.format("%s_%s", testId, testDate.getTime())));
-//    assertThat(readInputStreamToString(readResource.getInputStream()), is("my-data"));
+    assertThat(readInputStreamToString(readResource.getInputStream()), is(TEST_DATA_STRING));
   }
 
   @Test
@@ -577,7 +579,7 @@ public class WebHdfsClientTest {
         name,
         resourceUri,
         null,
-        new ByteArrayInputStream("my-data".getBytes()),
+        new ByteArrayInputStream(TEST_DATA_STRING.getBytes()),
         MediaType.TEXT_PLAIN,
         10,
         getMetadata(id, metadataModified, resourceModified, resourceUri));

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -22,16 +22,21 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.connexta.replication.data.ResourceImpl;
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
+import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -44,6 +49,8 @@ import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.data.CreateStorageRequest;
 import org.codice.ditto.replication.api.data.Metadata;
 import org.codice.ditto.replication.api.data.Resource;
+import org.codice.ditto.replication.api.data.ResourceRequest;
+import org.codice.ditto.replication.api.data.ResourceResponse;
 import org.codice.ditto.replication.api.data.UpdateStorageRequest;
 import org.junit.Before;
 import org.junit.Rule;
@@ -107,6 +114,166 @@ public class WebHdfsNodeAdapterTest {
         .execute(any(HttpRequestBase.class), any(ResponseHandler.class));
 
     assertThat(webHdfsNodeAdapter.isAvailable(), is(false));
+  }
+
+  @SuppressWarnings({"Duplicates", "unchecked"})
+  @Test
+  public void testReadResource() throws URISyntaxException, IOException {
+    String testResourceId = "123456789";
+    Date testDate = new Date();
+    String testResourceName = String.format("%s_%s", testResourceId, testDate.getTime());
+    Long testResourceSize = 256L;
+    URI testResourceUri =
+        new URI(String.format("http://host1:8000/test/resource/%s.txt", testResourceName));
+    String testFileLocation = String.format("{\"Location\":\"%s\"}", testResourceUri.toString());
+
+    ResourceRequest mockResourceRequest = mock(ResourceRequest.class);
+    Metadata mockMetadata = mock(Metadata.class);
+
+    when(mockResourceRequest.getMetadata()).thenReturn(mockMetadata);
+    when(mockMetadata.getId()).thenReturn(testResourceId);
+    when(mockMetadata.getResourceUri()).thenReturn(testResourceUri);
+    when(mockMetadata.getResourceModified()).thenReturn(testDate);
+
+    /* Location response mocks */
+    HttpResponse mockLocationHttpResponse = mock(HttpResponse.class);
+    StatusLine mockLocationStatusLine = mock(StatusLine.class);
+    HttpEntity mockLocationHttpEntity = mock(HttpEntity.class);
+    Header mockLocationHeader = mock(Header.class);
+    InputStream locationContent = new ByteArrayInputStream(testFileLocation.getBytes());
+
+    when(mockLocationHttpResponse.getStatusLine()).thenReturn(mockLocationStatusLine);
+    when(mockLocationHttpResponse.getEntity()).thenReturn(mockLocationHttpEntity);
+    when(mockLocationStatusLine.getStatusCode()).thenReturn(200);
+    when(mockLocationHttpEntity.getContent()).thenReturn(locationContent);
+    when(mockLocationHttpEntity.getContentType()).thenReturn(mockLocationHeader);
+    when(mockLocationHeader.getValue()).thenReturn("application/json");
+    /* End */
+
+    /* Resource content mocks */
+    HttpResponse mockResourceHttpResponse = mock(HttpResponse.class);
+    StatusLine mockResourceStatusLine = mock(StatusLine.class);
+    HttpEntity mockResourceHttpEntity = mock(HttpEntity.class);
+    Header mockResourceHeader = mock(Header.class);
+    InputStream resourceContent = new ByteArrayInputStream("my-data".getBytes());
+
+    when(mockResourceHttpResponse.getStatusLine()).thenReturn(mockResourceStatusLine);
+    when(mockResourceHttpResponse.getEntity()).thenReturn(mockResourceHttpEntity);
+    when(mockResourceStatusLine.getStatusCode()).thenReturn(200);
+    when(mockResourceHttpEntity.getContent()).thenReturn(resourceContent);
+    when(mockResourceHttpEntity.getContentLength()).thenReturn(testResourceSize);
+    when(mockResourceHttpEntity.getContentType()).thenReturn(mockResourceHeader);
+    when(mockResourceHeader.getValue()).thenReturn("text/plain");
+    /* End */
+
+    doAnswer(
+            invocationOnMock -> {
+              ResponseHandler<String> responseHandler =
+                  (ResponseHandler<String>) invocationOnMock.getArguments()[1];
+              return responseHandler.handleResponse(mockLocationHttpResponse);
+            })
+        .doAnswer(
+            invocationOnMock -> {
+              ResponseHandler<String> responseHandler =
+                  (ResponseHandler<String>) invocationOnMock.getArguments()[1];
+              return responseHandler.handleResponse(mockResourceHttpResponse);
+            })
+        .when(client)
+        .execute(any(HttpRequestBase.class), any(ResponseHandler.class));
+
+    Resource expectedResource =
+        new ResourceImpl(
+            testResourceId,
+            testResourceName,
+            testResourceUri,
+            null,
+            new ByteArrayInputStream("my-data".getBytes()),
+            "text/plain",
+            testResourceSize,
+            mockMetadata);
+    ResourceResponse actualResponse = webHdfsNodeAdapter.readResource(mockResourceRequest);
+    Resource actualResource = actualResponse.getResource();
+
+    assertThat(actualResource.getId(), is(expectedResource.getId()));
+    assertThat(actualResource.getName(), is(expectedResource.getName()));
+    assertThat(
+        actualResource.getMetadata().getResourceUri(), is(expectedResource.getResourceUri()));
+    assertThat(
+        readInputStreamToString(actualResource.getInputStream()),
+        is(readInputStreamToString(expectedResource.getInputStream())));
+  }
+
+  @SuppressWarnings({"Duplicates", "unchecked"})
+  @Test
+  public void testGetLocationReadSuccess() throws URISyntaxException, IOException {
+    URI testResourceUri = new URI("http://host1:8000/test/resource/file.txt");
+    String testFileLocation = String.format("{\"Location\":\"%s\"}", testResourceUri.toString());
+    ResourceRequest mockResourceRequest = mock(ResourceRequest.class);
+    Metadata mockMetadata = mock(Metadata.class);
+
+    HttpResponse mockHttpResponse = mock(HttpResponse.class);
+    StatusLine mockStatusLine = mock(StatusLine.class);
+    HttpEntity mockHttpEntity = mock(HttpEntity.class);
+    InputStream content = new ByteArrayInputStream(testFileLocation.getBytes());
+
+    when(mockResourceRequest.getMetadata()).thenReturn(mockMetadata);
+    when(mockMetadata.getId()).thenReturn("123456789");
+    when(mockMetadata.getResourceUri()).thenReturn(testResourceUri);
+
+    when(mockHttpResponse.getStatusLine()).thenReturn(mockStatusLine);
+    when(mockStatusLine.getStatusCode()).thenReturn(200).thenReturn(201);
+    when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+    when(mockHttpEntity.getContent()).thenReturn(content);
+
+    doAnswer(
+            invocationOnMock -> {
+              ResponseHandler<String> responseHandler =
+                  (ResponseHandler<String>) invocationOnMock.getArguments()[1];
+              return responseHandler.handleResponse(mockHttpResponse);
+            })
+        .when(client)
+        .execute(any(HttpRequestBase.class), any(ResponseHandler.class));
+
+    assertThat(webHdfsNodeAdapter.getLocation(mockResourceRequest), is(testResourceUri.toString()));
+  }
+
+  @Test
+  public void testGetLocationNullMetadata() throws URISyntaxException {
+    ResourceRequest mockResourceRequest = mock(ResourceRequest.class);
+    when(mockResourceRequest.getMetadata()).thenReturn(null);
+
+    thrown.expect(ReplicationException.class);
+    thrown.expectMessage("No accessible metadata was found for the request.");
+
+    webHdfsNodeAdapter.getLocation(mockResourceRequest);
+  }
+
+  @Test
+  public void testReadFileAtLocationBadStatus() throws IOException {
+    ResourceRequest mockResourceRequest = mock(ResourceRequest.class);
+    Metadata mockMetadata = mock(Metadata.class);
+
+    when(mockMetadata.getId()).thenReturn("404");
+    when(mockResourceRequest.getMetadata()).thenReturn(mockMetadata);
+
+    HttpResponse httpResponse = mock(HttpResponse.class);
+    StatusLine statusLine = mock(StatusLine.class);
+    when(httpResponse.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_BAD_REQUEST);
+
+    doAnswer(
+            invocationOnMock -> {
+              ResponseHandler<String> responseHandler =
+                  (ResponseHandler<String>) invocationOnMock.getArguments()[1];
+              return responseHandler.handleResponse(httpResponse);
+            })
+        .when(client)
+        .execute(any(HttpRequestBase.class), any(ResponseHandler.class));
+
+    thrown.expect(ReplicationException.class);
+    thrown.expectMessage("Request failed with status code: 400");
+
+    webHdfsNodeAdapter.readFileAtLocation(mockResourceRequest, "");
   }
 
   @Test
@@ -524,5 +691,14 @@ public class WebHdfsNodeAdapterTest {
     when(updateStorageRequest.getResources()).thenReturn(resources);
 
     assertThat(webHdfsNodeAdapter.updateResource(updateStorageRequest), is(false));
+  }
+
+  private String readInputStreamToString(InputStream contentStream) throws IOException {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(contentStream));
+    try {
+      return reader.lines().collect(Collectors.joining("\n"));
+    } finally {
+      reader.close();
+    }
   }
 }

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -23,11 +23,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.connexta.replication.data.ResourceImpl;
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
-import java.util.stream.Collectors;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -693,12 +692,17 @@ public class WebHdfsNodeAdapterTest {
     assertThat(webHdfsNodeAdapter.updateResource(updateStorageRequest), is(false));
   }
 
-  private String readInputStreamToString(InputStream contentStream) throws IOException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(contentStream));
-    try {
-      return reader.lines().collect(Collectors.joining("\n"));
-    } finally {
-      reader.close();
+  /**
+   * Reads an {@link InputStream} into a readable {@link String}.
+   *
+   * @param contentStream - the {@link InputStream} to read
+   * @return The resulting {@link String} read
+   */
+  private String readInputStreamToString(InputStream contentStream) {
+    try (final Reader reader = new InputStreamReader(contentStream)) {
+      return IOUtils.toString(reader);
+    } catch (IOException e) {
+      throw new ReplicationException("Failed to read the input stream.", e);
     }
   }
 }


### PR DESCRIPTION
#### What does this PR do?

Implements the read resource method for the WebHDFS adapter. It takes a request with a metadata object and returns the resource based on that. The metadata should have a resource URI that points the adapter to the correct WebHDFS endpoint for retrieving it. The adapter then builds a resource object with the data response.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@cjlange 
@aaronilovici 
@josephthweatt

#### How should this be tested? (List steps with links to updated documentation)

Verify that all unit and integration tests pass.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #324 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
