### PR TITLE
Updating feature and policy to work with DDF distributions

### DIFF
--- a/adapters/ddf-adapter/pom.xml
+++ b/adapters/ddf-adapter/pom.xml
@@ -160,8 +160,8 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Import-Package>
+              !com.google.common.cache,
               !org.jvnet.staxex,
-              ddf.security.permission,
               ddf.security.encryption;version="[1.0.0, 3.0.0]",
               *
             </Import-Package>
@@ -169,6 +169,7 @@
               commons-collections4,
               ogc-tools-gml-jts,
               ddf-security-common,
+              ddf.security.permission,
               platform-util,
               jaxb-core,
               commons-lang3,

--- a/admin/query/pom.xml
+++ b/admin/query/pom.xml
@@ -37,6 +37,11 @@
             <version>${admin-query.version}</version>
         </dependency>
         <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
             <groupId>ddf.admin</groupId>
             <artifactId>admin-configurator-api</artifactId>
             <version>${ddf.version}</version>
@@ -66,6 +71,83 @@
           <artifactId>gt-cql</artifactId>
           <version>${org.geotools.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>stax2-api</artifactId>
+            <version>3.1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.pac4j</groupId>
+            <artifactId>pac4j-oidc</artifactId>
+            <version>3.8.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.pac4j</groupId>
+            <artifactId>pac4j-core</artifactId>
+            <version>3.8.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.crypto.tink</groupId>
+            <artifactId>tink</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.12.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>oauth2-oidc-sdk</artifactId>
+            <version>6.23</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>8.19</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>lang-tag</artifactId>
+            <version>1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+            <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>asm</artifactId>
+            <version>1.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cryptomator</groupId>
+            <artifactId>siv-mode</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180813</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk16</artifactId>
+            <version>1.44</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -76,8 +158,36 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Import-Package>
+                            !junit.*,
+                            *
+                        </Import-Package>
+                        <Export-Package>
+                            org.codice.ddf.admin.configurator.*,
+                            org.codice.ddf.configuration.*,
+                            org.codice.ddf.*,
+                            org.bouncycastle.*,
+                            ddf.catalog.*,
+                            ddf.measure.*,
+                            ddf.security.*,
+                            com.nimbusds.jose.*,
+                        </Export-Package>
                         <Embed-Dependency>
-                            admin-query-common
+                            admin-query-common,
+                            catalog-core-api-impl,
+                            commons-lang3,
+                            stax2-api,
+                            pac4j-oidc,
+                            tink,
+                            protobuf-java,
+                            oauth2-oidc-sdk,
+                            nimbus-jose-jwt,
+                            lang-tag,
+                            jcip-annotations,
+                            json-smart,
+                            asm,
+                            siv-mode,
+                            json,
                         </Embed-Dependency>
                     </instructions>
                 </configuration>

--- a/distributions/osgi/features/replication/src/main/feature/feature.xml
+++ b/distributions/osgi/features/replication/src/main/feature/feature.xml
@@ -32,6 +32,8 @@
         <feature>graphql-transformer-servlet</feature>
         <feature>admin-query-ui</feature>
         <feature>jackson</feature>
+        <bundle>mvn:org.apache.tika/tika-core/${tika.version}</bundle>
+        <bundle>mvn:ddf.mime.tika/mime-tika-resolver/${ddf.version}</bundle>
         <bundle>mvn:replication/replication-api/${project.version}</bundle>
         <bundle>mvn:replication/replication-api-impl/${project.version}</bundle>
         <bundle>mvn:replication/replication-admin-query/${project.version}</bundle>

--- a/distributions/osgi/replication.policy
+++ b/distributions/osgi/replication.policy
@@ -1,5 +1,17 @@
 priority "grant";
 
+grant codeBase "file:/ddf-adapter" {
+    permission java.lang.RuntimePermission "createClassLoader";
+}
+
+grant codeBase "file:/ddf-adapter/replication-api-impl" {
+    permission java.lang.RuntimePermission "createClassLoader";
+}
+
+grant codeBase "file:/org.apache.servicemix.bundles.xstream" {
+    permission java.lang.RuntimePermission "createClassLoader";
+}
+
 grant codeBase "file:/org.apache.felix.fileinstall/admin-core-jolokia/javax.servlet-api/org.eclipse.jetty.servlet/security-filter-api/platform-filter-clientinfo/platform-filter-response/security-filter-authorization/security-filter-login/org.apache.cxf.cxf-rt-transports-http" {
     permission java.io.FilePermission "${ddf.home.perm}etc${/}definitions${/}-", "read,write";
     permission java.io.FilePermission "${ddf.home.perm}etc${/}definitions", "read";

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <directory.maven.plugin.version>0.3.1</directory.maven.plugin.version>
         <project.report.output.directory>project-info</project.report.output.directory>
         <jackson.version>2.10.3</jackson.version>
-
+        <tika.version>1.22</tika.version>
         <!-- documentation replacements -->
         <platform>DDF Base</platform>
         <admin-console>Admin Console</admin-console>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -140,22 +140,30 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Import-Package>
                             !org.jvnet.staxex,
-                            ddf.security.permission,
                             ddf.security.encryption;version="[1.0.0, 3.0.0]",
                             *
                         </Import-Package>
                         <Export-Package>
-                            org.codice.ditto.replication.api.impl.data
+                            org.codice.ditto.replication.api.impl.data,
+                            org.codice.ddf.admin.configurator.*,
+                            com.google.api.client.*,
+                            com.google.common.*,
+                            com.google.errorprone.annotations.*,
+                            com.google.thirdparty.publicsuffix,
                         </Export-Package>
                         <Embed-Dependency>
                             commons-collections4,
                             catalog-core-api-impl,
                             ddf-security-common,
+                            ddf.security.permission,
+                            com.google.common.*,
                             platform-util,
                             platform-util-unavailableurls,
                             commons-lang3,
+                            security-core-api,
                             security-core-impl,
-                            commons
+                            commons,
+                            guava
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>


### PR DESCRIPTION
#### What does this PR do?
- Updates the feature.xml to include the latest Tika bundles in our feature. This is needed because we can’t assume the version of DIB/DDF/Alliance we’re installing on has the right version for our needs, so we need to include it ourselves.
- Updates the replication.policy. THIS IS IMPORTANT. Before starting DDF, this file needs to be copied into the unzipped distributions /security directory to live next to the other policy files. Then, installing starting up DDF, installing and configuring, and drop the kar in the deploy directory as normal.


Here is some proof of the fix from testing on 2.21.1.

Installation works:
```
admin@root()> feature:list | grep replication-0.3.0-SNAPSHOT
jackson                                         │ 0.3.0.SNAPSHOT   │ x        │ Started     │ replication-0.3.0-SNAPSHOT    │
replication                                     │ 0.3.0.SNAPSHOT   │ x        │ Started     │ replication-0.3.0-SNAPSHOT    │ Provides capabilities and console commands for re
```

The sites are mated with their adapters:
```

2020-06-04T16:23:24,903 | INFO  | rocessorThread 0 | ReplicatorImpl                   | lication.api.impl.ReplicatorImpl  314 | 916 - replication-api-impl - 0.3.0.SNAPSHOT | Checking if site ddf.distribution is of type DDF
2020-06-04T16:23:25,029 | WARN  | cxf-StsThread 14 | CryptoBase                       | e.wss4j.common.crypto.CryptoBase  325 | 231 - org.apache.wss4j.wss4j-ws-security-common - 2.2.3 | No Subject DN Certificate Constraints were defined. This could be a security issue
2020-06-04T16:23:25,069 | INFO  | igParserThread 0 | MetadataConfigurationParser      | amlp.MetadataConfigurationParser  221 | 338 - security-core-api - 2.21.1 | entityId = https://localhost:8993/services/saml
2020-06-04T16:23:25,132 | INFO  | rocessorThread 0 | DdfNodeAdapter                   | tion.adapters.ddf.DdfNodeAdapter  108 | 908 - ddf-adapter - 0.3.0.SNAPSHOT | Successfully contacted CSW server version 2.0.2 at https://localhost:8993/services
2020-06-04T16:23:25,132 | INFO  | rocessorThread 0 | ReplicatorImpl                   | lication.api.impl.ReplicatorImpl  317 | 916 - replication-api-impl - 0.3.0.SNAPSHOT | Site ddf.distribution is type DDF


2020-06-04T16:23:25,419 | INFO  | rocessorThread 0 | ReplicatorImpl                   | lication.api.impl.ReplicatorImpl  314 | 916 - replication-api-impl - 0.3.0.SNAPSHOT | Checking if site hdfs.local is of type WEBHDFS
2020-06-04T16:23:25,421 | INFO  | rocessorThread 0 | WebHdfsNodeAdapter               | pters.webhdfs.WebHdfsNodeAdapter   92 | 918 - webhdfs-adapter - 0.3.0.SNAPSHOT | Checking access to: http://localhost:9870/webhdfs/v1/user/aaronilovici/
2020-06-04T16:23:25,424 | INFO  | rocessorThread 0 | ReplicatorImpl                   | lication.api.impl.ReplicatorImpl  317 | 916 - replication-api-impl - 0.3.0.SNAPSHOT | Site hdfs.local is type WEBHDFS
```

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@josephthweatt 
@mdang8
@cjlange 
 
#### How should this be tested? (List steps with links to updated documentation)

#### Any background context you want to provide?

#### What are the relevant tickets?

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
