### PR TITLE
DIB 9599

### DIFF
--- a/adapters/ddf-adapter/pom.xml
+++ b/adapters/ddf-adapter/pom.xml
@@ -171,8 +171,7 @@
               ddf-security-common,
               platform-util,
               jaxb-core,
-              commons-lang3,
-              commons
+              commons-lang3
             </Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
           </instructions>

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/DdfNodeAdapter.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/DdfNodeAdapter.java
@@ -18,6 +18,7 @@ import com.connexta.replication.adapters.ddf.csw.Csw;
 import com.connexta.replication.adapters.ddf.csw.CswRecordCollection;
 import com.connexta.replication.adapters.ddf.rest.DdfRestClient;
 import com.connexta.replication.adapters.ddf.rest.DdfRestClientFactory;
+import com.connexta.replication.data.MetadataAttribute;
 import com.connexta.replication.data.QueryRequestImpl;
 import com.connexta.replication.data.QueryResponseImpl;
 import com.connexta.replication.data.ResourceResponseImpl;
@@ -182,7 +183,7 @@ public class DdfNodeAdapter implements NodeAdapter {
     String systemName;
     if (!results.isEmpty()) {
       systemName =
-          ((MetacardAttribute) ((Map) results.get(0).getRawMetadata()).get("title")).getValue();
+          ((MetadataAttribute) ((Map) results.get(0).getRawMetadata()).get("title")).getValue();
     } else {
       throw new AdapterException(
           String.format(
@@ -279,14 +280,14 @@ public class DdfNodeAdapter implements NodeAdapter {
     Map metadataMap = (Map) metadata.getRawMetadata();
     metadataMap.put(
         Constants.METACARD_TAGS,
-        new MetacardAttribute(
+        new MetadataAttribute(
             Constants.METACARD_TAGS,
             "string",
             new ArrayList(metadata.getTags()),
             Collections.emptyList()));
     metadataMap.put(
         Replication.ORIGINS,
-        new MetacardAttribute(
+        new MetadataAttribute(
             Replication.ORIGINS, "string", metadata.getLineage(), Collections.emptyList()));
   }
 

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/CswRecordConverter.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/CswRecordConverter.java
@@ -25,7 +25,7 @@ import static com.connexta.replication.adapters.ddf.csw.Constants.RESOURCE_URI;
 import static com.connexta.replication.adapters.ddf.csw.Constants.VERSIONED_ON;
 import static com.connexta.replication.adapters.ddf.csw.Constants.VERSION_OF_ID;
 
-import com.connexta.replication.adapters.ddf.MetacardAttribute;
+import com.connexta.replication.data.MetadataAttribute;
 import com.connexta.replication.data.MetadataImpl;
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.Converter;
@@ -170,7 +170,7 @@ public class CswRecordConverter implements Converter {
     }
   }
 
-  public static @Nullable Date convertToDate(@Nullable MetacardAttribute value) {
+  public static @Nullable Date convertToDate(@Nullable MetadataAttribute value) {
     if (value == null) {
       return null;
     }
@@ -201,12 +201,12 @@ public class CswRecordConverter implements Converter {
     StringWriter metadataWriter = new StringWriter();
     HierarchicalStreamReader reader = copyXml(hreader, metadataWriter, namespaceMap);
 
-    Map<String, MetacardAttribute> metadataMap = new HashMap<>();
+    Map<String, MetadataAttribute> metadataMap = new HashMap<>();
     metadataMap.put(
         Constants.RAW_METADATA_KEY,
-        new MetacardAttribute(Constants.RAW_METADATA_KEY, null, metadataWriter.toString()));
+        new MetadataAttribute(Constants.RAW_METADATA_KEY, null, metadataWriter.toString()));
     String id = reader.getAttribute("gml:id");
-    metadataMap.put(METACARD_ID, new MetacardAttribute(METACARD_ID, null, id));
+    metadataMap.put(METACARD_ID, new MetadataAttribute(METACARD_ID, null, id));
     // If we want to grab the type we will have to do so below. As you move through the child nodes
     // check if the node name is type and save the value.
 
@@ -239,11 +239,11 @@ public class CswRecordConverter implements Converter {
     }
 
     metadataMap.get(METACARD_TAGS).getValues().forEach(metadata::addTag);
-    MetacardAttribute origin = metadataMap.get(Replication.ORIGINS);
+    MetadataAttribute origin = metadataMap.get(Replication.ORIGINS);
     if (origin != null) {
       origin.getValues().forEach(metadata::addLineage);
     }
-    MetacardAttribute versionAction = metadataMap.get(ACTION);
+    MetadataAttribute versionAction = metadataMap.get(ACTION);
     if (versionAction != null) {
       metadata.setIsDeleted(versionAction.getValue().startsWith("Deleted"));
     }
@@ -254,7 +254,7 @@ public class CswRecordConverter implements Converter {
   }
 
   private static void parseToMap(
-      HierarchicalStreamReader reader, Map<String, MetacardAttribute> metadataMap) {
+      HierarchicalStreamReader reader, Map<String, MetadataAttribute> metadataMap) {
     while (reader.hasMoreChildren()) {
       reader.moveDown();
 
@@ -268,7 +268,7 @@ public class CswRecordConverter implements Converter {
         }
       }
       if (!reader.hasMoreChildren()) {
-        metadataMap.put(entryType, new MetacardAttribute(entryType, null, reader.getValue()));
+        metadataMap.put(entryType, new MetadataAttribute(entryType, null, reader.getValue()));
         reader.moveUp();
         continue;
       }
@@ -280,7 +280,7 @@ public class CswRecordConverter implements Converter {
         copyXml(reader, xmlWriter, null);
         metadataMap.put(
             attributeName,
-            new MetacardAttribute(
+            new MetadataAttribute(
                 attributeName, entryType, Collections.singletonList(xmlWriter.toString()), xmlns));
         reader.moveUp();
         reader.moveUp();
@@ -297,7 +297,7 @@ public class CswRecordConverter implements Converter {
       LOGGER.trace("attribute name: {} value: {}.", attributeName, values);
       if (StringUtils.isNotEmpty(attributeName) && !values.isEmpty()) {
         metadataMap.put(
-            attributeName, new MetacardAttribute(attributeName, entryType, values, xmlns));
+            attributeName, new MetadataAttribute(attributeName, entryType, values, xmlns));
       }
 
       reader.moveUp();

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/MetacardMarshaller.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/MetacardMarshaller.java
@@ -15,7 +15,7 @@ package com.connexta.replication.adapters.ddf.csw;
 
 import static com.connexta.replication.adapters.ddf.csw.Constants.DEFAULT_METACARD_TYPE_NAME;
 
-import com.connexta.replication.adapters.ddf.MetacardAttribute;
+import com.connexta.replication.data.MetadataAttribute;
 import com.google.common.collect.ImmutableMap;
 import java.io.StringWriter;
 import java.util.HashMap;
@@ -56,7 +56,7 @@ public class MetacardMarshaller {
 
   public static String marshal(Metadata metadata) {
     EscapingPrintWriter writer = new EscapingPrintWriter(new StringWriter(1024));
-    Map<String, MetacardAttribute> attributes = getAttributeMap(metadata);
+    Map<String, MetadataAttribute> attributes = getAttributeMap(metadata);
     writer.startNode("metacard");
     for (Map.Entry<String, String> nsRow : NAMESPACE_MAP.entrySet()) {
       writer.addAttribute(nsRow.getKey(), nsRow.getValue());
@@ -78,33 +78,33 @@ public class MetacardMarshaller {
       writer.endNode(); // source
     }
 
-    for (MetacardAttribute metacardAttribute : attributes.values()) {
-      String attributeName = metacardAttribute.getName();
+    for (MetadataAttribute metadataAttribute : attributes.values()) {
+      String attributeName = metadataAttribute.getName();
       if (attributeName.equals(Constants.METACARD_ID)
           || attributeName.equals(Constants.RAW_METADATA_KEY)) {
         continue;
       }
-      writeAttributeToXml(writer, metacardAttribute);
+      writeAttributeToXml(writer, metadataAttribute);
     }
     writer.endNode(); // metacard
     return writer.makeString();
   }
 
-  private static Map<String, MetacardAttribute> getAttributeMap(Metadata metadata) {
+  private static Map<String, MetadataAttribute> getAttributeMap(Metadata metadata) {
     if (!(metadata.getRawMetadata() instanceof Map)) {
       throw new AdapterException(
           "Metadata type " + metadata.getType() + " is incompatible with the DDF adapter");
     }
-    Map<String, MetacardAttribute> attributes = new HashMap<>();
+    Map<String, MetadataAttribute> attributes = new HashMap<>();
     ((Map) metadata.getRawMetadata())
         .values().stream()
-            .filter(MetacardAttribute.class::isInstance)
-            .map(MetacardAttribute.class::cast)
-            .forEach(e -> attributes.put(((MetacardAttribute) e).getName(), (MetacardAttribute) e));
+            .filter(MetadataAttribute.class::isInstance)
+            .map(MetadataAttribute.class::cast)
+            .forEach(e -> attributes.put(((MetadataAttribute) e).getName(), (MetadataAttribute) e));
     return attributes;
   }
 
-  private static void writeAttributeToXml(EscapingPrintWriter writer, MetacardAttribute attribute) {
+  private static void writeAttributeToXml(EscapingPrintWriter writer, MetadataAttribute attribute) {
     String attributeName = attribute.getName();
     List<String> values = attribute.getValues();
     String format = attribute.getType();

--- a/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/DdfNodeAdapterTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/DdfNodeAdapterTest.java
@@ -28,6 +28,7 @@ import com.connexta.replication.adapters.ddf.csw.Csw;
 import com.connexta.replication.adapters.ddf.csw.CswRecordCollection;
 import com.connexta.replication.adapters.ddf.rest.DdfRestClient;
 import com.connexta.replication.adapters.ddf.rest.DdfRestClientFactory;
+import com.connexta.replication.data.MetadataAttribute;
 import com.connexta.replication.data.MetadataImpl;
 import com.connexta.replication.data.QueryRequestImpl;
 import com.connexta.replication.data.ResourceImpl;
@@ -288,13 +289,13 @@ public class DdfNodeAdapterTest {
   }
 
   private Metadata getMetadata() {
-    Map<String, MetacardAttribute> map = new HashMap<>();
+    Map<String, MetadataAttribute> map = new HashMap<>();
 
-    map.put(Constants.METACARD_ID, new MetacardAttribute(Constants.METACARD_ID, null, "123456789"));
-    map.put("type", new MetacardAttribute("type", null, "ddf.metacard"));
+    map.put(Constants.METACARD_ID, new MetadataAttribute(Constants.METACARD_ID, null, "123456789"));
+    map.put("type", new MetadataAttribute("type", null, "ddf.metacard"));
     map.put(
-        Constants.METACARD_TAGS, new MetacardAttribute(Constants.METACARD_TAGS, "string", "tag"));
-    map.put("title", new MetacardAttribute("title", null, "mytitle"));
+        Constants.METACARD_TAGS, new MetadataAttribute(Constants.METACARD_TAGS, "string", "tag"));
+    map.put("title", new MetadataAttribute("title", null, "mytitle"));
 
     return new MetadataImpl(map, Map.class, UUID.randomUUID().toString(), new Date());
   }

--- a/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/csw/CswRecordConverterTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/csw/CswRecordConverterTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
-import com.connexta.replication.adapters.ddf.MetacardAttribute;
+import com.connexta.replication.data.MetadataAttribute;
 import com.connexta.replication.data.MetadataImpl;
 import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
@@ -45,40 +45,40 @@ import org.xmlpull.v1.XmlPullParserFactory;
 @RunWith(MockitoJUnitRunner.class)
 public class CswRecordConverterTest {
 
-  private Map<String, MetacardAttribute> map;
+  private Map<String, MetadataAttribute> map;
 
   @Before
   public void setUp() throws Exception {
     map = new HashMap<>();
-    map.put(Constants.METACARD_ID, new MetacardAttribute(Constants.METACARD_ID, null, "123456789"));
-    map.put("type", new MetacardAttribute("type", null, "my-type"));
-    map.put("source", new MetacardAttribute("source", null, "source-id"));
+    map.put(Constants.METACARD_ID, new MetadataAttribute(Constants.METACARD_ID, null, "123456789"));
+    map.put("type", new MetadataAttribute("type", null, "my-type"));
+    map.put("source", new MetadataAttribute("source", null, "source-id"));
     map.put(
-        Constants.METACARD_TAGS, new MetacardAttribute(Constants.METACARD_TAGS, "string", "tag"));
+        Constants.METACARD_TAGS, new MetadataAttribute(Constants.METACARD_TAGS, "string", "tag"));
     map.put(
         Constants.METACARD_MODIFIED,
-        new MetacardAttribute(Constants.METACARD_MODIFIED, "date", "1234-01-02T03:04:05.060"));
+        new MetadataAttribute(Constants.METACARD_MODIFIED, "date", "1234-01-02T03:04:05.060"));
     map.put(
         "location",
-        new MetacardAttribute(
+        new MetadataAttribute(
             "location",
             "geometry",
             Collections.singletonList("<ns2:point>123,456</ns2:point>"),
             Collections.singletonList("xmlns:ns2=http://some/namespace")));
-    map.put(Replication.ORIGINS, new MetacardAttribute(Replication.ORIGINS, "string", "otherhost"));
+    map.put(Replication.ORIGINS, new MetadataAttribute(Replication.ORIGINS, "string", "otherhost"));
     map.put(
-        Constants.RESOURCE_URI, new MetacardAttribute(Constants.RESOURCE_URI, "string", "my:uri"));
+        Constants.RESOURCE_URI, new MetadataAttribute(Constants.RESOURCE_URI, "string", "my:uri"));
     map.put(
-        Constants.RESOURCE_SIZE, new MetacardAttribute(Constants.RESOURCE_SIZE, "long", "1234"));
+        Constants.RESOURCE_SIZE, new MetadataAttribute(Constants.RESOURCE_SIZE, "long", "1234"));
     map.put(
         Constants.MODIFIED,
-        new MetacardAttribute(Constants.MODIFIED, "date", "1234-01-01T03:04:05.060"));
+        new MetadataAttribute(Constants.MODIFIED, "date", "1234-01-01T03:04:05.060"));
     map.put(
         Constants.DERIVED_RESOURCE_URI,
-        new MetacardAttribute(Constants.DERIVED_RESOURCE_URI, "string", "my:derived:uri"));
+        new MetadataAttribute(Constants.DERIVED_RESOURCE_URI, "string", "my:derived:uri"));
     map.put(
         Constants.DERIVED_RESOURCE_DOWNLOAD_URL,
-        new MetacardAttribute(
+        new MetadataAttribute(
             Constants.DERIVED_RESOURCE_DOWNLOAD_URL, "string", "http://host/path"));
   }
 
@@ -125,7 +125,7 @@ public class CswRecordConverterTest {
             ISODateTimeFormat.dateOptionalTimeParser()
                 .parseDateTime("1234-01-01T03:04:05.060")
                 .toDate()));
-    Map<String, MetacardAttribute> map = (Map) metadata.getRawMetadata();
+    Map<String, MetadataAttribute> map = (Map) metadata.getRawMetadata();
     assertThat(map.containsKey(Constants.DERIVED_RESOURCE_URI), is(false));
     assertThat(map.containsKey(Constants.DERIVED_RESOURCE_DOWNLOAD_URL), is(false));
     assertThat(map.get("location").getValue(), is("<ns2:point>123,456</ns2:point>"));
@@ -136,11 +136,11 @@ public class CswRecordConverterTest {
   public void unmarshalDeletedRecord() throws Exception {
     map.put(
         Constants.VERSIONED_ON,
-        new MetacardAttribute(Constants.VERSIONED_ON, "date", "1234-01-01T01:04:05.060"));
+        new MetadataAttribute(Constants.VERSIONED_ON, "date", "1234-01-01T01:04:05.060"));
     map.put(
         Constants.VERSION_OF_ID,
-        new MetacardAttribute(Constants.VERSION_OF_ID, "string", "987654321"));
-    map.put(Constants.ACTION, new MetacardAttribute(Constants.ACTION, "string", "Deleted"));
+        new MetadataAttribute(Constants.VERSION_OF_ID, "string", "987654321"));
+    map.put(Constants.ACTION, new MetadataAttribute(Constants.ACTION, "string", "Deleted"));
 
     String metacardXml =
         MetacardMarshaller.marshal(new MetadataImpl(map, Map.class, "123456789", new Date(1)));
@@ -192,7 +192,7 @@ public class CswRecordConverterTest {
   @Test
   public void convertToDateBadFormat() {
     assertThat(
-        CswRecordConverter.convertToDate(new MetacardAttribute("att", "string", "notadate")),
+        CswRecordConverter.convertToDate(new MetadataAttribute("att", "string", "notadate")),
         is(nullValue()));
   }
 

--- a/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/csw/MetacardMarshallerTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/csw/MetacardMarshallerTest.java
@@ -16,7 +16,7 @@ package com.connexta.replication.adapters.ddf.csw;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
-import com.connexta.replication.adapters.ddf.MetacardAttribute;
+import com.connexta.replication.data.MetadataAttribute;
 import com.connexta.replication.data.MetadataImpl;
 import java.util.Collections;
 import java.util.Date;
@@ -35,24 +35,24 @@ public class MetacardMarshallerTest {
 
   @Test
   public void marshal() {
-    Map<String, MetacardAttribute> map = new HashMap<>();
+    Map<String, MetadataAttribute> map = new HashMap<>();
 
-    map.put(Constants.METACARD_ID, new MetacardAttribute(Constants.METACARD_ID, null, "123456789"));
-    map.put("type", new MetacardAttribute("type", null, "my-type"));
-    map.put("source", new MetacardAttribute("source", null, "source-id"));
+    map.put(Constants.METACARD_ID, new MetadataAttribute(Constants.METACARD_ID, null, "123456789"));
+    map.put("type", new MetadataAttribute("type", null, "my-type"));
+    map.put("source", new MetadataAttribute("source", null, "source-id"));
     map.put(
-        Constants.METACARD_TAGS, new MetacardAttribute(Constants.METACARD_TAGS, "string", "tag"));
+        Constants.METACARD_TAGS, new MetadataAttribute(Constants.METACARD_TAGS, "string", "tag"));
     map.put(
         "location",
-        new MetacardAttribute(
+        new MetadataAttribute(
             "location",
             "geometry",
             Collections.singletonList("<ns2:point>123,456</ns2:point>"),
             Collections.singletonList("xmlns:ns2=http://some/namespace")));
     map.put(
         "metadata",
-        new MetacardAttribute("metadata", "stringxml", "<test><data>testing</data></test>"));
-    map.put("not-marshaled", new MetacardAttribute("not-marshaled", null, "not-marshaled-value"));
+        new MetadataAttribute("metadata", "stringxml", "<test><data>testing</data></test>"));
+    map.put("not-marshaled", new MetadataAttribute("not-marshaled", null, "not-marshaled-value"));
 
     String metacardxml =
         MetacardMarshaller.marshal(new MetadataImpl(map, Map.class, "123456789", new Date(1)));
@@ -61,23 +61,23 @@ public class MetacardMarshallerTest {
 
   @Test
   public void marshalNoType() {
-    Map<String, MetacardAttribute> map = new HashMap<>();
+    Map<String, MetadataAttribute> map = new HashMap<>();
 
-    map.put(Constants.METACARD_ID, new MetacardAttribute(Constants.METACARD_ID, null, "123456789"));
-    map.put("source", new MetacardAttribute("source", null, "source-id"));
+    map.put(Constants.METACARD_ID, new MetadataAttribute(Constants.METACARD_ID, null, "123456789"));
+    map.put("source", new MetadataAttribute("source", null, "source-id"));
     map.put(
-        Constants.METACARD_TAGS, new MetacardAttribute(Constants.METACARD_TAGS, "string", "tag"));
+        Constants.METACARD_TAGS, new MetadataAttribute(Constants.METACARD_TAGS, "string", "tag"));
     map.put(
         "location",
-        new MetacardAttribute(
+        new MetadataAttribute(
             "location",
             "geometry",
             Collections.singletonList("<ns2:point>123,456</ns2:point>"),
             Collections.singletonList("xmlns:ns2=http://some/namespace")));
     map.put(
         "metadata",
-        new MetacardAttribute("metadata", "stringxml", "<test><data>testing</data></test>"));
-    map.put("not-marshaled", new MetacardAttribute("not-marshaled", null, "not-marshaled-value"));
+        new MetadataAttribute("metadata", "stringxml", "<test><data>testing</data></test>"));
+    map.put("not-marshaled", new MetadataAttribute("not-marshaled", null, "not-marshaled-value"));
 
     String metacardxml =
         MetacardMarshaller.marshal(new MetadataImpl(map, Map.class, "123456789", new Date(1)));
@@ -95,7 +95,7 @@ public class MetacardMarshallerTest {
     String metacardxml =
         MetacardMarshaller.marshal(
             new MetadataImpl(
-                new HashMap<String, MetacardAttribute>(), Map.class, "123456789", new Date(1)));
+                new HashMap<String, MetadataAttribute>(), Map.class, "123456789", new Date(1)));
     assertThat(metacardxml, is(minimalMetacardXml));
   }
 }

--- a/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/rest/DdfRestClientTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/rest/DdfRestClientTest.java
@@ -20,9 +20,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.connexta.replication.adapters.ddf.MetacardAttribute;
 import com.connexta.replication.adapters.ddf.csw.Constants;
 import com.connexta.replication.adapters.ddf.csw.MetacardMarshaller;
+import com.connexta.replication.data.MetadataAttribute;
 import com.connexta.replication.data.MetadataImpl;
 import com.connexta.replication.data.ResourceImpl;
 import java.io.ByteArrayInputStream;
@@ -182,11 +182,11 @@ public class DdfRestClientTest {
   }
 
   private Metadata getMetadata(String id) {
-    Map<String, MetacardAttribute> map = new HashMap<>();
+    Map<String, MetadataAttribute> map = new HashMap<>();
 
-    map.put(Constants.METACARD_ID, new MetacardAttribute(Constants.METACARD_ID, null, id));
-    map.put("type", new MetacardAttribute("type", null, "ddf.metacard"));
-    map.put(Constants.METACARD_TAGS, new MetacardAttribute(Constants.METACARD_TAGS, null, "tag"));
+    map.put(Constants.METACARD_ID, new MetadataAttribute(Constants.METACARD_ID, null, id));
+    map.put("type", new MetadataAttribute("type", null, "ddf.metacard"));
+    map.put(Constants.METACARD_TAGS, new MetadataAttribute(Constants.METACARD_TAGS, null, "tag"));
 
     return new MetadataImpl(map, Map.class, id, new Date());
   }

--- a/adapters/webhdfs-adapter/pom.xml
+++ b/adapters/webhdfs-adapter/pom.xml
@@ -140,7 +140,7 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.84</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>

--- a/adapters/webhdfs-adapter/pom.xml
+++ b/adapters/webhdfs-adapter/pom.xml
@@ -141,17 +141,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.20</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.20</minimum>
+                                            <minimum>0.90</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.20</minimum>
+                                            <minimum>0.80</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/adapters/webhdfs-adapter/pom.xml
+++ b/adapters/webhdfs-adapter/pom.xml
@@ -91,6 +91,17 @@
             <version>${hadoop.version}</version>
         </dependency>
         <dependency>
+            <groupId>replication</groupId>
+            <artifactId>commons</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>replication</groupId>
+            <artifactId>replication-api-impl</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.sakserv</groupId>
             <artifactId>hadoop-mini-clusters-common</artifactId>
             <version>${hadoop.mini.clusters.version}</version>
@@ -101,11 +112,6 @@
             <artifactId>hadoop-mini-clusters-hdfs</artifactId>
             <version>${hadoop.mini.clusters.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>replication</groupId>
-            <artifactId>replication-api-impl</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>replication-adapters</groupId>

--- a/adapters/webhdfs-adapter/pom.xml
+++ b/adapters/webhdfs-adapter/pom.xml
@@ -141,17 +141,17 @@
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.20</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.20</minimum>
                                         </limit>
                                         <limit implementation="org.codice.jacoco.LenientLimit">
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.68</minimum>
+                                            <minimum>0.20</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/adapters/webhdfs-adapter/pom.xml
+++ b/adapters/webhdfs-adapter/pom.xml
@@ -180,8 +180,7 @@
                             mime-tika-resolver,
                             platform-util,
                             jaxb-core,
-                            commons-lang3,
-                            commons
+                            commons-lang3
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -310,18 +310,21 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
   }
 
   /**
-   * Returns the files relevant for this replication
+   * Returns the files meeting the criteria for replication by removing elements that: 1) are of
+   * type DIRECTORY or 2) have a modification time before or equal to the filter date, when the
+   * filter date is specified
    *
    * @param files a {@code List} of all {@link FileStatus} objects returned by the GET request
-   * @param filterDate specifies a point in time such that older files are excluded; this value will
-   *     be set to {@code null} during the first execution of replication
+   * @param filterDate specifies a point in time such that only files more-recent are included; this
+   *     value will be set to {@code null} during the first execution of replication
    * @return a resulting {@code List} of {@link FileStatus} objects meeting the criteria
    */
-  private List<FileStatus> getRelevantFiles(List<FileStatus> files, @Nullable Date filterDate) {
+  @VisibleForTesting
+  List<FileStatus> getRelevantFiles(List<FileStatus> files, @Nullable Date filterDate) {
     files.removeIf(
         file ->
             file.isDirectory()
-                || (filterDate != null && file.getModificationTime().before(filterDate)));
+                || (filterDate != null && !file.getModificationTime().after(filterDate)));
 
     return files;
   }

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -58,6 +58,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.codice.ditto.replication.api.NodeAdapter;
+import org.codice.ditto.replication.api.Replication;
 import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.data.CreateRequest;
 import org.codice.ditto.replication.api.data.CreateStorageRequest;
@@ -95,6 +96,8 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
 
   private static final String METADATA_ATTRIBUTE_TYPE_STRING = "string";
   private static final String METADATA_ATTRIBUTE_TYPE_DATE = "date";
+
+  private static final String REPLICATION_ORIGINS = "HDFS";
 
   private final URL webHdfsUrl;
 
@@ -227,6 +230,14 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
             Collections.singletonList(String.valueOf(fileStatus.getLength())),
             Collections.emptyList());
     metadataAttributes.put(Core.RESOURCE_SIZE, lengthAttribute);
+
+    MetadataAttribute replicationOriginsAttribute =
+        new MetadataAttribute(
+            Replication.ORIGINS,
+            METADATA_ATTRIBUTE_TYPE_STRING,
+            Collections.singletonList(REPLICATION_ORIGINS),
+            Collections.emptyList());
+    metadataAttributes.put(Replication.ORIGINS, replicationOriginsAttribute);
 
     Metadata metadata = new MetadataImpl(metadataAttributes, Map.class, id, modificationTime);
 

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -178,6 +178,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
     Map<String, MetadataAttribute> metadataAttributes = new HashMap<>();
 
     String fileUrl = getWebHdfsUrl().toString() + fileStatus.getPathSuffix();
+    LOGGER.debug("Creating Metadata object from file at: {}", fileUrl);
 
     Date modificationTime = fileStatus.getModificationTime();
     String id = getVersion4Uuid(fileUrl, modificationTime);
@@ -260,6 +261,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
     StringBuilder version4Uuid = new StringBuilder(version3Uuid);
     version4Uuid.setCharAt(UUID_VERSION_INDEX, '4');
 
+    LOGGER.info("UUID for {} is {}", fileUrl, version4Uuid);
     return version4Uuid.toString();
   }
 
@@ -292,6 +294,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
         ResponseHandler<List<FileStatus>> responseHandler =
             response -> {
               int statusCode = response.getStatusLine().getStatusCode();
+              LOGGER.debug("Response contains status code: {}", statusCode);
 
               if (statusCode == HttpStatus.SC_OK) {
                 InputStream content = response.getEntity().getContent();
@@ -329,6 +332,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
       }
     } while (remainingEntries.intValue() > 0);
 
+    LOGGER.info("Identified {} files to replicate.", filesToReplicate.size());
     return filesToReplicate;
   }
 

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -15,9 +15,9 @@ package com.connexta.replication.adapters.webhdfs;
 
 import com.connexta.replication.adapters.webhdfs.filesystem.DirectoryListing;
 import com.connexta.replication.adapters.webhdfs.filesystem.FileStatus;
+import com.connexta.replication.adapters.webhdfs.filesystem.Result;
 import com.connexta.replication.data.QueryRequestImpl;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import ddf.mime.tika.TikaMimeTypeResolver;
@@ -25,10 +25,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
@@ -156,12 +159,14 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
             if (statusCode == HttpStatus.SC_OK) {
               InputStream content = response.getEntity().getContent();
 
-              ObjectMapper objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+              String text = IOUtils.toString(content, StandardCharsets.UTF_8.name());
 
-              DirectoryListing directoryListing = objectMapper.readValue(content, DirectoryListing.class);
+              ObjectMapper objectMapper = new ObjectMapper();
+
+              Result result = objectMapper.readValue(text, Result.class);
+              DirectoryListing directoryListing = result.getDirectoryListing();
 
               int remainingEntries = directoryListing.getRemainingEntries();
-
               List<FileStatus> filesToReplicate = getRelevantFiles(directoryListing.getPartialListing().getFileStatuses().getFileStatusList());
 
 

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -73,6 +73,8 @@ import org.codice.ditto.replication.api.impl.data.CreateStorageRequestImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 /** Interacts with a remote Hadoop instance through the webHDFS REST API */
 public class WebHdfsNodeAdapter implements NodeAdapter {
 
@@ -237,7 +239,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
    * @return a resulting {@code List} of {@link FileStatus} objects meeting the criteria
    */
   @VisibleForTesting
-  List<FileStatus> getFilesToReplicate(Date filterDate) {
+  List<FileStatus> getFilesToReplicate(@Nullable Date filterDate) {
 
     List<FileStatus> filesToReplicate = new ArrayList<>();
     AtomicInteger remainingEntries = new AtomicInteger();
@@ -301,11 +303,15 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
    * Returns the files relevant for this replication
    *
    * @param files a {@code List} of all {@link FileStatus} objects returned by the GET request
-   * @param filterDate specifies a point in time such that older files are excluded
+   * @param filterDate specifies a point in time such that older files are excluded; this value will
+   *     be set to {@code null} during the first execution of replication
    * @return a resulting {@code List} of {@link FileStatus} objects meeting the criteria
    */
-  private List<FileStatus> getRelevantFiles(List<FileStatus> files, Date filterDate) {
-    files.removeIf(file -> file.isDirectory() || file.getModificationTime().before(filterDate));
+  private List<FileStatus> getRelevantFiles(List<FileStatus> files, @Nullable Date filterDate) {
+    files.removeIf(
+        file ->
+            file.isDirectory()
+                || (filterDate != null && file.getModificationTime().before(filterDate)));
 
     return files;
   }

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -142,6 +142,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
     return "webHDFS";
   }
 
+  // TODO: 6/5/20 remove this method after done testing implementation
   /** TEMPORARY METHOD FOR IMPLEMENTATION TESTING */
   public QueryResponse testQuery() {
     Date modifiedAfter = new Date(22222222L);
@@ -157,13 +158,14 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
 
     List<FileStatus> filesToReplicate = getFilesToReplicate(queryRequest.getModifiedAfter());
 
+    // TODO: 6/4/20 evaluate whether to sort here or after populating metadata iterable
     filesToReplicate.sort(Comparator.comparing(FileStatus::getModificationTime));
 
     List<Metadata> results = new ArrayList<>();
 
     try {
       MessageDigest messageDigest = MessageDigest.getInstance("MD5");
-
+      // TODO: 6/4/20 evaluate whether to use foreach (as written) or a stream?
       for (FileStatus file : filesToReplicate) {
         results.add(createMetadata(file, messageDigest));
       }

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -261,7 +261,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
     StringBuilder version4Uuid = new StringBuilder(version3Uuid);
     version4Uuid.setCharAt(UUID_VERSION_INDEX, '4');
 
-    LOGGER.info("UUID for {} is {}", fileUrl, version4Uuid);
+    LOGGER.debug("UUID for {} is {}", fileUrl, version4Uuid);
     return version4Uuid.toString();
   }
 

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -182,8 +182,8 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
 
     String fileUrl = getWebHdfsUrl().toString() + fileStatus.getPathSuffix();
 
-    String id = getVersion4Uuid(fileUrl);
     Date modificationTime = fileStatus.getModificationTime();
+    String id = getVersion4Uuid(fileUrl, modificationTime);
 
     MetadataAttribute idAttribute =
         new MetadataAttribute(
@@ -267,10 +267,12 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
    * a version-4 UUID by changing the version number in the UUID from 3 to 4.
    *
    * @param fileUrl the full URL of the file
+   * @param modificationTime modification time of the file
    * @return a {@code String} representing a version-4 UUID
    */
-  private String getVersion4Uuid(String fileUrl) {
-    String version3Uuid = UUID.nameUUIDFromBytes(fileUrl.getBytes()).toString();
+  private String getVersion4Uuid(String fileUrl, Date modificationTime) {
+    String input = String.format("%s_%d", fileUrl, modificationTime.getTime());
+    String version3Uuid = UUID.nameUUIDFromBytes(input.getBytes()).toString();
     StringBuilder version4Uuid = new StringBuilder(version3Uuid);
     version4Uuid.setCharAt(UUID_VERSION_INDEX, '4');
     return version4Uuid.toString();

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -58,7 +58,6 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.codice.ditto.replication.api.NodeAdapter;
-import org.codice.ditto.replication.api.Replication;
 import org.codice.ditto.replication.api.ReplicationException;
 import org.codice.ditto.replication.api.data.CreateRequest;
 import org.codice.ditto.replication.api.data.CreateStorageRequest;
@@ -96,8 +95,6 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
 
   private static final String METADATA_ATTRIBUTE_TYPE_STRING = "string";
   private static final String METADATA_ATTRIBUTE_TYPE_DATE = "date";
-
-  private static final String REPLICATION_ORIGINS = "HDFS";
 
   private static final int UUID_VERSION_INDEX = 14;
 
@@ -232,22 +229,6 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
             Collections.singletonList(String.valueOf(fileStatus.getLength())),
             Collections.emptyList());
     metadataAttributes.put(Core.RESOURCE_SIZE, lengthAttribute);
-
-    MetadataAttribute replicationOriginsAttribute =
-        new MetadataAttribute(
-            Replication.ORIGINS,
-            METADATA_ATTRIBUTE_TYPE_STRING,
-            Collections.singletonList(REPLICATION_ORIGINS),
-            Collections.emptyList());
-    metadataAttributes.put(Replication.ORIGINS, replicationOriginsAttribute);
-
-    MetadataAttribute typeAttribute =
-        new MetadataAttribute(
-            "type",
-            METADATA_ATTRIBUTE_TYPE_STRING,
-            Collections.singletonList("ddf.metacard"),
-            Collections.emptyList());
-    metadataAttributes.put("type", typeAttribute);
 
     Metadata metadata = new MetadataImpl(metadataAttributes, Map.class, id, modificationTime);
 

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -233,6 +233,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
     try {
       metadata.setResourceUri(new URI(fileUrl));
       metadata.setResourceModified(modificationTime);
+      metadata.setResourceSize(fileStatus.getLength());
 
       return metadata;
     } catch (URISyntaxException e) {

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterFactory.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterFactory.java
@@ -42,10 +42,7 @@ public class WebHdfsNodeAdapterFactory implements NodeAdapterFactory {
     String baseUrl = protocol + url.getHost() + ":" + url.getPort() + url.getPath();
 
     if (!baseUrl.endsWith("/")) {
-      baseUrl =
-          baseUrl.concat(
-              "/"); // TODO: 6/5/20 the trailing slash is removed when the URL is created again so
-      // this may not be beneficial
+      baseUrl = baseUrl.concat("/");
     }
 
     try {
@@ -55,19 +52,6 @@ public class WebHdfsNodeAdapterFactory implements NodeAdapterFactory {
       throw new AdapterException("Failed to create adapter", e);
     }
   }
-
-  // TODO: 6/5/20 remove this after testing complete
-  //  public static void main(String[] args) {
-  //    try {
-  //      WebHdfsNodeAdapter adapter =
-  //          new WebHdfsNodeAdapter(
-  //              new URL("http://localhost:9870/webhdfs/v1/user/chris"),
-  // HttpClients.createDefault());
-  //      adapter.testQuery();
-  //    } catch (MalformedURLException e) {
-  //      System.exit(0);
-  //    }
-  //  }
 
   @Override
   public NodeAdapterType getType() {

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterFactory.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterFactory.java
@@ -41,7 +41,10 @@ public class WebHdfsNodeAdapterFactory implements NodeAdapterFactory {
         "http://" + url.getHost() + ":" + url.getPort() + "/webhdfs/v1" + url.getPath();
 
     if (!baseUrl.endsWith("/")) {
-      baseUrl = baseUrl.concat("/");
+      baseUrl =
+          baseUrl.concat(
+              "/"); // TODO: 6/5/20 the trailing slash is removed when the URL is created again so
+      // this may not be beneficial
     }
 
     try {
@@ -51,16 +54,18 @@ public class WebHdfsNodeAdapterFactory implements NodeAdapterFactory {
     }
   }
 
-  public static void main(String[] args) {
-    try {
-      WebHdfsNodeAdapter adapter =
-          new WebHdfsNodeAdapter(
-              new URL("http://localhost:9870/webhdfs/v1/user/chris"), HttpClients.createDefault());
-      adapter.testQuery();
-    } catch (MalformedURLException e) {
-      System.exit(0);
-    }
-  }
+  // TODO: 6/5/20 remove this after testing complete
+  //  public static void main(String[] args) {
+  //    try {
+  //      WebHdfsNodeAdapter adapter =
+  //          new WebHdfsNodeAdapter(
+  //              new URL("http://localhost:9870/webhdfs/v1/user/chris"),
+  // HttpClients.createDefault());
+  //      adapter.testQuery();
+  //    } catch (MalformedURLException e) {
+  //      System.exit(0);
+  //    }
+  //  }
 
   @Override
   public NodeAdapterType getType() {

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterFactory.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterFactory.java
@@ -51,6 +51,17 @@ public class WebHdfsNodeAdapterFactory implements NodeAdapterFactory {
     }
   }
 
+  public static void main(String[] args) {
+    try {
+      WebHdfsNodeAdapter adapter =
+          new WebHdfsNodeAdapter(
+              new URL("http://localhost:9870/webhdfs/v1/user/chris"), HttpClients.createDefault());
+      adapter.testQuery();
+    } catch (MalformedURLException e) {
+      System.exit(0);
+    }
+  }
+
   @Override
   public NodeAdapterType getType() {
     return NodeAdapterType.WEBHDFS;

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/DirectoryListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/DirectoryListing.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.adapters.webhdfs.filesystem;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class DirectoryListing {
+
+    private static final String PARTIAL_LISTING_KEY = "partialListing";
+    private static final String REMAINING_ENTRIES_KEY = "remainingEntries";
+    private static final String FILE_STATUSES_KEY = "FileStatuses";
+    private static final String FILE_STATUS_KEY = "FileStatus";
+
+    private List<FileStatus> partialListing;
+    private int remainingEntries = 0;
+
+    public DirectoryListing(Map<String, Object> directoryListing) {
+
+        this.partialListing = getPartialListing((Map) directoryListing.get(PARTIAL_LISTING_KEY));
+
+        this.remainingEntries = (Integer) directoryListing.get(REMAINING_ENTRIES_KEY);
+    }
+
+    private List<FileStatus> getPartialListing(Map<String, Object> partialListing) {
+
+        return getFileStatuses((Map) partialListing.get(FILE_STATUSES_KEY));
+
+    }
+
+    private List<FileStatus> getFileStatuses(Map<String, Object> fileStatuses) {
+
+        List<FileStatus> files = new ArrayList<>();
+
+        for(Map<String, Object> file : (ArrayList<Map<String, Object>>) fileStatuses.get(FILE_STATUS_KEY)) {
+            files.add(new FileStatus(file));
+        }
+        return files;
+
+    }
+
+}

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/DirectoryListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/DirectoryListing.java
@@ -15,40 +15,6 @@ package com.connexta.replication.adapters.webhdfs.filesystem;
 
 public class DirectoryListing {
 
-  //    private static final String PARTIAL_LISTING_KEY = "partialListing";
-  //    private static final String REMAINING_ENTRIES_KEY = "remainingEntries";
-  //    private static final String FILE_STATUSES_KEY = "FileStatuses";
-  //    private static final String FILE_STATUS_KEY = "FileStatus";
-
-  //    private List<FileStatus> partialListing;
-  //    private int remainingEntries = 0;
-
-  //    public DirectoryListing(Map<String, Object> directoryListing) {
-
-  //        this.partialListing = getPartialListing((Map)
-  // directoryListing.get(PARTIAL_LISTING_KEY));
-  //
-  //        this.remainingEntries = (Integer) directoryListing.get(REMAINING_ENTRIES_KEY);
-  //    }
-
-  //    private List<FileStatus> getPartialListing(Map<String, Object> partialListing) {
-  //
-  //        return getFileStatuses((Map) partialListing.get(FILE_STATUSES_KEY));
-  //
-  //    }
-  //
-  //    private List<FileStatus> getFileStatuses(Map<String, Object> fileStatuses) {
-  //
-  //        List<FileStatus> files = new ArrayList<>();
-  //
-  //        for(Map<String, Object> file : (ArrayList<Map<String, Object>>)
-  // fileStatuses.get(FILE_STATUS_KEY)) {
-  //            files.add(new FileStatus(file));
-  //        }
-  //        return files;
-  //
-  //    }
-
   PartialListing partialListing;
   int remainingEntries;
 

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/DirectoryListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/DirectoryListing.java
@@ -13,6 +13,7 @@
  */
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
+/** Represents a DirectoryListing JSON object received through an HTTP GET request */
 public class DirectoryListing {
 
   PartialListing partialListing;

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/DirectoryListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/DirectoryListing.java
@@ -13,42 +13,58 @@
  */
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 public class DirectoryListing {
 
-    private static final String PARTIAL_LISTING_KEY = "partialListing";
-    private static final String REMAINING_ENTRIES_KEY = "remainingEntries";
-    private static final String FILE_STATUSES_KEY = "FileStatuses";
-    private static final String FILE_STATUS_KEY = "FileStatus";
+  //    private static final String PARTIAL_LISTING_KEY = "partialListing";
+  //    private static final String REMAINING_ENTRIES_KEY = "remainingEntries";
+  //    private static final String FILE_STATUSES_KEY = "FileStatuses";
+  //    private static final String FILE_STATUS_KEY = "FileStatus";
 
-    private List<FileStatus> partialListing;
-    private int remainingEntries = 0;
+  //    private List<FileStatus> partialListing;
+  //    private int remainingEntries = 0;
 
-    public DirectoryListing(Map<String, Object> directoryListing) {
+  //    public DirectoryListing(Map<String, Object> directoryListing) {
 
-        this.partialListing = getPartialListing((Map) directoryListing.get(PARTIAL_LISTING_KEY));
+  //        this.partialListing = getPartialListing((Map)
+  // directoryListing.get(PARTIAL_LISTING_KEY));
+  //
+  //        this.remainingEntries = (Integer) directoryListing.get(REMAINING_ENTRIES_KEY);
+  //    }
 
-        this.remainingEntries = (Integer) directoryListing.get(REMAINING_ENTRIES_KEY);
-    }
+  //    private List<FileStatus> getPartialListing(Map<String, Object> partialListing) {
+  //
+  //        return getFileStatuses((Map) partialListing.get(FILE_STATUSES_KEY));
+  //
+  //    }
+  //
+  //    private List<FileStatus> getFileStatuses(Map<String, Object> fileStatuses) {
+  //
+  //        List<FileStatus> files = new ArrayList<>();
+  //
+  //        for(Map<String, Object> file : (ArrayList<Map<String, Object>>)
+  // fileStatuses.get(FILE_STATUS_KEY)) {
+  //            files.add(new FileStatus(file));
+  //        }
+  //        return files;
+  //
+  //    }
 
-    private List<FileStatus> getPartialListing(Map<String, Object> partialListing) {
+  PartialListing partialListing;
+  int remainingEntries;
 
-        return getFileStatuses((Map) partialListing.get(FILE_STATUSES_KEY));
+  public PartialListing getPartialListing() {
+    return partialListing;
+  }
 
-    }
+  public void setPartialListing(PartialListing partialListing) {
+    this.partialListing = partialListing;
+  }
 
-    private List<FileStatus> getFileStatuses(Map<String, Object> fileStatuses) {
+  public int getRemainingEntries() {
+    return remainingEntries;
+  }
 
-        List<FileStatus> files = new ArrayList<>();
-
-        for(Map<String, Object> file : (ArrayList<Map<String, Object>>) fileStatuses.get(FILE_STATUS_KEY)) {
-            files.add(new FileStatus(file));
-        }
-        return files;
-
-    }
-
+  public void setRemainingEntries(int remainingEntries) {
+    this.remainingEntries = remainingEntries;
+  }
 }

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
@@ -13,10 +13,10 @@
  */
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
+import java.util.Date;
 import org.apache.commons.io.FilenameUtils;
 
-import java.util.Date;
-
+/** Represents a FileStatus JSON object received through an HTTP GET request */
 public class FileStatus {
 
   private Date accessTime;

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.adapters.webhdfs.filesystem;
+
+import java.util.Date;
+import java.util.Map;
+
+public class FileStatus {
+
+    private final Date accessTime;
+    private final int blockSize;
+    private final int childrenNum;
+    private final int fileId;
+    private final String group;
+    private final int length;
+    private final Date modificationTime;
+    private final String owner;
+    private final String pathSuffix;
+    private final String permission;
+    private final int replication;
+    private final int storagePolicy;
+    private final String type;
+
+    public FileStatus(Map<String, Object> file) {
+
+        this.accessTime = (Date) file.get("accessTime");
+        this.blockSize = (int) file.get("blockSize");
+        this.childrenNum = (int) file.get("childrenNum");
+        this.fileId = (int) file.get("fileId");
+        this.group = (String) file.get("group");
+        this.length = (int) file.get("length");
+        this.modificationTime = (Date) file.get("modificationTime");
+        this.owner = (String) file.get("owner");
+        this.pathSuffix = (String) file.get("pathSuffix");
+        this.permission = (String) file.get("permission");
+        this.replication = (int) file.get("replication");
+        this.storagePolicy = (int) file.get("storagePolicy");
+        this.type = (String) file.get("type");
+    }
+
+    public Date getAccessTime() {
+        return accessTime;
+    }
+
+    public int getBlockSize() {
+        return blockSize;
+    }
+
+    public int getChildrenNum() {
+        return childrenNum;
+    }
+
+    public int getFileId() {
+        return fileId;
+    }
+
+    public String getGroup() {
+        return group;
+    }
+
+    public int getLength() {
+        return length;
+    }
+
+    public Date getModificationTime() {
+        return modificationTime;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getPathSuffix() {
+        return pathSuffix;
+    }
+
+    public String getPermission() {
+        return permission;
+    }
+
+    public int getReplication() {
+        return replication;
+    }
+
+    public int getStoragePolicy() {
+        return storagePolicy;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
@@ -142,6 +142,7 @@ public class FileStatus {
   }
 
   public boolean isOlderThan(Date date) {
+    // TODO: 6/4/20 remove this and use modificationTime directly?
     String filename = FilenameUtils.removeExtension(getPathSuffix());
 
     // get time portion of the filename

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
@@ -14,90 +14,124 @@
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
 import java.util.Date;
-import java.util.Map;
 
 public class FileStatus {
 
-    private final Date accessTime;
-    private final int blockSize;
-    private final int childrenNum;
-    private final int fileId;
-    private final String group;
-    private final int length;
-    private final Date modificationTime;
-    private final String owner;
-    private final String pathSuffix;
-    private final String permission;
-    private final int replication;
-    private final int storagePolicy;
-    private final String type;
+  private Date accessTime;
+  private int blockSize;
+  private int childrenNum;
+  private int fileId;
+  private String group;
+  private int length;
+  private Date modificationTime;
+  private String owner;
+  private String pathSuffix;
+  private String permission;
+  private int replication;
+  private int storagePolicy;
+  private String type;
 
-    public FileStatus(Map<String, Object> file) {
+  public Date getAccessTime() {
+    return accessTime;
+  }
 
-        this.accessTime = (Date) file.get("accessTime");
-        this.blockSize = (int) file.get("blockSize");
-        this.childrenNum = (int) file.get("childrenNum");
-        this.fileId = (int) file.get("fileId");
-        this.group = (String) file.get("group");
-        this.length = (int) file.get("length");
-        this.modificationTime = (Date) file.get("modificationTime");
-        this.owner = (String) file.get("owner");
-        this.pathSuffix = (String) file.get("pathSuffix");
-        this.permission = (String) file.get("permission");
-        this.replication = (int) file.get("replication");
-        this.storagePolicy = (int) file.get("storagePolicy");
-        this.type = (String) file.get("type");
-    }
+  public void setAccessTime(Date accessTime) {
+    this.accessTime = accessTime;
+  }
 
-    public Date getAccessTime() {
-        return accessTime;
-    }
+  public int getBlockSize() {
+    return blockSize;
+  }
 
-    public int getBlockSize() {
-        return blockSize;
-    }
+  public void setBlockSize(int blockSize) {
+    this.blockSize = blockSize;
+  }
 
-    public int getChildrenNum() {
-        return childrenNum;
-    }
+  public int getChildrenNum() {
+    return childrenNum;
+  }
 
-    public int getFileId() {
-        return fileId;
-    }
+  public void setChildrenNum(int childrenNum) {
+    this.childrenNum = childrenNum;
+  }
 
-    public String getGroup() {
-        return group;
-    }
+  public int getFileId() {
+    return fileId;
+  }
 
-    public int getLength() {
-        return length;
-    }
+  public void setFileId(int fileId) {
+    this.fileId = fileId;
+  }
 
-    public Date getModificationTime() {
-        return modificationTime;
-    }
+  public String getGroup() {
+    return group;
+  }
 
-    public String getOwner() {
-        return owner;
-    }
+  public void setGroup(String group) {
+    this.group = group;
+  }
 
-    public String getPathSuffix() {
-        return pathSuffix;
-    }
+  public int getLength() {
+    return length;
+  }
 
-    public String getPermission() {
-        return permission;
-    }
+  public void setLength(int length) {
+    this.length = length;
+  }
 
-    public int getReplication() {
-        return replication;
-    }
+  public Date getModificationTime() {
+    return modificationTime;
+  }
 
-    public int getStoragePolicy() {
-        return storagePolicy;
-    }
+  public void setModificationTime(Date modificationTime) {
+    this.modificationTime = modificationTime;
+  }
 
-    public String getType() {
-        return type;
-    }
+  public String getOwner() {
+    return owner;
+  }
+
+  public void setOwner(String owner) {
+    this.owner = owner;
+  }
+
+  public String getPathSuffix() {
+    return pathSuffix;
+  }
+
+  public void setPathSuffix(String pathSuffix) {
+    this.pathSuffix = pathSuffix;
+  }
+
+  public String getPermission() {
+    return permission;
+  }
+
+  public void setPermission(String permission) {
+    this.permission = permission;
+  }
+
+  public int getReplication() {
+    return replication;
+  }
+
+  public void setReplication(int replication) {
+    this.replication = replication;
+  }
+
+  public int getStoragePolicy() {
+    return storagePolicy;
+  }
+
+  public void setStoragePolicy(int storagePolicy) {
+    this.storagePolicy = storagePolicy;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
 }

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
@@ -13,8 +13,8 @@
  */
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Date;
-import org.apache.commons.io.FilenameUtils;
 
 /** Represents a FileStatus JSON object received through an HTTP GET request */
 public class FileStatus {
@@ -137,18 +137,8 @@ public class FileStatus {
     this.type = type;
   }
 
+  @JsonIgnore
   public boolean isDirectory() {
     return getType().equals("DIRECTORY");
-  }
-
-  public boolean isOlderThan(Date date) {
-    // TODO: 6/4/20 remove this and use modificationTime directly?
-    String filename = FilenameUtils.removeExtension(getPathSuffix());
-
-    // get time portion of the filename
-    long fileTime = Long.parseLong(filename.substring(filename.lastIndexOf('_') + 1));
-
-    Date fileDate = new Date(fileTime);
-    return fileDate.before(date);
   }
 }

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatus.java
@@ -13,6 +13,8 @@
  */
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
+import org.apache.commons.io.FilenameUtils;
+
 import java.util.Date;
 
 public class FileStatus {
@@ -133,5 +135,19 @@ public class FileStatus {
 
   public void setType(String type) {
     this.type = type;
+  }
+
+  public boolean isDirectory() {
+    return getType().equals("DIRECTORY");
+  }
+
+  public boolean isOlderThan(Date date) {
+    String filename = FilenameUtils.removeExtension(getPathSuffix());
+
+    // get time portion of the filename
+    long fileTime = Long.parseLong(filename.substring(filename.lastIndexOf('_') + 1));
+
+    Date fileDate = new Date(fileTime);
+    return fileDate.before(date);
   }
 }

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatuses.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatuses.java
@@ -14,9 +14,9 @@
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
+/** Represents a FileStatuses JSON object received through an HTTP GET request */
 public class FileStatuses {
 
   @JsonProperty("FileStatus")

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatuses.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatuses.java
@@ -13,10 +13,13 @@
  */
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public class FileStatuses {
 
+  @JsonProperty("FileStatus")
   List<FileStatus> fileStatusList;
 
   public List<FileStatus> getFileStatusList() {

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatuses.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/FileStatuses.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.adapters.webhdfs.filesystem;
+
+import java.util.List;
+
+public class FileStatuses {
+
+  List<FileStatus> fileStatusList;
+
+  public List<FileStatus> getFileStatusList() {
+    return fileStatusList;
+  }
+
+  public void setFileStatusList(List<FileStatus> fileStatusList) {
+    this.fileStatusList = fileStatusList;
+  }
+}

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/IterativeDirectoryListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/IterativeDirectoryListing.java
@@ -1,7 +1,21 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** Represents the data returned by the HTTP GET request to iteratively list a directory */
 public class IterativeDirectoryListing {
 
   @JsonProperty("DirectoryListing")

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/IterativeDirectoryListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/IterativeDirectoryListing.java
@@ -15,7 +15,7 @@ package com.connexta.replication.adapters.webhdfs.filesystem;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** Represents the data returned by the HTTP GET request to iteratively list a directory */
+/** Represents the data returned by an HTTP GET request to iteratively list a directory */
 public class IterativeDirectoryListing {
 
   @JsonProperty("DirectoryListing")

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/IterativeDirectoryListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/IterativeDirectoryListing.java
@@ -2,7 +2,7 @@ package com.connexta.replication.adapters.webhdfs.filesystem;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Result {
+public class IterativeDirectoryListing {
 
   @JsonProperty("DirectoryListing")
   DirectoryListing directoryListing;

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/PartialListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/PartialListing.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package com.connexta.replication.adapters.webhdfs.filesystem;
+
+public class PartialListing {
+
+  FileStatuses fileStatuses;
+
+  public FileStatuses getFileStatuses() {
+    return fileStatuses;
+  }
+
+  public void setFileStatuses(FileStatuses fileStatuses) {
+    this.fileStatuses = fileStatuses;
+  }
+}

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/PartialListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/PartialListing.java
@@ -15,6 +15,7 @@ package com.connexta.replication.adapters.webhdfs.filesystem;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/** Represents a PartialListing JSON object received through an HTTP GET request */
 public class PartialListing {
 
   @JsonProperty("FileStatuses")

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/PartialListing.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/PartialListing.java
@@ -13,8 +13,11 @@
  */
 package com.connexta.replication.adapters.webhdfs.filesystem;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class PartialListing {
 
+  @JsonProperty("FileStatuses")
   FileStatuses fileStatuses;
 
   public FileStatuses getFileStatuses() {

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/Result.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/filesystem/Result.java
@@ -1,0 +1,17 @@
+package com.connexta.replication.adapters.webhdfs.filesystem;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Result {
+
+  @JsonProperty("DirectoryListing")
+  DirectoryListing directoryListing;
+
+  public DirectoryListing getDirectoryListing() {
+    return directoryListing;
+  }
+
+  public void setDirectoryListing(DirectoryListing directoryListing) {
+    this.directoryListing = directoryListing;
+  }
+}

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsClientTest.java
@@ -17,8 +17,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-import com.connexta.replication.adapters.ddf.MetacardAttribute;
 import com.connexta.replication.adapters.ddf.csw.Constants;
+import com.connexta.replication.data.MetadataAttribute;
 import com.connexta.replication.data.MetadataImpl;
 import com.connexta.replication.data.ResourceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -419,10 +419,10 @@ public class WebHdfsClientTest {
    * @return The newly created {@link MetadataImpl}
    */
   private Metadata getMetadata(String id, Date metadataModified, Date resourceModified) {
-    Map<String, MetacardAttribute> map = new HashMap<>();
-    map.put(Constants.METACARD_ID, new MetacardAttribute(Constants.METACARD_ID, null, id));
-    map.put("type", new MetacardAttribute("type", null, "hdfs.metacard"));
-    map.put(Constants.METACARD_TAGS, new MetacardAttribute(Constants.METACARD_TAGS, null, "tag"));
+    Map<String, MetadataAttribute> map = new HashMap<>();
+    map.put(Constants.METACARD_ID, new MetadataAttribute(Constants.METACARD_ID, null, id));
+    map.put("type", new MetadataAttribute("type", null, "hdfs.metacard"));
+    map.put(Constants.METACARD_TAGS, new MetadataAttribute(Constants.METACARD_TAGS, null, "tag"));
 
     Metadata metadata = new MetadataImpl(map, Map.class, id, metadataModified);
     metadata.setResourceModified(resourceModified);

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -245,6 +245,7 @@ public class WebHdfsNodeAdapterTest {
     assertThat(metadata.getId(), is(hashedId));
     assertThat(metadata.getMetadataModified(), is(date));
     assertThat(metadata.getResourceUri().toString(), is("http://host:1234/some/path/test.txt"));
+    assertThat(metadata.getResourceModified(), is(date));
 
     // and the metadata object's attributes will have values corresponding to the FileStatus object
     Map<String, MetadataAttribute> metadataAttributes =

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -72,7 +72,6 @@ import org.codice.ditto.replication.api.data.ResourceRequest;
 import org.codice.ditto.replication.api.data.ResourceResponse;
 import org.codice.ditto.replication.api.data.UpdateStorageRequest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -141,7 +140,6 @@ public class WebHdfsNodeAdapterTest {
     assertThat(webHdfsNodeAdapter.getSystemName(), is("webHDFS"));
   }
 
-  @Ignore
   @SuppressWarnings("unchecked")
   @Test
   public void testQuery() throws IOException {
@@ -198,9 +196,8 @@ public class WebHdfsNodeAdapterTest {
 
     // and the query response contains the metadata with the expected values
     // object
-    String id = "9705ed4a-607d-4746-b368-45222b217327";
-
-    assertThat(metadata.getId(), is(id));
+    assertThat(metadata.getId().charAt(14), is('4')); // indicating version-4 UUID
+    assertThat(metadata.getId().length(), is(36)); // 32 digits, plus 4 -'s
     assertThat(metadata.getMetadataModified(), is(fileDate));
     assertThat(metadata.getResourceUri().toString(), is("http://host:1234/some/path/file1.ext"));
     assertThat(metadata.getResourceModified(), is(fileDate));
@@ -210,7 +207,7 @@ public class WebHdfsNodeAdapterTest {
     Map<String, MetadataAttribute> metadataAttributes =
         (Map<String, MetadataAttribute>) metadata.getRawMetadata();
 
-    assertThat(metadataAttributes.get("id").getValue(), is(id));
+    assertThat(metadataAttributes.get("id").getValue(), is(metadata.getId()));
     assertThat(metadataAttributes.get("title").getValue(), is("file1.ext"));
     assertThat(metadataAttributes.get("created").getValue(), is(fileDate.toString()));
     assertThat(metadataAttributes.get("modified").getValue(), is(fileDate.toString()));
@@ -218,10 +215,8 @@ public class WebHdfsNodeAdapterTest {
         metadataAttributes.get("resource-uri").getValue(),
         is("http://host:1234/some/path/file1.ext"));
     assertThat(metadataAttributes.get("resource-size").getValue(), is("251"));
-    assertThat(metadataAttributes.get("replication.origins").getValue(), is("HDFS"));
   }
 
-  @Ignore
   @SuppressWarnings("unchecked")
   @Test
   public void testCreateMetadata() {
@@ -243,14 +238,14 @@ public class WebHdfsNodeAdapterTest {
     when(fileStatus.getType()).thenReturn("FILE");
     when(fileStatus.getLength()).thenReturn(251);
 
-    //    String hashedId = DigestUtils.md5Hex(filename).toUpperCase();
-
     // and createMetadata is called
     Metadata metadata = webHdfsNodeAdapter.createMetadata(fileStatus);
 
     // then the resulting metadata object will have values corresponding to the FileStatus object
-    //    assertThat(metadata.getId(), is(hashedId));
-    assertThat(metadata.getMetadataModified(), is(date));
+    assertThat(metadata.getId().charAt(14), is('4')); // indicating version-4 UUID
+    assertThat(
+        metadata.getId().length(),
+        is(36)); // 32 digits, plus 4 -'s    assertThat(metadata.getMetadataModified(), is(date));
     assertThat(metadata.getResourceUri().toString(), is("http://host:1234/some/path/test.txt"));
     assertThat(metadata.getResourceModified(), is(date));
     assertThat(metadata.getResourceSize(), is(251L));
@@ -258,7 +253,7 @@ public class WebHdfsNodeAdapterTest {
     // and the metadata object's attributes will have values corresponding to the FileStatus object
     Map<String, MetadataAttribute> metadataAttributes =
         (Map<String, MetadataAttribute>) metadata.getRawMetadata();
-    //    assertThat(metadataAttributes.get("id").getValue(), is(hashedId));
+    assertThat(metadataAttributes.get("id").getValue(), is(metadata.getId()));
     assertThat(metadataAttributes.get("title").getValue(), is(filename));
     assertThat(metadataAttributes.get("created").getValue(), is(date.toString()));
     assertThat(metadataAttributes.get("modified").getValue(), is(date.toString()));
@@ -266,10 +261,8 @@ public class WebHdfsNodeAdapterTest {
         metadataAttributes.get("resource-uri").getValue(),
         is("http://host:1234/some/path/test.txt"));
     assertThat(metadataAttributes.get("resource-size").getValue(), is("251"));
-    assertThat(metadataAttributes.get("replication.origins").getValue(), is("HDFS"));
   }
 
-  @Ignore
   @Test
   public void testCreateMetadataBadUri() {
     FileStatus fileStatus = mock(FileStatus.class);

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -50,6 +50,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
@@ -282,6 +284,27 @@ public class WebHdfsNodeAdapterTest {
     webHdfsNodeAdapter.createMetadata(fileStatus);
   }
 
+  @Test
+  public void testGetRelevantFilesNullFilterDate() {
+
+    FileStatus file1 = new FileStatus();
+    file1.setType("FILE");
+    FileStatus file2 = new FileStatus();
+    file2.setType("DIRECTORY");
+    FileStatus file3 = new FileStatus();
+    file3.setType("FILE");
+
+    List<FileStatus> files = Stream.of(file1, file2, file3).collect(Collectors.toList());
+
+    // when getting a list of relevant files with no specified filter date
+    List<FileStatus> result = webHdfsNodeAdapter.getRelevantFiles(files, null);
+
+    // then all items of type FILE are returned
+    assertThat(result.get(0), is(file1));
+    assertThat(result.get(1), is(file3));
+    assertThat(result.size(), is(2));
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void testGetFilesToReplicate() throws IOException {
@@ -314,7 +337,7 @@ public class WebHdfsNodeAdapterTest {
     FileStatus file2 = getFileStatus(afterFilter1, "file2.ext", "FILE", 222);
     FileStatus file3 = getFileStatus(afterFilter2, "someDirectory", "DIRECTORY", 0);
 
-    List<FileStatus> files1 = Arrays.asList(file1, file2, file3);
+    List<FileStatus> files1 = Stream.of(file1, file2, file3).collect(Collectors.toList());
 
     // and there are two additional entries to retrieve
     String idl1 = getIterativeDirectoryListingAsString(files1, 2);

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -218,6 +218,7 @@ public class WebHdfsNodeAdapterTest {
         metadataAttributes.get("resource-uri").getValue(),
         is("http://host:1234/some/path/file1.ext"));
     assertThat(metadataAttributes.get("resource-size").getValue(), is("251"));
+    assertThat(metadataAttributes.get("replication.origins").getValue(), is("HDFS"));
   }
 
   @SuppressWarnings("unchecked")
@@ -264,6 +265,7 @@ public class WebHdfsNodeAdapterTest {
         metadataAttributes.get("resource-uri").getValue(),
         is("http://host:1234/some/path/test.txt"));
     assertThat(metadataAttributes.get("resource-size").getValue(), is("251"));
+    assertThat(metadataAttributes.get("replication.origins").getValue(), is("HDFS"));
   }
 
   @Test

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -195,9 +195,8 @@ public class WebHdfsNodeAdapterTest {
     Metadata metadata = Iterables.get(metadataIterable, 0);
 
     // and the query response contains the metadata with the expected values
-    // object
-    assertThat(metadata.getId().charAt(14), is('4')); // indicating version-4 UUID
-    assertThat(metadata.getId().length(), is(36)); // 32 digits, plus 4 -'s
+    assertThat(metadata.getId().charAt(14), is('4')); // indicates version-4 UUID
+    assertThat(metadata.getId().length(), is(36)); // 32 digits, plus 4 hyphens
     assertThat(metadata.getMetadataModified(), is(fileDate));
     assertThat(metadata.getResourceUri().toString(), is("http://host:1234/some/path/file1.ext"));
     assertThat(metadata.getResourceModified(), is(fileDate));
@@ -243,9 +242,8 @@ public class WebHdfsNodeAdapterTest {
 
     // then the resulting metadata object will have values corresponding to the FileStatus object
     assertThat(metadata.getId().charAt(14), is('4')); // indicating version-4 UUID
-    assertThat(
-        metadata.getId().length(),
-        is(36)); // 32 digits, plus 4 -'s    assertThat(metadata.getMetadataModified(), is(date));
+    assertThat(metadata.getId().length(), is(36)); // 32 digits, plus 4 hyphens
+    assertThat(metadata.getMetadataModified(), is(date));
     assertThat(metadata.getResourceUri().toString(), is("http://host:1234/some/path/test.txt"));
     assertThat(metadata.getResourceModified(), is(date));
     assertThat(metadata.getResourceSize(), is(251L));
@@ -353,8 +351,8 @@ public class WebHdfsNodeAdapterTest {
     when(response.getStatusLine()).thenReturn(statusLine);
     when(statusLine.getStatusCode()).thenReturn(200);
 
-    // and the first response contains the first set of files and the second response contains the
-    // second set of files
+    // and the first response contains the first set of files
+    // and the second response contains the second set of files
     HttpEntity httpEntity = mock(HttpEntity.class);
     when(response.getEntity()).thenReturn(httpEntity);
     when(httpEntity.getContent()).thenReturn(inputStream1).thenReturn(inputStream2);
@@ -374,7 +372,7 @@ public class WebHdfsNodeAdapterTest {
     // then there are three files that fit the criteria
     assertThat(filesToReplicate.size() == 3, is(true));
 
-    // and the modification dates on the files are those meeting the filter criteria
+    // and the modification dates on the results are more recent than the filter date
     assertThat(filesToReplicate.get(0).getModificationTime().compareTo(filter), is(1));
     assertThat(filesToReplicate.get(1).getModificationTime().compareTo(filter), is(1));
     assertThat(filesToReplicate.get(2).getModificationTime().compareTo(filter), is(1));
@@ -415,7 +413,7 @@ public class WebHdfsNodeAdapterTest {
         .when(client)
         .execute(any(HttpGet.class), any(ResponseHandler.class));
 
-    // then a replication exception is thrown and
+    // then a replication exception is thrown
     thrown.expect(ReplicationException.class);
     thrown.expectMessage("List Status Batch request failed with status code: 400");
 

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -52,7 +52,6 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -73,6 +72,7 @@ import org.codice.ditto.replication.api.data.ResourceRequest;
 import org.codice.ditto.replication.api.data.ResourceResponse;
 import org.codice.ditto.replication.api.data.UpdateStorageRequest;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -141,6 +141,7 @@ public class WebHdfsNodeAdapterTest {
     assertThat(webHdfsNodeAdapter.getSystemName(), is("webHDFS"));
   }
 
+  @Ignore
   @SuppressWarnings("unchecked")
   @Test
   public void testQuery() throws IOException {
@@ -197,10 +198,9 @@ public class WebHdfsNodeAdapterTest {
 
     // and the query response contains the metadata with the expected values
     // object
-    String hashedId = DigestUtils.md5Hex("file1.ext").toUpperCase();
-    ;
+    String id = "9705ed4a-607d-4746-b368-45222b217327";
 
-    assertThat(metadata.getId(), is(hashedId));
+    assertThat(metadata.getId(), is(id));
     assertThat(metadata.getMetadataModified(), is(fileDate));
     assertThat(metadata.getResourceUri().toString(), is("http://host:1234/some/path/file1.ext"));
     assertThat(metadata.getResourceModified(), is(fileDate));
@@ -210,7 +210,7 @@ public class WebHdfsNodeAdapterTest {
     Map<String, MetadataAttribute> metadataAttributes =
         (Map<String, MetadataAttribute>) metadata.getRawMetadata();
 
-    assertThat(metadataAttributes.get("id").getValue(), is(hashedId));
+    assertThat(metadataAttributes.get("id").getValue(), is(id));
     assertThat(metadataAttributes.get("title").getValue(), is("file1.ext"));
     assertThat(metadataAttributes.get("created").getValue(), is(fileDate.toString()));
     assertThat(metadataAttributes.get("modified").getValue(), is(fileDate.toString()));
@@ -221,6 +221,7 @@ public class WebHdfsNodeAdapterTest {
     assertThat(metadataAttributes.get("replication.origins").getValue(), is("HDFS"));
   }
 
+  @Ignore
   @SuppressWarnings("unchecked")
   @Test
   public void testCreateMetadata() {
@@ -242,13 +243,13 @@ public class WebHdfsNodeAdapterTest {
     when(fileStatus.getType()).thenReturn("FILE");
     when(fileStatus.getLength()).thenReturn(251);
 
-    String hashedId = DigestUtils.md5Hex(filename).toUpperCase();
+    //    String hashedId = DigestUtils.md5Hex(filename).toUpperCase();
 
     // and createMetadata is called
     Metadata metadata = webHdfsNodeAdapter.createMetadata(fileStatus);
 
     // then the resulting metadata object will have values corresponding to the FileStatus object
-    assertThat(metadata.getId(), is(hashedId));
+    //    assertThat(metadata.getId(), is(hashedId));
     assertThat(metadata.getMetadataModified(), is(date));
     assertThat(metadata.getResourceUri().toString(), is("http://host:1234/some/path/test.txt"));
     assertThat(metadata.getResourceModified(), is(date));
@@ -257,7 +258,7 @@ public class WebHdfsNodeAdapterTest {
     // and the metadata object's attributes will have values corresponding to the FileStatus object
     Map<String, MetadataAttribute> metadataAttributes =
         (Map<String, MetadataAttribute>) metadata.getRawMetadata();
-    assertThat(metadataAttributes.get("id").getValue(), is(hashedId));
+    //    assertThat(metadataAttributes.get("id").getValue(), is(hashedId));
     assertThat(metadataAttributes.get("title").getValue(), is(filename));
     assertThat(metadataAttributes.get("created").getValue(), is(date.toString()));
     assertThat(metadataAttributes.get("modified").getValue(), is(date.toString()));
@@ -268,6 +269,7 @@ public class WebHdfsNodeAdapterTest {
     assertThat(metadataAttributes.get("replication.origins").getValue(), is("HDFS"));
   }
 
+  @Ignore
   @Test
   public void testCreateMetadataBadUri() {
     FileStatus fileStatus = mock(FileStatus.class);
@@ -275,7 +277,7 @@ public class WebHdfsNodeAdapterTest {
     // when a bad filename is utilized to generate a URI
     Date date = new Date();
     when(fileStatus.getModificationTime()).thenReturn(date);
-    String badFilename = "?* !";
+    String badFilename = "* !";
     when(fileStatus.getPathSuffix()).thenReturn(badFilename);
     when(fileStatus.getType()).thenReturn("FILE");
 

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -24,7 +24,7 @@
 
   <name>Replication :: Commons</name>
   <artifactId>commons</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
 
   <dependencies>
     <dependency>
@@ -53,6 +53,17 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Export-Package>com.connexta.replication.data</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/commons/src/main/java/com/connexta/replication/data/MetadataAttribute.java
+++ b/commons/src/main/java/com/connexta/replication/data/MetadataAttribute.java
@@ -11,13 +11,13 @@
  * License is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-package com.connexta.replication.adapters.ddf;
+package com.connexta.replication.data;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class MetacardAttribute {
+public class MetadataAttribute {
 
   private String name;
 
@@ -27,14 +27,14 @@ public class MetacardAttribute {
 
   private List<String> xmlns;
 
-  public MetacardAttribute(String name, String type, List<String> values, List<String> xmlns) {
+  public MetadataAttribute(String name, String type, List<String> values, List<String> xmlns) {
     this.name = name;
     this.type = type;
     this.values = values;
     this.xmlns = xmlns;
   }
 
-  public MetacardAttribute(String name, String type, String value) {
+  public MetadataAttribute(String name, String type, String value) {
     this.name = name;
     this.type = type;
     this.values = Collections.singletonList(value);

--- a/distributions/osgi/features/replication/src/main/feature/feature.xml
+++ b/distributions/osgi/features/replication/src/main/feature/feature.xml
@@ -36,6 +36,7 @@
         <bundle>mvn:replication/replication-api-impl/${project.version}</bundle>
         <bundle>mvn:replication/replication-admin-query/${project.version}</bundle>
         <bundle>mvn:replication/replication-ui/${project.version}</bundle>
+        <bundle>mvn:replication/commons/${project.version}</bundle>
         <bundle>mvn:replication-adapters/ddf-adapter/${project.version}</bundle>
         <bundle>mvn:replication-adapters/webhdfs-adapter/${project.version}</bundle>
     </feature>

--- a/ui/src/main/webapp/components/sites/AddSite.js
+++ b/ui/src/main/webapp/components/sites/AddSite.js
@@ -158,7 +158,7 @@ const AddSite = class extends React.Component {
               type='text'
               onChange={this.handleChange('rootContext')}
               fullWidth
-              helperText='The path under which the replication services can be found. Typically this is under `services` for DDF-based nodes. HDFS-based systems require entering the full path after the port; ie `/webhdfs/v1/desiredDrectoryPath`'
+              helperText='The path under which the replication services can be found. Typically this is under `services` for DDF-based nodes. HDFS-based systems require entering the full path after the port; ie `/webhdfs/v1/desiredDirectoryPath`'
               value={rootContext}
             />
           </DialogContent>


### PR DESCRIPTION
#### What does this PR do?
- Implements the query method in the WebHdfsNodeAdapter, to allow replication from an HDFS instance to a DIB.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@aaronilovici 
@mdang8 
@josephthweatt 

#### How should this be tested? (List steps with links to updated documentation)
1. Modify your HDFS site properties file at `etc/hadoop/hdfs-site.xml`:
```
<property>
    <name>dfs.ls.limit</name>
    <value>3</value>
</property>
```
    
This specifies the maximum number of entries that can be returned by a single `ls` command on HDFS.  This is useful to test the iterative nature of this implementation to retrieve _all_ results, so you can easily place more files on your HDFS instance than can be returned in a single response.

2. Setup a local HDFS instance
3. Setup a DIB locally
4. Install the kar generated using this branch
5. Setup a replication from your HDFS instance to your DIB instance
6. Upload a file to your HDFS instance
7. Confirm the file exists in your DIB after the next run of Replication

#### Any background context you want to provide?

#### What are the relevant tickets?
[DIB-9599](https://jira.di2e.net/browse/DIB-9599)

#### Screenshots (if appropriate)
N/A
#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests --> will be done in a separate pull request
