### PR TITLE
Fix WebHDFS adapter query to retry failed resources

### DIFF
--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -154,7 +154,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
     List<String> failedItemIds = queryRequest.getFailedItemIds();
 
     if (!failedItemIds.isEmpty()) {
-      LOGGER.info("Found failed item IDs: " + failedItemIds);
+      LOGGER.info(String.format("Found failed item IDs: %s", failedItemIds));
     }
 
     List<FileStatus> filesToReplicate =
@@ -277,6 +277,7 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
    * additional results if the file system contains more results than can be returned in a single
    * response.
    *
+   * @param failedItemIds the list of IDs that failed to be created
    * @param filterDate specifies a point in time such that only files more recent are returned
    * @return a resulting {@code List} of {@link FileStatus} objects meeting the criteria
    */
@@ -385,9 +386,8 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
 
     // generates the UUID of the file to lookup if it is a failed ID
     String id = getVersion4Uuid(fileUrl, modificationTime);
-    boolean isFailedId = failedIds.contains(id);
 
-    return isFailedId;
+    return failedIds.contains(id);
   }
 
   @Override

--- a/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
+++ b/adapters/webhdfs-adapter/src/main/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapter.java
@@ -345,15 +345,23 @@ public class WebHdfsNodeAdapter implements NodeAdapter {
   }
 
   /**
-   * Returns the files meeting the criteria for replication by only including elements that: 1) are
-   * of type FILE or 2) have a modification time after the filter date or 3) have a UUID matching
-   * one of the items in the failed IDs list
+   * Takes a list of {@link FileStatus} and returns only the ones that are relevant to the current
+   * replication run. Relevancy is determined by meeting the following criteria:
    *
-   * @param files a {@code List} of all {@link FileStatus} objects returned by the GET request
-   * @param failedItemIds a {@code List} of the IDs that failed to be created
-   * @param filterDate specifies a point in time such that only files more recent are included; this
-   *     value will be set to {@code null} during the first execution of replication
-   * @return a resulting {@code List} of {@link FileStatus} objects meeting the criteria
+   * <ol>
+   *   <li>It is of type "FILE". A valid {@link FileStatus} can be either a directory or a file.
+   *   <li>It has a modification date after the {@code filterDate} OR it has a UUID matching one in
+   *       the failed IDs list
+   * </ol>
+   *
+   * <p>For the case when a replication job is first run and the {@code filterDate} is null, all
+   * files will be included in the returned results.
+   *
+   * @param files - the list of {@link FileStatus} to be filtered down
+   * @param failedItemIds - the list of failed IDs from the previous replication run
+   * @param filterDate - the date to use in filtering so that all files modified after will be
+   *     included; this value will be set to {@code null} on the first replication run
+   * @return A list of {@link FileStatus} that have met the relevancy criteria.
    */
   @VisibleForTesting
   List<FileStatus> getRelevantFiles(

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -302,7 +302,6 @@ public class WebHdfsNodeAdapterTest {
 
     QueryResponse queryResponse = webHdfsNodeAdapter.query(queryRequest);
 
-    // expected sort order: failedFile2, failedFile1, file1, failedFile3
     Iterable<Metadata> metadataIterable = queryResponse.getMetadata();
     Metadata metadata1 = Iterables.get(metadataIterable, 0);
     Metadata metadata2 = Iterables.get(metadataIterable, 1);

--- a/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
+++ b/adapters/webhdfs-adapter/src/test/java/com/connexta/replication/adapters/webhdfs/WebHdfsNodeAdapterTest.java
@@ -302,21 +302,27 @@ public class WebHdfsNodeAdapterTest {
 
     QueryResponse queryResponse = webHdfsNodeAdapter.query(queryRequest);
 
+    // expected sort order: failedFile2, failedFile1, file1, failedFile3
     Iterable<Metadata> metadataIterable = queryResponse.getMetadata();
-    Metadata failedFile2Metadata = Iterables.get(metadataIterable, 0);
-    Metadata failedFile1Metadata = Iterables.get(metadataIterable, 1);
-    Metadata file1Metadata = Iterables.get(metadataIterable, 2);
-    Metadata failedFile3Metadata = Iterables.get(metadataIterable, 3);
+    Metadata metadata1 = Iterables.get(metadataIterable, 0);
+    Metadata metadata2 = Iterables.get(metadataIterable, 1);
+    Metadata metadata3 = Iterables.get(metadataIterable, 2);
+    Metadata metadata4 = Iterables.get(metadataIterable, 3);
     int metadataIterableSize =
         (int) StreamSupport.stream(metadataIterable.spliterator(), false).count();
 
     assertThat(metadataIterableSize, is(4));
     assertThat(
-        failedFile1Metadata.getResourceUri().toString(),
+        metadata1.getResourceUri().toString(),
+        is(String.format("%s%s", WEBHDFS_URL, "failed-file2.ext")));
+    assertThat(
+        metadata2.getResourceUri().toString(),
         is(String.format("%s%s", WEBHDFS_URL, "failed-file1.ext")));
     assertThat(
-        file1Metadata.getResourceUri().toString(),
-        is(String.format("%s%s", WEBHDFS_URL, "file1.ext")));
+        metadata3.getResourceUri().toString(), is(String.format("%s%s", WEBHDFS_URL, "file1.ext")));
+    assertThat(
+        metadata4.getResourceUri().toString(),
+        is(String.format("%s%s", WEBHDFS_URL, "failed-file3.ext")));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
#### What does this PR do?

Fixes the query method for the WebHDFS adapter to include failed resources from previous replication runs. The `QueryRequest` passed to the query method contains a list of failed item IDs from the previous run of replication. These items should be included in the next run to retry creating them in DDF.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@cjlange 
@aaronilovici 
@josephthweatt 

#### How should this be tested? (List steps with links to updated documentation)

1. Build and install replication.
2. Configure a replication job with the HDFS instance as the source and DDF as the destination.
3. Upload some files to HDFS to be replicated.
4. Connect a remote debugger to DDF and set a breakpoint on line 302 in `DdfNodeAdapter`.
5. When the breakpoint gets hit, set the value of the `response` variable to `null`.
6. Resume execution in the debugger and verify an error for creating the metadata gets printed in the logs.
7. On the next replication run, verify a line gets printed in the logs that says "Found failed item IDs: [...]" with the failed ID inside the brackets.
8. Verify the failed item gets successfully replicated after that run.

#### Any background context you want to provide?

Integration tests are not included in this pull request.

#### What are the relevant tickets?
Fixes #331 

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
