### PR TITLE
Update DDF version to 2.25.2

### DIFF
--- a/adapters/ddf-adapter/pom.xml
+++ b/adapters/ddf-adapter/pom.xml
@@ -52,8 +52,8 @@
       <version>${ddf.version}</version>
     </dependency>
     <dependency>
-      <groupId>ddf.security</groupId>
-      <artifactId>ddf-security-common</artifactId>
+      <groupId>ddf.security.core</groupId>
+      <artifactId>security-core-services</artifactId>
       <version>${ddf.version}</version>
     </dependency>
     <dependency>
@@ -69,9 +69,9 @@
 
     <!-- XML dependencies -->
     <dependency>
-      <groupId>org.jvnet.ogc</groupId>
+      <groupId>io.github.soc</groupId>
       <artifactId>ogc-tools-gml-jts</artifactId>
-      <version>${ogc.tools.version}</version>
+      <version>${ogc-tools-gml-jts.version}</version>
     </dependency>
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
@@ -105,6 +105,26 @@
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.codice.ddf</groupId>
+      <artifactId>alerts</artifactId>
+      <version>${ddf.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>${httpcore.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>${google-http-client.version}</version>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>junit</groupId>
@@ -113,6 +133,15 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.woodstox</groupId>
+        <artifactId>woodstox-core</artifactId>
+        <version>${woodstox.core.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <resources>
@@ -164,9 +193,12 @@
               *
             </Import-Package>
             <Embed-Dependency>
+              alerts,
+              httpcore,
+              httpclient,
+              google-http-client,
               commons-collections4,
               ogc-tools-gml-jts,
-              ddf-security-common,
               platform-util,
               jaxb-core,
               commons-lang3

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/CswRecordConverter.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/CswRecordConverter.java
@@ -226,7 +226,7 @@ public class CswRecordConverter implements Converter {
     }
 
     MetadataImpl metadata = new MetadataImpl(metadataMap, Map.class, id, metacardModified);
-    if (metadataMap.get(RESOURCE_SIZE) != null) {
+    if (metadataMap.get(RESOURCE_SIZE) != null && metadataMap.get(RESOURCE_URI) != null) {
       metadata.setResourceSize(Long.parseLong(metadataMap.get(RESOURCE_SIZE).getValue()));
       metadata.setResourceModified(convertToDate(metadataMap.get(MODIFIED)));
 

--- a/adapters/webhdfs-adapter/pom.xml
+++ b/adapters/webhdfs-adapter/pom.xml
@@ -117,8 +117,51 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.soc</groupId>
+            <artifactId>ogc-tools-gml-jts</artifactId>
+            <version>${ogc-tools-gml-jts.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>${google-http-client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-services</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>alerts</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics-runtime</artifactId>
+            <version>${jvnet.jaxb2.version}</version>
+        </dependency>
     </dependencies>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${woodstox.core.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
@@ -172,13 +215,16 @@
                             *
                         </Import-Package>
                         <Embed-Dependency>
-                            commons-collections4,
+                            google-http-client,
+                            httpcore,
+                            httpclient,
+                            alerts,
+                            jaxb2-basics-runtime,
                             ogc-tools-gml-jts,
-                            ddf-security-common,
+                            security-core-impl,
                             mime-tika-resolver,
                             platform-util,
-                            jaxb-core,
-                            commons-lang3
+                            jaxb-core
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                     </instructions>

--- a/dependency-check-maven-config.xml
+++ b/dependency-check-maven-config.xml
@@ -358,4 +358,26 @@
         <cve>CVE-2018-1337</cve>
         <cve>CVE-2014-0114</cve>
     </suppress>
+    <suppress>
+        <notes>
+            This is from Shiro Core 1.5.3 and can only be removed when DDF uses an upgraded version
+        </notes>
+        <cve>CVE-2020-13933</cve>
+    </suppress>
+    <suppress>
+        <notes>
+            This is webhdfs adapter suppress set. It is not part of the deployment right now
+            netty-3.6.2.Final.jar: CVE-2019-16869, CVE-2019-20445, CVE-2019-20444
+            netty-all-4.0.23.Final.jar: CVE-2019-16869, CVE-2019-20445, CVE-2019-20444
+            htrace-core-3.1.0-incubating.jar CVE-2020-14195, CVE-2020-24616, CVE-2020-14060, CVE-2020-14061, CVE-2020-14062
+        </notes>
+        <cve>CVE-2019-16869</cve>
+        <cve>CVE-2019-20445</cve>
+        <cve>CVE-2019-20444</cve>
+        <cve>CVE-2020-14195</cve>
+        <cve>CVE-2020-24616</cve>
+        <cve>CVE-2020-14060</cve>
+        <cve>CVE-2020-14061</cve>
+        <cve>CVE-2020-14062</cve>
+    </suppress>
 </suppressions>

--- a/distributions/osgi/features/replication/src/main/feature/feature.xml
+++ b/distributions/osgi/features/replication/src/main/feature/feature.xml
@@ -40,6 +40,5 @@
         <bundle>mvn:replication/replication-ui/${project.version}</bundle>
         <bundle>mvn:replication/commons/${project.version}</bundle>
         <bundle>mvn:replication-adapters/ddf-adapter/${project.version}</bundle>
-        <bundle>mvn:replication-adapters/webhdfs-adapter/${project.version}</bundle>
     </feature>
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <releases.repository.url />
         <admin-query.version>1.3.2</admin-query.version>
         <ddf.support.version>2.3.16</ddf.support.version>
-        <ddf.version>2.21.5</ddf.version>
+        <ddf.version>2.25.2</ddf.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <surefire.version>2.20.1</surefire.version>
         <karaf.version>4.2.6</karaf.version>
@@ -44,11 +44,16 @@
         <commons.lang3.version>3.9</commons.lang3.version>
         <commons.collection4.version>4.1</commons.collection4.version>
         <guava.version>25.1-jre</guava.version>
+        <google-http-client.version>1.22.0</google-http-client.version>
+        <woodstox.core.version>5.3.0</woodstox.core.version>
         <ogc.version>1.1.0</ogc.version>
         <thirdparty.ogc.version>1.1.0_5</thirdparty.ogc.version>
-        <ogc.tools.version>1.0.3</ogc.tools.version>
+        <ogc-tools-gml-jts.version>1.1.90</ogc-tools-gml-jts.version>
         <jts.version>1.14.0</jts.version>
         <jaxb.version>2.2.11</jaxb.version>
+        <jvnet.jaxb2.version>0.11.0</jvnet.jaxb2.version>
+        <httpclient.version>4.5.6</httpclient.version>
+        <httpcore.version>4.4.10</httpcore.version>
         <cxf.frontend.version>3.2.12</cxf.frontend.version>
         <validation.version>1.1.0.Final</validation.version>
         <xstream.version>1.4.11.1</xstream.version>
@@ -73,7 +78,7 @@
         <directory.maven.plugin.version>0.3.1</directory.maven.plugin.version>
         <project.report.output.directory>project-info</project.report.output.directory>
         <jackson.version>2.10.3</jackson.version>
-        <tika.version>1.22</tika.version>
+        <tika.version>1.24.1</tika.version>
 
         <!-- documentation replacements -->
         <platform>DDF Base</platform>

--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -36,24 +36,25 @@
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
-            <groupId>ddf.security</groupId>
-            <artifactId>ddf-security-common</artifactId>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-impl</artifactId>
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.security.core</groupId>
-            <artifactId>security-core-impl</artifactId>
+            <artifactId>security-core-services</artifactId>
             <version>${ddf.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.platform.util</groupId>
             <artifactId>platform-util</artifactId>
             <version>${ddf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.platform.util</groupId>
-            <artifactId>platform-util-unavailableurls</artifactId>
-            <version>${ddf.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.jodah</groupId>
+                    <artifactId>failsafe</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ddf.persistence.core</groupId>
@@ -81,6 +82,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>${google-http-client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -128,7 +134,31 @@
             <artifactId>commons</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf</groupId>
+            <artifactId>alerts</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${httpcore.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${woodstox.core.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>
@@ -148,11 +178,14 @@
                             org.codice.ditto.replication.api.impl.data
                         </Export-Package>
                         <Embed-Dependency>
+                            alerts,
+                            failsafe,
+                            httpclient,
+                            httpcore,
+                            google-http-client,
                             commons-collections4,
                             catalog-core-api-impl,
-                            ddf-security-common,
                             platform-util,
-                            platform-util-unavailableurls,
                             commons-lang3,
                             security-core-impl,
                             commons

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorImpl.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 import net.jodah.failsafe.Failsafe;
 import net.jodah.failsafe.RetryPolicy;
 import org.apache.commons.collections4.queue.UnmodifiableQueue;
-import org.codice.ddf.security.common.Security;
+import org.codice.ddf.security.Security;
 import org.codice.ditto.replication.api.NodeAdapter;
 import org.codice.ditto.replication.api.NodeAdapterType;
 import org.codice.ditto.replication.api.ReplicationException;
@@ -73,15 +73,6 @@ public class ReplicatorImpl implements Replicator {
   private final Map<String, Syncer.Job> syncerJobMap = new ConcurrentHashMap<>();
 
   private final Security security;
-
-  public ReplicatorImpl(
-      NodeAdapters nodeAdapters,
-      ReplicatorHistoryManager history,
-      SiteManager siteManager,
-      ExecutorService executor,
-      Syncer syncer) {
-    this(nodeAdapters, history, siteManager, executor, syncer, Security.getInstance());
-  }
 
   public ReplicatorImpl(
       NodeAdapters nodeAdapters,

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorRunner.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ReplicatorRunner.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.codice.ddf.security.common.Security;
+import org.codice.ddf.security.Security;
 import org.codice.ditto.replication.api.Replicator;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.impl.data.ReplicationStatusImpl;
@@ -53,14 +53,6 @@ public class ReplicatorRunner {
       String.valueOf(TimeUnit.MINUTES.toSeconds(5));
 
   public ReplicatorRunner(
-      ScheduledExecutorService scheduledExecutor,
-      Replicator replicator,
-      ReplicatorConfigManager replicatorConfigManager) {
-    this(scheduledExecutor, replicator, replicatorConfigManager, Security.getInstance());
-  }
-
-  @VisibleForTesting
-  ReplicatorRunner(
       ScheduledExecutorService scheduledExecutor,
       Replicator replicator,
       ReplicatorConfigManager replicatorConfigManager,

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ScheduledReplicatorDeleter.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/ScheduledReplicatorDeleter.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.NotFoundException;
 import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.persistence.PersistenceException;
-import org.codice.ddf.security.common.Security;
+import org.codice.ddf.security.Security;
 import org.codice.ditto.replication.api.ReplicationItem;
 import org.codice.ditto.replication.api.ReplicationPersistenceException;
 import org.codice.ditto.replication.api.data.ReplicationStatus;
@@ -61,26 +61,8 @@ public class ScheduledReplicatorDeleter {
 
   private final int pageSize;
 
-  public ScheduledReplicatorDeleter(
-      ReplicatorConfigManager replicatorConfigManager,
-      ScheduledExecutorService scheduledExecutorService,
-      ReplicationItemManager replicationItemManager,
-      ReplicatorHistoryManager replicatorHistory,
-      Metacards metacards) {
-    this(
-        replicatorConfigManager,
-        scheduledExecutorService,
-        replicationItemManager,
-        replicatorHistory,
-        metacards,
-        Security.getInstance(),
-        TimeUnit.MINUTES.toMillis(1),
-        DEFAULT_PAGE_SIZE);
-  }
-
-  @VisibleForTesting
   @SuppressWarnings("squid:S00107" /* Only for testing */)
-  ScheduledReplicatorDeleter(
+  public ScheduledReplicatorDeleter(
       ReplicatorConfigManager replicatorConfigManager,
       ScheduledExecutorService scheduledExecutorService,
       ReplicationItemManager replicationItemManager,

--- a/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -20,6 +20,7 @@
     <reference id="catalog" interface="ddf.catalog.CatalogFramework"/>
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
     <reference id="xmlTransformer" interface="ddf.catalog.transform.InputTransformer" filter="(id=xml)" />
+    <reference id="security" interface="org.codice.ddf.security.Security" />
 
     <bean id="QueryService" class="org.codice.ditto.replication.api.impl.QueryServiceImpl">
         <argument ref="catalog"/>
@@ -45,6 +46,9 @@
         <argument ref="replicationItemManager"/>
         <argument ref="historyManager"/>
         <argument ref="metacards"/>
+        <argument ref="security"/>
+        <argument value="60000"/>
+        <argument value="1000"/>
     </bean>
 
     <bean id="replicationItemManager"
@@ -99,6 +103,7 @@
         <argument ref="siteManager"/>
         <argument ref="replicatorImplExecutor"/>
         <argument ref="syncer"/>
+        <argument ref="security"/>
     </bean>
 
     <service ref="replicator" interface="org.codice.ditto.replication.api.Replicator"/>
@@ -129,5 +134,6 @@
         <argument ref="replicatorRunnerExecutor"/>
         <argument ref="replicator"/>
         <argument ref="configManager"/>
+        <argument ref="security"/>
     </bean>
 </blueprint>

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorImplTest.java
@@ -28,7 +28,7 @@ import java.net.URL;
 import java.security.PrivilegedAction;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import org.codice.ddf.security.common.Security;
+import org.codice.ddf.security.impl.Security;
 import org.codice.ditto.replication.api.NodeAdapter;
 import org.codice.ditto.replication.api.NodeAdapterFactory;
 import org.codice.ditto.replication.api.NodeAdapterType;

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorRunnerTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ReplicatorRunnerTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-import org.codice.ddf.security.common.Security;
+import org.codice.ddf.security.impl.Security;
 import org.codice.ditto.replication.api.Replicator;
 import org.codice.ditto.replication.api.SyncRequest;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;

--- a/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ScheduledReplicatorDeleterTest.java
+++ b/replication-api-impl/src/test/java/org/codice/ditto/replication/api/impl/ScheduledReplicatorDeleterTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Stream;
 import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.persistence.PersistenceException;
-import org.codice.ddf.security.common.Security;
+import org.codice.ddf.security.impl.Security;
 import org.codice.ditto.replication.api.ReplicationItem;
 import org.codice.ditto.replication.api.ReplicationPersistenceException;
 import org.codice.ditto.replication.api.data.ReplicationStatus;

--- a/replication-api/pom.xml
+++ b/replication-api/pom.xml
@@ -30,8 +30,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>ddf.security</groupId>
-            <artifactId>ddf-security-common</artifactId>
+            <groupId>ddf.security.core</groupId>
+            <artifactId>security-core-impl</artifactId>
             <version>${ddf.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
#### What does this PR do?
Update DDF version to 2.25.2
NOTE: WebHDFS adapter has been disabled for now

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@cjlange 
@aaronilovici 
#### How should this be tested? (List steps with links to updated documentation)
Install and verify basic DDF replication capability on a DDF 2.25.2 based system.
#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #XXXX

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
