### PR TITLE
Add site and configuration load from file

### DIFF
--- a/replication-api-impl/pom.xml
+++ b/replication-api-impl/pom.xml
@@ -139,6 +139,11 @@
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/ReplicatorConfigManagerImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/persistence/ReplicatorConfigManagerImpl.java
@@ -13,18 +13,72 @@
  */
 package org.codice.ditto.replication.api.impl.persistence;
 
+import com.google.gson.Gson;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.NotFoundException;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import org.codice.ditto.replication.api.ReplicationPersistenceException;
 import org.codice.ditto.replication.api.data.ReplicatorConfig;
 import org.codice.ditto.replication.api.impl.data.ReplicatorConfigImpl;
 import org.codice.ditto.replication.api.persistence.ReplicatorConfigManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ReplicatorConfigManagerImpl implements ReplicatorConfigManager {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReplicatorConfigManagerImpl.class);
+
   private ReplicationPersistentStore persistentStore;
+
+  private static final int RETRY_DELAY_SEC = 5;
+
+  private static final int RETRY_DURATION_MIN = 5;
+
+  private static final String REPLICATION_CONFIG_FILE = "/etc/replication-configs.json";
 
   public ReplicatorConfigManagerImpl(ReplicationPersistentStore persistentStore) {
     this.persistentStore = persistentStore;
+  }
+
+  public void init() {
+    RetryPolicy retryPolicy =
+        new RetryPolicy()
+            .withDelay(RETRY_DELAY_SEC, TimeUnit.SECONDS)
+            .withMaxDuration(RETRY_DURATION_MIN, TimeUnit.MINUTES)
+            .retryOn(ReplicationPersistenceException.class);
+
+    Failsafe.with(retryPolicy).run(this::loadConfigsFromFile);
+  }
+
+  /** Add replication configurations from file if they don't already exist */
+  void loadConfigsFromFile() {
+    String basePath = System.getProperty("karaf.home", "./");
+    File sitesFile = new File(basePath + REPLICATION_CONFIG_FILE);
+    if (!sitesFile.exists()) {
+      return;
+    }
+    Gson gson = new Gson();
+    Set<String> existingConfigs =
+        this.objects().map(ReplicatorConfig::getId).collect(Collectors.toSet());
+    try {
+      ReplicatorConfigImpl[] configs =
+          gson.fromJson(new FileReader(sitesFile), ReplicatorConfigImpl[].class);
+      for (ReplicatorConfigImpl config : configs) {
+        if (!existingConfigs.contains(config.getId())) {
+          this.save(config);
+        }
+      }
+    } catch (FileNotFoundException e) {
+      LOGGER.warn("Could not load replication config: {}", e.getMessage());
+      LOGGER.debug("Replication config load error: ", e);
+    }
   }
 
   @Override

--- a/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/replication-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -73,7 +73,7 @@
         <argument ref="filterBuilder"/>
     </bean>
 
-    <bean id="configManager" class="org.codice.ditto.replication.api.impl.persistence.ReplicatorConfigManagerImpl">
+    <bean id="configManager" class="org.codice.ditto.replication.api.impl.persistence.ReplicatorConfigManagerImpl" init-method="init">
         <argument ref="replicationPersistentStore"/>
     </bean>
 

--- a/replication-api-impl/src/test/resources/etc/replication-configs.json
+++ b/replication-api-impl/src/test/resources/etc/replication-configs.json
@@ -1,0 +1,11 @@
+[
+  {
+    "bidirectional":"false",
+    "name":"config-test",
+    "id":"test-confg-id",
+    "destination":"destination-1",
+    "source":"source-1",
+    "filter":"(\"anyText\" ILIKE 'asdf')",
+    "retry_count": 5
+  }
+]

--- a/replication-api-impl/src/test/resources/etc/replication-sites.json
+++ b/replication-api-impl/src/test/resources/etc/replication-sites.json
@@ -1,0 +1,12 @@
+[
+  {
+    "url":"https://src:8993/services",
+    "name":"src",
+    "id":"source-1"
+ },
+ {
+    "url":"https://dest:8993/services",
+    "name":"dest",
+    "id":"destination-1"
+ }
+]


### PR DESCRIPTION
#### What does this PR do?
Adds ability to load initial sites and replication configurations from file

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@aaronilovici 

#### How should this be tested? (List steps with links to updated documentation)
Drop site and replication config files in etc and restart replication. 
Verify that the new sites and replications show up in the ui
