### PR TITLE
NA-47 Location attribute doesn't get replicated over for metacards without resource

### DIFF
--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/Constants.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/Constants.java
@@ -13,6 +13,9 @@
  */
 package com.connexta.replication.adapters.ddf.csw;
 
+import java.util.Arrays;
+import java.util.List;
+
 public final class Constants {
 
   private Constants() {}
@@ -52,6 +55,8 @@ public final class Constants {
   public static final String METACARD_SCHEMA = "urn:catalog:metacard";
 
   public static final String RAW_METADATA_KEY = "raw-metadata";
+
+  public static final List<String> COMPLEX_TYPES = Arrays.asList("geometry", "stringxml");
 
   // CSW constants
   public static final String NAMESPACE_DECLARATIONS = "NAMESPACE_DECLARATIONS";

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/CswRecordConverter.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/CswRecordConverter.java
@@ -14,6 +14,7 @@
 package com.connexta.replication.adapters.ddf.csw;
 
 import static com.connexta.replication.adapters.ddf.csw.Constants.ACTION;
+import static com.connexta.replication.adapters.ddf.csw.Constants.COMPLEX_TYPES;
 import static com.connexta.replication.adapters.ddf.csw.Constants.DERIVED_RESOURCE_DOWNLOAD_URL;
 import static com.connexta.replication.adapters.ddf.csw.Constants.DERIVED_RESOURCE_URI;
 import static com.connexta.replication.adapters.ddf.csw.Constants.METACARD_ID;
@@ -46,7 +47,6 @@ import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -75,8 +75,6 @@ public class CswRecordConverter implements Converter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CswRecordConverter.class);
   private static final HierarchicalStreamCopier COPIER = new HierarchicalStreamCopier();
-
-  private static final List<String> COMPLEX_TYPE = Arrays.asList("geometry", "stringxml");
 
   @Override
   public boolean canConvert(Class clazz) {
@@ -277,7 +275,9 @@ public class CswRecordConverter implements Converter {
         continue;
       }
 
-      if (COMPLEX_TYPE.contains(entryType)) {
+      String trimmedType = entryType.substring(entryType.indexOf(':') + 1);
+
+      if (COMPLEX_TYPES.contains(trimmedType)) {
         reader.moveDown();
         reader.moveDown();
         StringWriter xmlWriter = new StringWriter();

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/MetacardMarshaller.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/csw/MetacardMarshaller.java
@@ -13,6 +13,7 @@
  */
 package com.connexta.replication.adapters.ddf.csw;
 
+import static com.connexta.replication.adapters.ddf.csw.Constants.COMPLEX_TYPES;
 import static com.connexta.replication.adapters.ddf.csw.Constants.DEFAULT_METACARD_TYPE_NAME;
 
 import com.connexta.replication.data.MetadataAttribute;
@@ -120,7 +121,9 @@ public class MetacardMarshaller {
 
         writer.startNode("value");
 
-        if (format.equals("stringxml") || format.equals("geometry")) {
+        String trimmedFormat = format.substring(format.indexOf(':') + 1);
+
+        if (COMPLEX_TYPES.contains(trimmedFormat)) {
           writer.setRawValue(value);
         } else {
           writer.setValue(value);

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/rest/DdfRestClient.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/rest/DdfRestClient.java
@@ -17,6 +17,7 @@ import com.connexta.replication.adapters.ddf.csw.MetacardMarshaller;
 import com.connexta.replication.data.ResourceImpl;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -120,6 +121,8 @@ public class DdfRestClient {
         .query("transform", "resource")
         .accept(MediaType.APPLICATION_OCTET_STREAM);
     Response response = webClient.get();
+    URI resourceUri = webClient.getCurrentURI();
+    webClient.reset();
     if (!response.getStatusInfo().getFamily().equals(Family.SUCCESSFUL)) {
       throw new AdapterException(
           "Failed to retrieve resource. Received status code: " + response.getStatus());
@@ -133,7 +136,7 @@ public class DdfRestClient {
     return new ResourceImpl(
         metadata.getId(),
         name,
-        webClient.getCurrentURI(),
+        resourceUri,
         null,
         (InputStream) response.getEntity(),
         response.getMediaType().toString(),


### PR DESCRIPTION
#### What does this PR do?
Fixed two issues: 
1. The location attribute wasn't always getting replicated over when replicating a metacard with no resource. This was due to logic expecting the `geometry` xml tag to not be namespaced. Because it can be namespaced (for example, <ns2:geometry> instead of just <geometry>), I added logic to trim off the namespace before doing the existing check.

2. Added a webClient.reset() call in the get method of DdfRestClient. Because we are using the same WebClient instance, without a call to reset, the path and query parameters kept appending to one another on subsequent calls to the get method, creating invalid URLs. 

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard 
@shaundmorris 
@rececoffin

#### How should this be tested? (List steps with links to updated documentation)
1. Replicate a few metacards that have location attributes and no resources attached and verify the location values are properly replicated. 
2. Replicate a few metacards that do have resources attached and verify that they all get replicated over.

#### Any background context you want to provide?

#### What are the relevant tickets?
https://octoconsulting.atlassian.net/browse/NA-47

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
