### PR TITLE
Fix delete replications for bi-directional configurations

### DIFF
--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/DdfNodeAdapter.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/DdfNodeAdapter.java
@@ -345,8 +345,12 @@ public class DdfNodeAdapter implements NodeAdapter {
     LOGGER.debug("Base query filter: {}", cql);
     final List<String> filters = new ArrayList<>();
 
+    List<String> originFilters = new ArrayList<>();
     for (String excludedNode : queryRequest.getExcludedNodes()) {
-      filters.add(CqlBuilder.negate(CqlBuilder.equalTo(Replication.ORIGINS, excludedNode)));
+      originFilters.add(CqlBuilder.negate(CqlBuilder.equalTo(Replication.ORIGINS, excludedNode)));
+    }
+    if (!originFilters.isEmpty()) {
+      filters.addAll(originFilters);
     }
     filters.add(CqlBuilder.equalTo(Constants.METACARD_TAGS, Constants.DEFAULT_TAG));
 
@@ -369,7 +373,7 @@ public class DdfNodeAdapter implements NodeAdapter {
       deletedFilters.add(CqlBuilder.after(Constants.VERSIONED_ON, modifiedAfter));
       deletedFilters.add(CqlBuilder.equalTo(Constants.METACARD_TAGS, Constants.VERSION_TAG));
       deletedFilters.add(CqlBuilder.like(Constants.ACTION, "Deleted*"));
-
+      deletedFilters.addAll(originFilters);
       String timeTypeFilter = CqlBuilder.allOf(filters);
       String deletedItemsFilter = CqlBuilder.allOf(deletedFilters);
       LOGGER.debug("Time and type filter: {}", timeTypeFilter);

--- a/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/DdfNodeAdapterTest.java
+++ b/adapters/ddf-adapter/src/test/java/com/connexta/replication/adapters/ddf/DdfNodeAdapterTest.java
@@ -262,7 +262,7 @@ public class DdfNodeAdapterTest {
         adapter.createDdfQueryRequest(request).getCql(),
         is(
             String.format(
-                "[ [ [ title like '*' ] AND [ [ [ NOT [ \"replication.origins\" = 'node1' ] ] AND [ \"metacard-tags\" = 'resource' ] AND [ \"metacard.modified\" after %s ] ] OR [ [ \"metacard.version.versioned-on\" after %s ] AND [ \"metacard-tags\" = 'revision' ] AND [ \"metacard.version.action\" like 'Deleted*' ] ] ] ] OR [ [ [ \"metacard.version.id\" = '123456789' ] AND [ \"metacard.version.action\" like 'Deleted*' ] ] ] ]",
+                "[ [ [ title like '*' ] AND [ [ [ NOT [ \"replication.origins\" = 'node1' ] ] AND [ \"metacard-tags\" = 'resource' ] AND [ \"metacard.modified\" after %s ] ] OR [ [ \"metacard.version.versioned-on\" after %s ] AND [ \"metacard-tags\" = 'revision' ] AND [ \"metacard.version.action\" like 'Deleted*' ] AND [ NOT [ \"replication.origins\" = 'node1' ] ] ] ] ] OR [ [ [ \"metacard.version.id\" = '123456789' ] AND [ \"metacard.version.action\" like 'Deleted*' ] ] ] ]",
                 modifiedString, modifiedString)));
   }
 


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where a bi-directional replication config pushed items to a remote node and then are deleted on the remote system. The deletions were incorrectly replicated back to the origin.

I have verified the issue and the solution

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@shaundmorris 
@sgalla
@rececoffin

#### How should this be tested? (List steps with links to updated documentation)
Create a bi-direction replication between 2 nodes where some data is pushed from one to the other. Delete the data on the node that was pushed to. Verify the deletes are not replicated back to the source. 

