### PR TITLE
NA-64 Add sorting to replication jobs

### DIFF
--- a/adapters/ddf-adapter/pom.xml
+++ b/adapters/ddf-adapter/pom.xml
@@ -140,7 +140,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+    <dependency>
+      <groupId>ddf.lib</groupId>
+      <artifactId>gson-support</artifactId>
+      <version>${ddf.version}</version>
+    </dependency>
     <!-- XML dependencies -->
     <dependency>
       <groupId>io.github.soc</groupId>

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/DdfNodeAdapter.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/DdfNodeAdapter.java
@@ -173,7 +173,7 @@ public class DdfNodeAdapter implements NodeAdapter {
       PropertyNameType propertyName = new PropertyNameType();
       propertyName.setContent(Arrays.asList(Constants.METACARD_MODIFIED));
       sortProperty.setPropertyName(propertyName);
-      sortProperty.setSortOrder(SortOrderType.ASC);
+      sortProperty.setSortOrder(SortOrderType.DESC);
       cswSortBy.getSortProperty().add(sortProperty);
     } else {
       Class<List<Map<String, String>>> clazz =

--- a/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/ResultIterable.java
+++ b/adapters/ddf-adapter/src/main/java/com/connexta/replication/adapters/ddf/ResultIterable.java
@@ -216,7 +216,8 @@ public class ResultIterable implements Iterable<Metadata> {
               request.getFailedItemIds(),
               request.getModifiedAfter(),
               index,
-              request.getPageSize());
+              request.getPageSize(),
+              request.getSorting());
     }
   }
 }

--- a/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/persist/CreateReplication.java
+++ b/admin/query/src/main/java/org/codice/ditto/replication/admin/query/replications/persist/CreateReplication.java
@@ -131,7 +131,7 @@ public class CreateReplication extends BaseFunctionField<ReplicationField> {
     }
 
     try {
-      ECQL.toFilter(filter.getValue());
+      ECQL.toFilter(filter.getValue().split("::")[0]);
     } catch (CQLException e) {
       addErrorMessage(ReplicationMessages.invalidFilter());
     }

--- a/commons/src/main/java/com/connexta/replication/data/QueryRequestImpl.java
+++ b/commons/src/main/java/com/connexta/replication/data/QueryRequestImpl.java
@@ -68,18 +68,22 @@ public class QueryRequestImpl implements QueryRequest {
       int startIndex,
       int pageSize,
       String sorts) {
-    this.cql = cql;
-    this.sorts = sorts;
+
+    String cqlTmp = cql;
+    String sortsTmp = sorts;
+    String[] parts = cql.split("::");
+    if (parts.length > 1) {
+      cqlTmp = parts[0];
+      sortsTmp = sorts == null ? parts[1] : sorts;
+    }
+
+    this.cql = cqlTmp;
+    this.sorts = sortsTmp;
     this.excludedNodes = excludedNodes;
     this.failedItemIds = failedItemIds;
     this.modifiedAfter = modifiedAfter;
     this.startIndex = startIndex;
     this.pageSize = pageSize;
-    String[] parts = this.cql.split("::");
-    if (parts.length > 1) {
-      cql = parts[0];
-      sorts = sorts == null ? parts[1] : sorts;
-    }
   }
 
   @Override

--- a/commons/src/main/java/com/connexta/replication/data/QueryRequestImpl.java
+++ b/commons/src/main/java/com/connexta/replication/data/QueryRequestImpl.java
@@ -23,6 +23,8 @@ public class QueryRequestImpl implements QueryRequest {
 
   private final String cql;
 
+  private final String sorts;
+
   private final List<String> excludedNodes;
 
   private final List<String> failedItemIds;
@@ -42,7 +44,11 @@ public class QueryRequestImpl implements QueryRequest {
   }
 
   public QueryRequestImpl(String cql, int startIndex, int pageSize) {
-    this(cql, Collections.emptyList(), Collections.emptyList(), null, startIndex, pageSize);
+    this(cql, Collections.emptyList(), Collections.emptyList(), null, startIndex, pageSize, null);
+  }
+
+  public QueryRequestImpl(String cql, String sorts, int startIndex, int pageSize) {
+    this(cql, Collections.emptyList(), Collections.emptyList(), null, startIndex, pageSize, sorts);
   }
 
   public QueryRequestImpl(String cql, List<String> excludedNodes, List<String> failedItemIds) {
@@ -51,7 +57,7 @@ public class QueryRequestImpl implements QueryRequest {
 
   public QueryRequestImpl(
       String cql, List<String> excludedNodes, List<String> failedItemIds, Date modifiedAfter) {
-    this(cql, excludedNodes, failedItemIds, modifiedAfter, 1, 100);
+    this(cql, excludedNodes, failedItemIds, modifiedAfter, 1, 100, null);
   }
 
   public QueryRequestImpl(
@@ -60,18 +66,30 @@ public class QueryRequestImpl implements QueryRequest {
       List<String> failedItemIds,
       Date modifiedAfter,
       int startIndex,
-      int pageSize) {
+      int pageSize,
+      String sorts) {
     this.cql = cql;
+    this.sorts = sorts;
     this.excludedNodes = excludedNodes;
     this.failedItemIds = failedItemIds;
     this.modifiedAfter = modifiedAfter;
     this.startIndex = startIndex;
     this.pageSize = pageSize;
+    String[] parts = this.cql.split("::");
+    if (parts.length > 1) {
+      cql = parts[0];
+      sorts = sorts == null ? parts[1] : sorts;
+    }
   }
 
   @Override
   public String getCql() {
     return cql;
+  }
+
+  @Override
+  public String getSorting() {
+    return sorts;
   }
 
   @Override

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/QueryServiceImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/QueryServiceImpl.java
@@ -25,7 +25,6 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.codice.ditto.replication.api.QueryException;
@@ -89,7 +88,7 @@ public class QueryServiceImpl implements QueryService {
     String cql = (String) mcard.getAttribute("cql").getValue();
     String sortJson =
         mcard.getAttribute("sorts").getValues().stream()
-            .map(Objects::toString)
+            .map(value -> value.toString().replace('=', ':'))
             .collect(Collectors.joining(",", "::[", "]"));
     return new org.codice.ditto.replication.api.impl.data.QueryImpl(title, cql + sortJson);
   }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/QueryServiceImpl.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/QueryServiceImpl.java
@@ -25,6 +25,8 @@ import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.codice.ditto.replication.api.QueryException;
 import org.codice.ditto.replication.api.QueryService;
@@ -85,6 +87,10 @@ public class QueryServiceImpl implements QueryService {
       Metacard mcard) {
     String title = (String) mcard.getAttribute(Core.TITLE).getValue();
     String cql = (String) mcard.getAttribute("cql").getValue();
-    return new org.codice.ditto.replication.api.impl.data.QueryImpl(title, cql);
+    String sortJson =
+        mcard.getAttribute("sorts").getValues().stream()
+            .map(Objects::toString)
+            .collect(Collectors.joining(",", "::[", "]"));
+    return new org.codice.ditto.replication.api.impl.data.QueryImpl(title, cql + sortJson);
   }
 }

--- a/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/Syncer.java
+++ b/replication-api-impl/src/main/java/org/codice/ditto/replication/api/impl/Syncer.java
@@ -173,14 +173,14 @@ public class Syncer {
           }
         }
 
-        if (replicationStatus.getLastMetadataModified() == null
-            || metadata.getMetadataModified().after(replicationStatus.getLastMetadataModified())) {
-          replicationStatus.setLastMetadataModified(metadata.getMetadataModified());
+        if (modifiedAfter == null || metadata.getMetadataModified().after(modifiedAfter)) {
+          modifiedAfter = metadata.getMetadataModified();
         }
       }
 
       synchronized (lock) {
         replicationStatus.setStatus(canceled ? Status.CANCELED : Status.SUCCESS);
+        replicationStatus.setLastMetadataModified(canceled ? null : modifiedAfter);
       }
       return new SyncResponse(replicationStatus.getStatus());
     }

--- a/replication-api/src/main/java/org/codice/ditto/replication/api/data/QueryRequest.java
+++ b/replication-api/src/main/java/org/codice/ditto/replication/api/data/QueryRequest.java
@@ -33,6 +33,13 @@ public interface QueryRequest {
   String getCql();
 
   /**
+   * A Json string representing the sorting order
+   *
+   * @return json list of sorting attributes and order
+   */
+  String getSorting();
+
+  /**
    * A list of system names that should be compared against the lineage of a {@link Metadata}. If
    * the {@link Metadata}s lineage contains the {@link
    * org.codice.ditto.replication.api.NodeAdapter}s name, it should not be returned in the query.

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
     "react-interval": "2.0.2",
     "react-router-dom": "4.3.1",
     "react-select": "3.0.3",
+    "relaxed-json": "1.0.3",
     "unfetch": "4.1.0"
   },
   "devDependencies": {

--- a/ui/src/main/webapp/components/replications/QuerySelector.js
+++ b/ui/src/main/webapp/components/replications/QuerySelector.js
@@ -31,7 +31,7 @@ function QuerySelector(props) {
   return (
     <div>
       <FormLabel>
-        Select a search to use its filter, or create your own
+        Select a search to use its filter and sort policies, or create your own
       </FormLabel>
       <Query query={allQueries}>
         {({ loading, error, data, refetch }) => {

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -90,7 +90,7 @@ class ReplicationRow extends React.Component {
 
   getSorts = (filter) => {
     const parts = filter.split('::')
-    if (parts.length > 1) {
+    if (parts.length > 1 && parts[1] != '[]') {
       const sorts = RJSON.parse(parts[1])
       return sorts.map(s => (
           <div style={{ 'display': 'flex', 'alignItems': 'center' }}>

--- a/ui/src/main/webapp/components/replications/ReplicationsTable.js
+++ b/ui/src/main/webapp/components/replications/ReplicationsTable.js
@@ -65,6 +65,18 @@ class ReplicationRow extends React.Component {
     this.setState({ anchor: null })
   }
 
+  formatSorts = (sortStr) => {
+    //the "json" string is poorly formatted so we need to parse it manually
+    let str = sortStr.substr(1,sortStr.length -2)
+    let sortArray = str.split("},")
+    let sorts = ''
+    sortArray.forEach((sort)=>{
+      let parts = sort.replace('{','').replace('}','').split(',')
+      sorts += parts[0].substr(parts[0].indexOf("=")+1)+ "->"+parts [1].substr(parts[1].indexOf("=")+1)+" \n"
+    })
+    return sorts
+  }
+
   render() {
     const { replication } = this.props
 
@@ -118,7 +130,8 @@ class ReplicationRow extends React.Component {
           </Mutation>
         </TableCell>
         <TableCell>{replication.biDirectional ? 'Yes' : 'No'}</TableCell>
-        <TableCell>{replication.filter}</TableCell>
+        <TableCell>{replication.filter.split('::')[0]}</TableCell>
+        <TableCell>{replication.filter.split('::').length > 1?this.formatSorts(replication.filter.split('::')[1]):'metacard.modified: assending'}</TableCell>
         <TableCell>
           {replication.stats.pullCount + replication.stats.pushCount}
         </TableCell>
@@ -172,6 +185,7 @@ class ReplicationsTable extends React.Component {
               <TableCell>Priority</TableCell>
               <TableCell>Bidirectional</TableCell>
               <TableCell>Filter</TableCell>
+              <TableCell>Sorting</TableCell>
               <TableCell>Items Transferred</TableCell>
               <TableCell>Data Transferred</TableCell>
               <TableCell>Last Run</TableCell>

--- a/ui/src/main/webapp/components/replications/SortPolicies.js
+++ b/ui/src/main/webapp/components/replications/SortPolicies.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Connexta
+ *
+ * <p>This is free software: you can redistribute it and/or modify it under the terms of the GNU
+ * Lesser General Public License as published by the Free Software Foundation, either version 3 of
+ * the License, or any later version.
+ *
+ * <p>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public
+ * License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+import React from 'react'
+import {
+  MenuItem,
+  Select,
+  FormLabel,
+  FormControl,
+  TextField,
+  IconButton,
+} from '@material-ui/core'
+import ClearIcon from '@material-ui/icons/Clear'
+import AddIcon from '@material-ui/icons/Add'
+import { withStyles } from '@material-ui/core/styles'
+
+const styles = {
+  sortsFormControl: {
+    paddingTop: '16px',
+    width: '100%',
+  },
+  sortsFormLabel: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+  iconButton: {
+    '&:hover': {
+      backgroundColor: 'transparent',
+   },
+  }
+}
+
+function SortPolicies(props) {
+  const { sortPolicies = [], onAddSort, onRemoveSort, onChangeSort, classes } = props
+
+  return (
+    <FormControl className={classes.sortsFormControl}>
+      <FormLabel>
+        <div className={classes.sortsFormLabel}>
+          Sort Policies
+          <IconButton onClick={onAddSort} className={classes.iconButton}>
+            <AddIcon/>
+          </IconButton>
+        </div>
+      </FormLabel>
+      {sortPolicies.map((sort, index) => 
+        <div style={{ 'display': 'flex', 'alignItems': 'center' }}>
+          <TextField
+            margin='none'
+            fullWidth
+            onChange={(e) => onChangeSort({ id: 'attribute', value: e.target.value }, index)}
+            value={sort.attribute}
+            placeholder='Attribute name'
+          />
+          <Select
+            style={{ 'paddingRight': '12px' }}
+            value={sort.direction}
+            onChange={(e) => onChangeSort({ id: 'direction', value: e.target.value }, index)}
+          >
+            <MenuItem value='ascending'>Ascending</MenuItem>
+            <MenuItem value='descending'>Descending</MenuItem>
+          </Select>
+          <IconButton size="small" onClick={() => onRemoveSort(sort)} className={classes.iconButton}>
+            <ClearIcon/>
+          </IconButton>
+        </div>
+      )}
+    </FormControl>
+  )
+}
+
+export default withStyles(styles)(SortPolicies)

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1808,6 +1808,11 @@ commander@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
+commander@^2.6.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -5848,6 +5853,14 @@ regjsparser@^0.6.0:
 relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
+
+relaxed-json@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/relaxed-json/-/relaxed-json-1.0.3.tgz#eb2101ae0ee60e82267d95ed0ddf19a3604b8c1e"
+  integrity sha512-b7wGPo7o2KE/g7SqkJDDbav6zmrEeP4TK2VpITU72J/M949TLe/23y/ZHJo+pskcGM52xIfFoT9hydwmgr1AEg==
+  dependencies:
+    chalk "^2.4.2"
+    commander "^2.6.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
#### What does this PR do?
Adds support for specifying sort policies when configuring replication jobs. If a saved search is selected, sort policies will be populated with the sorts on the saved search, but can be edited before saving the replication job. The sort policies saved with a replication job specify the order in which data is replicated. For example, a replication job with a sort policy of "title, ascending" will replicate data in alphabetical order by title.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@clockard 
@shaundmorris 

#### How should this be tested? (List steps with links to updated documentation)
* Verify UI functions as expected (adding/removing/changing sort policies and the new sorting column in the replication table)
* Use breakpoints or a combination of large and small files to see that replication respects the sort order(s) specified.

#### Any background context you want to provide?

#### What are the relevant tickets?
Fixes #XXXX

#### Screenshots (if appropriate)
<img width="1782" alt="Screen Shot 2021-11-19 at 8 36 52 AM" src="https://user-images.githubusercontent.com/8962302/142649356-8c98b309-65d4-4991-89c2-10d72e12176e.png">
<img width="613" alt="Screen Shot 2021-11-18 at 9 42 39 PM" src="https://user-images.githubusercontent.com/8962302/142649362-47bd8f5b-ea14-46e2-912a-e9484967589c.png">
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
